### PR TITLE
Add iOS skills suite and update architecture docs

### DIFF
--- a/.agents/skills/core-data-expert/SKILL.md
+++ b/.agents/skills/core-data-expert/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: core-data-expert
+description: 'Expert Core Data guidance (iOS/macOS): stack setup, fetch requests & NSFetchedResultsController, saving/merge conflicts, threading & Swift Concurrency, batch operations & persistent history, migrations, performance, and NSPersistentCloudKitContainer/CloudKit sync.'
+---
+# Core Data Expert
+
+Fast, production-oriented guidance for building **correct**, **performant** Core Data stacks and fixing common crashes.
+
+## Agent behavior contract (follow these rules)
+
+1. Determine OS/deployment target when advice depends on availability (iOS 14+/17+ features, etc.).
+2. Identify the context type before proposing fixes: **view context (UI)** vs **background context (heavy work)**.
+3. Recommend `NSManagedObjectID` for cross-context/cross-task communication; **never pass `NSManagedObject` instances** across contexts.
+4. Prefer lightweight migration when possible; use staged migration (iOS 17+) for complex changes.
+5. When recommending batch operations, verify persistent history tracking is enabled (often required for UI updates).
+6. For CloudKit integration, remind developers that **Production schema is immutable**.
+7. Reference WWDC/external resources sparingly; prefer this skill’s `references/`.
+
+## First 60 seconds (triage template)
+
+- **Clarify the goal**: setup, bugfix, migration, performance, CloudKit?
+- **Collect minimal facts**:
+  - platform + deployment target
+  - store type (SQLite / in-memory) and whether CloudKit is enabled
+  - context involved (view vs background) and whether Swift Concurrency is in use
+  - exact error message + stack trace/logs
+- **Branch immediately**:
+  - threading/crash → focus on context confinement + `NSManagedObjectID` handoff
+  - migration error → identify model versions + migration strategy
+  - batch ops not updating UI → persistent history tracking + merge pipeline
+
+## Routing map (pick the right reference fast)
+
+- **Stack setup / merge policies / contexts** → `references/stack-setup.md`
+- **Saving patterns** → `references/saving.md`
+- **Fetch requests / list updates / aggregates** → `references/fetch-requests.md`
+- **Traditional threading (perform/performAndWait, object IDs)** → `references/threading.md`
+- **Swift Concurrency (async/await, actors, Sendable, DAOs)** → `references/concurrency.md`
+- **Batch insert/delete/update** → `references/batch-operations.md`
+- **Persistent history tracking + “batch ops not updating UI”** → `references/persistent-history.md`
+- **Model configuration (constraints, validation, derived/composite, transformables)** → `references/model-configuration.md`
+- **Schema migration (lightweight/staged/deferred)** → `references/migration.md`
+- **CloudKit integration & debugging** → `references/cloudkit-integration.md`
+- **Performance profiling & memory** → `references/performance.md`
+- **Testing patterns** → `references/testing.md`
+- **Terminology** → `references/glossary.md`
+
+## Common errors → next best move
+
+- **“Failed to find a unique match for an NSEntityDescription”** → `references/testing.md` (shared `NSManagedObjectModel`)
+- **`NSPersistentStoreIncompatibleVersionHashError`** → `references/migration.md` (versioning + migration)
+- **Cross-context/threading exceptions** (e.g. delete/update from wrong context) → `references/threading.md` and/or `references/concurrency.md` (use `NSManagedObjectID`)
+- **Sendable / actor-isolation warnings around Core Data** → `references/concurrency.md` (don’t “paper over” with `@unchecked Sendable`)
+- **`NSMergeConflict` / constraint violations** → `references/model-configuration.md` + `references/stack-setup.md` (constraints + merge policy)
+- **Batch operations not updating UI** → `references/persistent-history.md` + `references/batch-operations.md`
+- **CloudKit schema/sync issues** → `references/cloudkit-integration.md`
+- **Memory grows during fetch** → `references/performance.md` + `references/fetch-requests.md`
+
+## Verification checklist (when changing Core Data code)
+
+- Confirm the context matches the work (UI vs background).
+- Ensure `NSManagedObject` instances never cross contexts; pass `NSManagedObjectID` instead.
+- If using batch ops, confirm persistent history tracking + merge pipeline.
+- If using constraints, confirm merge policy and conflict resolution strategy.
+- If performance-related, profile with Instruments and validate fetch batching/limits.
+
+## Reference files
+
+- `references/_index.md` (navigation)
+- `references/stack-setup.md`
+- `references/saving.md`
+- `references/fetch-requests.md`
+- `references/threading.md`
+- `references/concurrency.md`
+- `references/batch-operations.md`
+- `references/persistent-history.md`
+- `references/model-configuration.md`
+- `references/migration.md`
+- `references/cloudkit-integration.md`
+- `references/performance.md`
+- `references/testing.md`
+- `references/glossary.md`

--- a/.agents/skills/core-data-expert/references/_index.md
+++ b/.agents/skills/core-data-expert/references/_index.md
@@ -1,0 +1,82 @@
+# Reference Index
+
+Quick navigation for Core Data topics.
+
+## Fundamentals
+
+- `stack-setup.md`: NSPersistentContainer setup, merge policies, context configuration
+- `saving.md`: Conditional saving, hasPersistentChanges, save timing strategies
+- `glossary.md`: Term definitions for quick lookup
+- `project-audit.md`: Checklist for discovering a project’s Core Data setup and constraints
+
+## Data Access
+
+- `fetch-requests.md`: Query optimization, NSFetchedResultsController, aggregates
+- `threading.md`: NSManagedObjectID, perform vs performAndWait, concurrency
+- `concurrency.md`: Swift Concurrency integration, async/await, actors, Sendable
+- `batch-operations.md`: NSBatchInsertRequest, NSBatchDeleteRequest, NSBatchUpdateRequest
+
+## Model & Schema
+
+- `model-configuration.md`: Constraints, derived attributes, transformables, validation, lifecycle
+- `migration.md`: Lightweight, staged, and deferred migration strategies
+
+## Advanced Topics
+
+- `persistent-history.md`: History tracking setup, Observer/Fetcher/Merger/Cleaner pattern
+- `cloudkit-integration.md`: NSPersistentCloudKitContainer, schema design, monitoring
+- `performance.md`: Profiling with Instruments, memory management, optimization
+- `testing.md`: In-memory stores, shared models, data generators
+
+## Quick Links by Problem
+
+### "I need to..."
+
+- **Set up Core Data** → `stack-setup.md`
+- **Save data efficiently** → `saving.md`
+- **Fetch and display data** → `fetch-requests.md`
+- **Work with background threads** → `threading.md`
+- **Use async/await with Core Data** → `concurrency.md`
+- **Import large datasets** → `batch-operations.md`
+- **Configure my model** → `model-configuration.md`
+- **Migrate my schema** → `migration.md`
+- **Sync with CloudKit** → `cloudkit-integration.md`
+- **Optimize performance** → `performance.md`
+- **Write tests** → `testing.md`
+
+### "I'm getting an error about..."
+
+- **"NSPersistentStoreIncompatibleVersionHashError"** → `migration.md`
+- **"Cannot delete objects in other contexts"** → `threading.md`
+- **"NSMergeConflict"** → `stack-setup.md` (merge policies), `model-configuration.md` (constraints)
+- **"Failed to find unique match for NSEntityDescription"** → `testing.md` (shared model)
+- **Batch operations not updating UI** → `persistent-history.md`
+- **CloudKit sync issues** → `cloudkit-integration.md`
+- **Memory growing unbounded** → `performance.md`, `fetch-requests.md`
+- **Validation errors** → `model-configuration.md`
+
+### "I want to..."
+
+- **Optimize queries** → `fetch-requests.md`, `performance.md`
+- **Handle relationships** → `model-configuration.md`, `fetch-requests.md`
+- **Validate data** → `model-configuration.md`
+- **Track changes across contexts** → `persistent-history.md`
+- **Debug performance issues** → `performance.md`
+- **Test my Core Data code** → `testing.md`
+
+## File Statistics
+
+- `project-audit.md`: Project discovery checklist (deployment target, stack, history tracking, concurrency risks)
+- `stack-setup.md`: NSPersistentContainer, merge policies, context configuration
+- `saving.md`: hasPersistentChanges, conditional saving, error handling
+- `fetch-requests.md`: Optimization, NSFetchedResultsController, aggregates, diffable data sources
+- `threading.md`: NSManagedObjectID, perform/performAndWait, traditional threading
+- `concurrency.md`: Swift Concurrency, async/await, actors, Sendable, @MainActor, DAOs
+- `batch-operations.md`: NSBatchInsertRequest, NSBatchDeleteRequest, NSBatchUpdateRequest
+- `model-configuration.md`: Constraints, derived attributes, transformables, validation, lifecycle
+- `migration.md`: Lightweight, staged (iOS 17+), deferred (iOS 14+), composite attributes
+- `persistent-history.md`: Observer, Fetcher, Merger, Cleaner, batch operation integration
+- `cloudkit-integration.md`: NSPersistentCloudKitContainer, schema design, monitoring, debugging
+- `performance.md`: Instruments profiling, memory management, optimization strategies
+- `testing.md`: In-memory stores, shared models, data generators, XCTest patterns
+- `glossary.md`: Core Data terminology and quick definitions

--- a/.agents/skills/core-data-expert/references/batch-operations.md
+++ b/.agents/skills/core-data-expert/references/batch-operations.md
@@ -1,0 +1,543 @@
+# Batch Operations
+
+Batch operations provide significant performance improvements for large-scale data modifications. They operate directly at the SQL level, bypassing the object graph.
+
+## Overview
+
+Core Data provides three batch operation types:
+- **NSBatchInsertRequest** - Bulk inserts (iOS 14+)
+- **NSBatchDeleteRequest** - Bulk deletes
+- **NSBatchUpdateRequest** - Bulk updates
+
+**Key Characteristics:**
+- Operate at SQL level (very fast)
+- Don't load objects into memory
+- Don't trigger validation
+- Don't send change notifications (requires persistent history tracking)
+- Can't set relationships during batch insert
+
+## NSBatchInsertRequest (iOS 14+)
+
+### Basic Usage
+
+```swift
+let context = container.newBackgroundContext()
+
+context.perform {
+    let batchInsert = NSBatchInsertRequest(entity: Article.entity()) { (object: NSManagedObject) -> Bool in
+        guard let article = object as? Article else { return true }
+        
+        article.name = "Sample Article"
+        article.content = "Content here"
+        article.creationDate = Date()
+        
+        return false // Continue inserting
+    }
+    
+    do {
+        try context.execute(batchInsert)
+    } catch {
+        print("Batch insert failed: \(error)")
+    }
+}
+```
+
+### Inserting Multiple Objects
+
+```swift
+func batchInsertArticles(_ data: [ArticleData]) {
+    let context = container.newBackgroundContext()
+    
+    context.perform {
+        var index = 0
+        let batchInsert = NSBatchInsertRequest(
+            entity: Article.entity()
+        ) { (object: NSManagedObject) -> Bool in
+            guard index < data.count else { return true } // Stop
+            guard let article = object as? Article else { return true }
+            
+            let articleData = data[index]
+            article.name = articleData.name
+            article.content = articleData.content
+            article.creationDate = Date()
+            
+            index += 1
+            return false // Continue
+        }
+        
+        do {
+            try context.execute(batchInsert)
+        } catch {
+            print("Batch insert failed: \(error)")
+        }
+    }
+}
+```
+
+### Using Dictionary Representation (Alternative)
+
+```swift
+let context = container.newBackgroundContext()
+
+context.perform {
+    let objects: [[String: Any]] = [
+        ["name": "Article 1", "content": "Content 1", "creationDate": Date()],
+        ["name": "Article 2", "content": "Content 2", "creationDate": Date()],
+        ["name": "Article 3", "content": "Content 3", "creationDate": Date()]
+    ]
+    
+    let batchInsert = NSBatchInsertRequest(
+        entity: Article.entity(),
+        objects: objects
+    )
+    
+    do {
+        try context.execute(batchInsert)
+    } catch {
+        print("Batch insert failed: \(error)")
+    }
+}
+```
+
+### Limitations
+
+**Cannot set relationships:**
+```swift
+// ❌ This won't work
+let batchInsert = NSBatchInsertRequest(entity: Article.entity()) { object in
+    guard let article = object as? Article else { return true }
+    article.category = someCategory // Can't set relationships!
+    return false
+}
+```
+
+**Workaround:** Set relationships after batch insert:
+```swift
+// 1. Batch insert articles
+let batchInsert = NSBatchInsertRequest(entity: Article.entity()) { object in
+    guard let article = object as? Article else { return true }
+    article.name = "Article"
+    return false
+}
+try context.execute(batchInsert)
+
+// 2. Fetch and set relationships
+let fetchRequest = Article.fetchRequest()
+let articles = try context.fetch(fetchRequest)
+for article in articles {
+    article.category = defaultCategory
+}
+try context.save()
+```
+
+## NSBatchDeleteRequest
+
+### Basic Usage
+
+```swift
+let context = container.newBackgroundContext()
+
+context.perform {
+    let fetchRequest: NSFetchRequest<NSFetchRequestResult> = Article.fetchRequest()
+    let batchDelete = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+    
+    do {
+        try context.execute(batchDelete)
+    } catch {
+        print("Batch delete failed: \(error)")
+    }
+}
+```
+
+### With Predicate
+
+```swift
+let fetchRequest: NSFetchRequest<NSFetchRequestResult> = Article.fetchRequest()
+fetchRequest.predicate = NSPredicate(format: "views < %d", 10)
+
+let batchDelete = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+
+context.perform {
+    do {
+        try context.execute(batchDelete)
+    } catch {
+        print("Batch delete failed: \(error)")
+    }
+}
+```
+
+### Getting Deleted Object IDs
+
+```swift
+let fetchRequest: NSFetchRequest<NSFetchRequestResult> = Article.fetchRequest()
+let batchDelete = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+batchDelete.resultType = .resultTypeObjectIDs
+
+context.perform {
+    do {
+        let result = try context.execute(batchDelete) as? NSBatchDeleteResult
+        if let objectIDs = result?.result as? [NSManagedObjectID] {
+            print("Deleted \(objectIDs.count) objects")
+        }
+    } catch {
+        print("Batch delete failed: \(error)")
+    }
+}
+```
+
+## NSBatchUpdateRequest
+
+### Basic Usage
+
+```swift
+let context = container.newBackgroundContext()
+
+context.perform {
+    let batchUpdate = NSBatchUpdateRequest(entityName: "Article")
+    batchUpdate.predicate = NSPredicate(format: "isRead == NO")
+    batchUpdate.propertiesToUpdate = ["isRead": true]
+    
+    do {
+        try context.execute(batchUpdate)
+    } catch {
+        print("Batch update failed: \(error)")
+    }
+}
+```
+
+### Updating Multiple Properties
+
+```swift
+let batchUpdate = NSBatchUpdateRequest(entityName: "Article")
+batchUpdate.predicate = NSPredicate(format: "views < %d", 100)
+batchUpdate.propertiesToUpdate = [
+    "views": 100,
+    "lastModified": Date(),
+    "isPopular": true
+]
+
+context.perform {
+    try? context.execute(batchUpdate)
+}
+```
+
+### Using Expressions
+
+```swift
+// Increment views by 1
+let batchUpdate = NSBatchUpdateRequest(entityName: "Article")
+batchUpdate.propertiesToUpdate = [
+    "views": NSExpression(format: "views + 1")
+]
+
+context.perform {
+    try? context.execute(batchUpdate)
+}
+```
+
+### Getting Updated Object IDs
+
+```swift
+let batchUpdate = NSBatchUpdateRequest(entityName: "Article")
+batchUpdate.propertiesToUpdate = ["isRead": true]
+batchUpdate.resultType = .updatedObjectIDsResultType
+
+context.perform {
+    do {
+        let result = try context.execute(batchUpdate) as? NSBatchUpdateResult
+        if let objectIDs = result?.result as? [NSManagedObjectID] {
+            print("Updated \(objectIDs.count) objects")
+        }
+    } catch {
+        print("Batch update failed: \(error)")
+    }
+}
+```
+
+## Persistent History Tracking Integration
+
+**Critical:** Batch operations don't send change notifications. You **must** enable persistent history tracking for UI updates.
+
+### Enable Persistent History Tracking
+
+```swift
+guard let description = container.persistentStoreDescriptions.first else { return }
+
+description.setOption(true as NSNumber, 
+                     forKey: NSPersistentHistoryTrackingKey)
+description.setOption(true as NSNumber,
+                     forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
+```
+
+### Observe Remote Changes
+
+```swift
+NotificationCenter.default.addObserver(
+    self,
+    selector: #selector(storeRemoteChange),
+    name: .NSPersistentStoreRemoteChange,
+    object: container.persistentStoreCoordinator
+)
+
+@objc func storeRemoteChange(_ notification: Notification) {
+    // Merge changes into view context
+    // See persistent-history.md for full implementation
+}
+```
+
+## Performance Comparison
+
+### Traditional Insert (Slow)
+
+```swift
+// Inserting 1000 objects: ~10 seconds
+for i in 0..<1000 {
+    let article = Article(context: context)
+    article.name = "Article \(i)"
+}
+try context.save()
+```
+
+### Batch Insert (Fast)
+
+```swift
+// Inserting 1000 objects: ~0.5 seconds
+var index = 0
+let batchInsert = NSBatchInsertRequest(entity: Article.entity()) { object in
+    guard index < 1000 else { return true }
+    guard let article = object as? Article else { return true }
+    article.name = "Article \(index)"
+    index += 1
+    return false
+}
+try context.execute(batchInsert)
+```
+
+**Performance gain: ~20x faster**
+
+## When to Use Batch Operations
+
+### Use Batch Insert When:
+- Importing large datasets (>100 objects)
+- Initial data seeding
+- Syncing data from server
+- Performance is critical
+
+### Use Batch Delete When:
+- Deleting many objects at once
+- Clearing old data
+- Implementing data retention policies
+- Performance is critical
+
+### Use Batch Update When:
+- Updating many objects with same values
+- Bulk status changes
+- Incrementing counters
+- Performance is critical
+
+### Don't Use Batch Operations When:
+- Need to set relationships
+- Need validation
+- Need to trigger lifecycle events (willSave, etc.)
+- Working with small datasets (<50 objects)
+- Need immediate UI updates without persistent history tracking
+
+## Complete Example: Import with Batch Insert
+
+```swift
+class DataImporter {
+    let container: NSPersistentContainer
+    
+    init(container: NSPersistentContainer) {
+        self.container = container
+    }
+    
+    func importArticles(_ data: [ArticleData]) {
+        let context = container.newBackgroundContext()
+        
+        context.perform {
+            var index = 0
+            let batchInsert = NSBatchInsertRequest(
+                entity: Article.entity()
+            ) { (object: NSManagedObject) -> Bool in
+                guard index < data.count else { return true }
+                guard let article = object as? Article else { return true }
+                
+                let articleData = data[index]
+                article.name = articleData.name
+                article.content = articleData.content
+                article.views = 0
+                article.creationDate = Date()
+                
+                index += 1
+                return false
+            }
+            
+            do {
+                let result = try context.execute(batchInsert) as? NSBatchInsertResult
+                print("Inserted \(data.count) articles")
+                
+                // If you need the object IDs
+                if let objectIDs = result?.result as? [NSManagedObjectID] {
+                    print("Object IDs: \(objectIDs)")
+                }
+            } catch {
+                print("Batch insert failed: \(error)")
+            }
+        }
+    }
+}
+```
+
+## Complete Example: Cleanup with Batch Delete
+
+```swift
+class DataCleaner {
+    let container: NSPersistentContainer
+    
+    init(container: NSPersistentContainer) {
+        self.container = container
+    }
+    
+    func deleteOldArticles(olderThan days: Int) {
+        let context = container.newBackgroundContext()
+        
+        context.perform {
+            let cutoffDate = Calendar.current.date(
+                byAdding: .day,
+                value: -days,
+                to: Date()
+            )!
+            
+            let fetchRequest: NSFetchRequest<NSFetchRequestResult> = Article.fetchRequest()
+            fetchRequest.predicate = NSPredicate(
+                format: "creationDate < %@",
+                cutoffDate as NSDate
+            )
+            
+            let batchDelete = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+            batchDelete.resultType = .resultTypeCount
+            
+            do {
+                let result = try context.execute(batchDelete) as? NSBatchDeleteResult
+                if let count = result?.result as? Int {
+                    print("Deleted \(count) old articles")
+                }
+            } catch {
+                print("Batch delete failed: \(error)")
+            }
+        }
+    }
+}
+```
+
+## Common Pitfalls
+
+### ❌ Not Enabling Persistent History Tracking
+
+```swift
+// Batch insert happens
+let batchInsert = NSBatchInsertRequest(entity: Article.entity()) { ... }
+try context.execute(batchInsert)
+
+// UI doesn't update! No notifications sent
+```
+
+### ❌ Trying to Set Relationships
+
+```swift
+let batchInsert = NSBatchInsertRequest(entity: Article.entity()) { object in
+    guard let article = object as? Article else { return true }
+    article.category = category // Won't work!
+    return false
+}
+```
+
+### ❌ Expecting Validation
+
+```swift
+// No validation happens!
+let batchInsert = NSBatchInsertRequest(entity: Article.entity()) { object in
+    guard let article = object as? Article else { return true }
+    article.name = "" // Empty name - no validation error
+    return false
+}
+```
+
+### ❌ Using on View Context
+
+```swift
+// Don't use batch operations on view context
+viewContext.perform {
+    let batchInsert = NSBatchInsertRequest(entity: Article.entity()) { ... }
+    try? viewContext.execute(batchInsert) // Blocks UI!
+}
+```
+
+### ✅ Correct Approach
+
+```swift
+// 1. Enable persistent history tracking
+description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
+
+// 2. Use background context
+let context = container.newBackgroundContext()
+
+// 3. Execute batch operation
+context.perform {
+    let batchInsert = NSBatchInsertRequest(entity: Article.entity()) { object in
+        guard let article = object as? Article else { return true }
+        article.name = "Valid Name"
+        return false
+    }
+    try? context.execute(batchInsert)
+}
+
+// 4. UI updates via persistent history tracking
+```
+
+## Testing Batch Operations
+
+```swift
+func testBatchInsert() throws {
+    let context = container.newBackgroundContext()
+    
+    let expectation = XCTestExpectation(description: "Batch insert")
+    
+    context.perform {
+        var count = 0
+        let batchInsert = NSBatchInsertRequest(entity: Article.entity()) { object in
+            guard count < 10 else { return true }
+            guard let article = object as? Article else { return true }
+            article.name = "Article \(count)"
+            count += 1
+            return false
+        }
+        
+        do {
+            try context.execute(batchInsert)
+            expectation.fulfill()
+        } catch {
+            XCTFail("Batch insert failed: \(error)")
+        }
+    }
+    
+    wait(for: [expectation], timeout: 5.0)
+    
+    // Verify
+    let fetchRequest = Article.fetchRequest()
+    let articles = try context.fetch(fetchRequest)
+    XCTAssertEqual(articles.count, 10)
+}
+```
+
+## Summary
+
+1. **Use batch operations for large datasets** - 10-20x performance improvement
+2. **Enable persistent history tracking** - Required for UI updates
+3. **Use background contexts** - Don't block UI
+4. **Can't set relationships in batch insert** - Set them separately if needed
+5. **No validation or lifecycle events** - Batch operations bypass object graph
+6. **Get result types** - Use resultType to get object IDs or counts
+7. **Test thoroughly** - Verify data integrity after batch operations
+8. **Consider trade-offs** - Speed vs validation/relationships/lifecycle events

--- a/.agents/skills/core-data-expert/references/cloudkit-integration.md
+++ b/.agents/skills/core-data-expert/references/cloudkit-integration.md
@@ -1,0 +1,259 @@
+# CloudKit Integration
+
+`NSPersistentCloudKitContainer` syncs Core Data with CloudKit, enabling seamless data synchronization across devices.
+
+## Setup
+
+### Basic Setup
+
+```swift
+import CoreData
+import CloudKit
+
+let container = NSPersistentCloudKitContainer(name: "Model")
+
+container.loadPersistentStores { description, error in
+    if let error = error {
+        fatalError("Failed to load store: \(error)")
+    }
+}
+```
+
+### Configure CloudKit Container
+
+In Xcode:
+1. Add CloudKit capability
+2. Select or create CloudKit container
+3. Enable "Use CloudKit" in Core Data model
+
+### Schema Design Limitations
+
+CloudKit has restrictions Core Data doesn't:
+
+**Not Supported:**
+- Unique constraints on entities
+- `Undefined` attribute type
+- `ObjectID` attribute type
+- Non-optional relationships (must be optional)
+- Relationships without inverse
+- Deny deletion rule
+
+**Supported:**
+- Adding new fields to record types
+- Adding new record types
+
+**Important:** Production schema is **immutable**. Plan carefully!
+
+## Schema Initialization
+
+### Development Environment
+
+```swift
+// First run initializes schema in Development
+container.loadPersistentStores { description, error in
+    // Schema created automatically
+}
+```
+
+### Promoting to Production
+
+1. Test thoroughly in Development
+2. Open CloudKit Dashboard
+3. Deploy schema to Production
+4. **Cannot modify after deployment!**
+
+## Monitoring Sync
+
+### Observe Events
+
+```swift
+NotificationCenter.default.addObserver(
+    self,
+    selector: #selector(storeDidChange),
+    name: NSPersistentCloudKitContainer.eventChangedNotification,
+    object: container
+)
+
+@objc func storeDidChange(_ notification: Notification) {
+    guard let event = notification.userInfo?[NSPersistentCloudKitContainer.eventNotificationUserInfoKey]
+            as? NSPersistentCloudKitContainer.Event else {
+        return
+    }
+    
+    switch event.type {
+    case .setup:
+        print("Setup: \(event.succeeded ? "succeeded" : "failed")")
+    case .import:
+        print("Import: \(event.succeeded ? "succeeded" : "failed")")
+    case .export:
+        print("Export: \(event.succeeded ? "succeeded" : "failed")")
+    @unknown default:
+        break
+    }
+    
+    if let error = event.error {
+        print("Error: \(error)")
+    }
+}
+```
+
+### Testing Sync
+
+```swift
+func testSync() {
+    let expectation = XCTestExpectation(description: "Export")
+    
+    // Create expectation for export
+    let observer = NotificationCenter.default.addObserver(
+        forName: NSPersistentCloudKitContainer.eventChangedNotification,
+        object: container,
+        queue: nil
+    ) { notification in
+        guard let event = notification.userInfo?[NSPersistentCloudKitContainer.eventNotificationUserInfoKey]
+                as? NSPersistentCloudKitContainer.Event else {
+            return
+        }
+        
+        if event.type == .export && event.endDate != nil {
+            expectation.fulfill()
+        }
+    }
+    
+    // Make changes
+    let article = Article(context: container.viewContext)
+    article.name = "Test"
+    try? container.viewContext.save()
+    
+    wait(for: [expectation], timeout: 60)
+    NotificationCenter.default.removeObserver(observer)
+}
+```
+
+## Cross-Version Compatibility
+
+### Strategy 1: Incremental Fields
+
+Add new fields, keep old ones:
+
+```swift
+// V1: name
+// V2: name, subtitle (new)
+// Old versions see records but not subtitle
+```
+
+### Strategy 2: Version Attribute
+
+```swift
+// Add version attribute
+article.schemaVersion = 2
+
+// Filter in fetch requests
+fetchRequest.predicate = NSPredicate(format: "schemaVersion <= %d", currentVersion)
+```
+
+### Strategy 3: New Container
+
+```swift
+let options = NSPersistentCloudKitContainerOptions(
+    containerIdentifier: "iCloud.com.example.app.v2"
+)
+
+let description = NSPersistentStoreDescription(url: storeURL)
+description.cloudKitContainerOptions = options
+```
+
+**Caution:** Large datasets take time to upload.
+
+## Debugging
+
+### System Logs
+
+Monitor these processes:
+- **Application** - Core Data activity
+- **dasd** - Scheduling decisions
+- **cloudd** - CloudKit operations
+- **apsd** - Push notifications
+
+### Using log stream
+
+```bash
+# Application logs
+log stream --predicate 'process == "YourApp"'
+
+# CloudKit logs
+log stream --predicate 'process == "cloudd" AND message CONTAINS "your.container.id"'
+
+# Push notifications
+log stream --predicate 'process == "apsd"'
+
+# Scheduling
+log stream --predicate 'process == "dasd" AND message CONTAINS "YourApp"'
+```
+
+### CloudKit Logging Profile
+
+1. Download from [Apple Developer Portal](https://developer.apple.com/bug-reporting/profiles-and-logs/)
+2. Install on device
+3. Reboot device
+4. Reproduce issue
+5. Collect sysdiagnose
+
+### Collecting Diagnostics
+
+**sysdiagnose:**
+- iOS: Volume Up + Volume Down + Power (hold)
+- macOS: Shift + Control + Option + Command + Period
+
+## Common Issues
+
+### Schema Mismatch
+
+**Problem:** Local schema doesn't match CloudKit schema.
+
+**Solution:**
+1. Delete app
+2. Reinstall
+3. Let schema reinitialize
+
+### Sync Not Working
+
+**Checklist:**
+- [ ] CloudKit capability enabled
+- [ ] Signed in to iCloud
+- [ ] Network connection available
+- [ ] CloudKit container configured
+- [ ] Schema initialized in Development
+- [ ] Schema promoted to Production
+
+### Large Initial Sync
+
+**Problem:** First sync takes too long.
+
+**Solutions:**
+- Use background fetch
+- Show progress indicator
+- Implement data generators for testing
+
+## Best Practices
+
+1. **Test in Development first** - Schema is mutable
+2. **Plan schema carefully** - Production is immutable
+3. **Make relationships optional** - Required by CloudKit
+4. **Add inverse relationships** - Required by CloudKit
+5. **Version your data** - For cross-version compatibility
+6. **Monitor sync events** - Detect and handle errors
+7. **Test with multiple devices** - Verify sync behavior
+8. **Handle conflicts** - Use appropriate merge policy
+9. **Collect diagnostics** - For debugging sync issues
+10. **Consider data size** - Large datasets take time to sync
+
+## Summary
+
+- Use `NSPersistentCloudKitContainer` for CloudKit sync
+- Schema has limitations (optional relationships, no constraints)
+- Production schema is immutable
+- Monitor sync with event notifications
+- Test thoroughly in Development before promoting
+- Plan for cross-version compatibility
+- Use system logs for debugging
+- Collect sysdiagnose for complex issues

--- a/.agents/skills/core-data-expert/references/concurrency.md
+++ b/.agents/skills/core-data-expert/references/concurrency.md
@@ -1,0 +1,522 @@
+# Core Data and Swift Concurrency
+
+Thread-safe patterns for using Core Data with Swift Concurrency.
+
+## Core Principles
+
+### Thread safety still matters
+
+Core Data's thread safety rules don't change with Swift Concurrency:
+- Can't pass `NSManagedObject` between threads
+- Must access objects on their context's thread
+- `NSManagedObjectID` is thread-safe (can pass around)
+
+### NSManagedObject cannot be Sendable
+
+```swift
+@objc(Article)
+public class Article: NSManagedObject {
+    @NSManaged public var title: String // ❌ Mutable, can't be Sendable
+}
+```
+
+**Don't use `@unchecked Sendable`** - hides warnings without fixing safety.
+
+## Available Async APIs
+
+### Context perform
+
+```swift
+extension NSManagedObjectContext {
+    func perform<T>(_ block: @escaping () throws -> T) async rethrows -> T
+}
+```
+
+### What's missing
+
+No async alternative for:
+```swift
+func loadPersistentStores(
+    completionHandler: @escaping (NSPersistentStoreDescription, Error?) -> Void
+)
+```
+
+Must bridge manually (see below).
+
+## Data Access Objects (DAO)
+
+Thread-safe value types representing managed objects.
+
+### Pattern
+
+```swift
+// Managed object (not Sendable)
+@objc(Article)
+public class Article: NSManagedObject {
+    @NSManaged public var title: String?
+    @NSManaged public var timestamp: Date?
+}
+
+// DAO (Sendable)
+struct ArticleDAO: Sendable, Identifiable {
+    let id: NSManagedObjectID
+    let title: String
+    let timestamp: Date
+    
+    init?(managedObject: Article) {
+        guard let title = managedObject.title,
+              let timestamp = managedObject.timestamp else {
+            return nil
+        }
+        self.id = managedObject.objectID
+        self.title = title
+        self.timestamp = timestamp
+    }
+}
+```
+
+### Benefits
+
+- **Sendable**: Safe to pass across isolation domains
+- **Immutable**: No accidental mutations
+- **Clear API**: Explicit data transfer
+
+### Drawbacks
+
+- **Requires rewrite**: All fetch/mutation logic
+- **Boilerplate**: DAO for each entity
+- **Complexity**: Additional layer of abstraction
+
+## Working Without DAOs
+
+Pass only `NSManagedObjectID` between contexts.
+
+### Basic pattern
+
+```swift
+@MainActor
+func fetchArticle(id: NSManagedObjectID) -> Article? {
+    viewContext.object(with: id) as? Article
+}
+
+func processInBackground(articleID: NSManagedObjectID) async throws {
+    let backgroundContext = container.newBackgroundContext()
+    try await backgroundContext.perform {
+        guard let article = backgroundContext.object(with: articleID) as? Article else {
+            return
+        }
+        // Process article
+        try backgroundContext.save()
+    }
+}
+```
+
+### NSManagedObjectID is Sendable
+
+```swift
+// Safe to pass between tasks
+let articleID = article.objectID
+
+Task {
+    try? await processInBackground(articleID: articleID)
+}
+```
+
+## Bridging Closures to Async
+
+### Load persistent stores
+
+```swift
+extension NSPersistentContainer {
+    func loadPersistentStores() async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            self.loadPersistentStores { description, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: ())
+                }
+            }
+        }
+    }
+}
+
+// Usage
+try await container.loadPersistentStores()
+```
+
+## Simple CoreDataStore Pattern
+
+Enforce isolation at API level:
+
+```swift
+final class CoreDataStore {
+    let persistentContainer: NSPersistentContainer
+
+    var viewContext: NSManagedObjectContext {
+        persistentContainer.viewContext
+    }
+
+    init(persistentContainer: NSPersistentContainer) {
+        self.persistentContainer = persistentContainer
+    }
+
+    // View context operations (main thread)
+    @MainActor
+    func read<T>(_ block: (NSManagedObjectContext) throws -> T) rethrows -> T {
+        try block(viewContext)
+    }
+
+    // Background operations
+    func performInBackground<T>(
+        _ block: @Sendable @escaping (NSManagedObjectContext) throws -> T
+    ) async rethrows -> T {
+        let context = persistentContainer.newBackgroundContext()
+        return try await context.perform {
+            try block(context)
+        }
+    }
+}
+```
+
+### Usage
+
+```swift
+let store = CoreDataStore(persistentContainer: container)
+
+// Main thread operations
+@MainActor
+func loadArticles() throws -> [Article] {
+    try store.read { context in
+        let request = Article.fetchRequest()
+        return try context.fetch(request)
+    }
+}
+
+// Background operations
+func deleteAll() async throws {
+    try await store.performInBackground { context in
+        let request = Article.fetchRequest()
+        let articles = try context.fetch(request)
+        articles.forEach { context.delete($0) }
+        try context.save()
+    }
+}
+```
+
+### Why this pattern works
+
+- **@MainActor**: Enforces view context on main thread
+- **Dedicated entry points**: Read/write APIs prevent accidental cross-context use
+- **Simple**: No custom executors needed
+
+## Custom Actor Executor (Advanced)
+
+**Note**: Usually not needed. Consider simple pattern first.
+
+### Implementation
+
+```swift
+final class NSManagedObjectContextExecutor: @unchecked Sendable, SerialExecutor {
+    private let context: NSManagedObjectContext
+    
+    init(context: NSManagedObjectContext) {
+        self.context = context
+    }
+    
+    func enqueue(_ job: consuming ExecutorJob) {
+        let unownedJob = UnownedJob(job)
+        let executor = asUnownedSerialExecutor()
+        
+        context.perform {
+            unownedJob.runSynchronously(on: executor)
+        }
+    }
+    
+    func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+        UnownedSerialExecutor(ordinary: self)
+    }
+}
+```
+
+### Actor usage
+
+```swift
+actor CoreDataStore {
+    let persistentContainer: NSPersistentContainer
+    private let context: NSManagedObjectContext
+    nonisolated let modelExecutor: NSManagedObjectContextExecutor
+    
+    nonisolated var unownedExecutor: UnownedSerialExecutor {
+        modelExecutor.asUnownedSerialExecutor()
+    }
+    
+    private init() {
+        persistentContainer = NSPersistentContainer(name: "MyApp")
+        context = persistentContainer.newBackgroundContext()
+        modelExecutor = NSManagedObjectContextExecutor(context: context)
+    }
+    
+    func deleteAll<T: NSManagedObject>(
+        using request: NSFetchRequest<T>
+    ) throws {
+        let objects = try context.fetch(request)
+        objects.forEach { context.delete($0) }
+        try context.save()
+    }
+}
+```
+
+### Drawbacks
+
+- **Hidden complexity**: Executor details obscure Core Data
+- **Forces concurrency**: Even for main thread operations
+- **Not simpler**: More code than `perform { }`
+- **Error prone**: Easy to use wrong context
+
+**Recommendation**: Use simple pattern instead.
+
+## Default MainActor Isolation
+
+### Problem with auto-generated code
+
+When default isolation set to `@MainActor`, auto-generated managed objects conflict:
+
+```swift
+// Auto-generated (can't modify)
+class Article: NSManagedObject {
+    // Inherits @MainActor, conflicts with NSManagedObject
+}
+```
+
+**Error**: `Main actor-isolated initializer has different actor isolation from nonisolated overridden declaration`
+
+### Solution: Manual code generation
+
+1. Set entity to "Manual/None" code generation
+2. Generate class definitions
+3. Mark as `nonisolated`:
+
+```swift
+nonisolated class Article: NSManagedObject {
+    @NSManaged public var title: String?
+    @NSManaged public var timestamp: Date?
+}
+```
+
+**Benefit**: Full control over isolation.
+
+## Common Patterns
+
+### Fetch on main thread
+
+```swift
+@MainActor
+func fetchArticles() throws -> [Article] {
+    let request = Article.fetchRequest()
+    return try viewContext.fetch(request)
+}
+```
+
+### Background save
+
+```swift
+func saveInBackground() async throws {
+    let context = container.newBackgroundContext()
+    try await context.perform {
+        let article = Article(context: context)
+        article.title = "New Article"
+        try context.save()
+    }
+}
+```
+
+### Pass ID, fetch in context
+
+```swift
+@MainActor
+func displayArticle(id: NSManagedObjectID) {
+    guard let article = viewContext.object(with: id) as? Article else {
+        return
+    }
+    // Use article
+}
+
+func processArticle(id: NSManagedObjectID) async throws {
+    let context = container.newBackgroundContext()
+    try await context.perform {
+        guard let article = context.object(with: id) as? Article else { return }
+        // Process article
+        try context.save()
+    }
+}
+```
+
+### Batch operations
+
+```swift
+func deleteAllArticles() async throws {
+    let context = container.newBackgroundContext()
+    try await context.perform {
+        let request = NSFetchRequest<NSFetchRequestResult>(entityName: "Article")
+        let deleteRequest = NSBatchDeleteRequest(fetchRequest: request)
+        try context.execute(deleteRequest)
+    }
+}
+```
+
+## SwiftUI Integration
+
+### Environment injection
+
+```swift
+@main
+struct MyApp: App {
+    let persistentContainer = NSPersistentContainer(name: "MyApp")
+    
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environment(\.managedObjectContext, persistentContainer.viewContext)
+        }
+    }
+}
+```
+
+### View usage
+
+```swift
+struct ContentView: View {
+    @Environment(\.managedObjectContext) private var viewContext
+    @FetchRequest(
+        sortDescriptors: [NSSortDescriptor(keyPath: \Article.timestamp, ascending: true)]
+    ) private var articles: FetchedResults<Article>
+    
+    var body: some View {
+        List(articles) { article in
+            Text(article.title ?? "")
+        }
+    }
+}
+```
+
+## Best Practices
+
+1. **Pass NSManagedObjectID only** - never managed objects
+2. **Use perform { }** - don't access context directly
+3. **@MainActor for view context** - enforce main thread
+4. **Use background contexts** - run heavy work off the main thread
+5. **Manual code generation** - control isolation
+6. **Keep it simple** - avoid custom executors unless needed
+7. **Enable Core Data debugging** - catch thread violations
+8. **Merge changes automatically** - `automaticallyMergesChangesFromParent = true`
+9. **Use background contexts** - for heavy operations
+10. **Test with Thread Sanitizer** - catch violations early
+
+## Debugging
+
+### Enable Core Data concurrency debugging
+
+```swift
+// Launch argument
+-com.apple.CoreData.ConcurrencyDebug 1
+```
+
+Crashes immediately on thread violations.
+
+### Thread Sanitizer
+
+Enable in scheme settings to catch data races.
+
+### Assertions
+
+```swift
+@MainActor
+func fetchArticles() -> [Article] {
+    assert(Thread.isMainThread)
+    // Fetch from viewContext
+}
+```
+
+## Decision Tree
+
+```
+Need to access Core Data?
+├─ UI/View context?
+│  └─ Use @MainActor + viewContext
+│
+├─ Background operation?
+│  ├─ Quick operation? → perform { } on background context
+│  └─ Batch operation? → NSBatchDeleteRequest/NSBatchUpdateRequest
+│
+├─ Pass between contexts?
+│  └─ Use NSManagedObjectID only
+│
+└─ Need Sendable type?
+   ├─ Can refactor? → Use DAO pattern
+   └─ Can't refactor? → Pass NSManagedObjectID
+```
+
+## Migration Strategy
+
+### For existing projects
+
+1. **Enable manual code generation** for all entities
+2. **Mark entities as nonisolated** if using default @MainActor
+3. **Wrap Core Data access** in CoreDataStore
+4. **Use @MainActor** for view context operations
+5. **Use background contexts** for write-heavy work
+6. **Pass NSManagedObjectID** between contexts
+7. **Test with debugging enabled**
+
+### For new projects
+
+1. **Start with simple pattern** (CoreDataStore)
+2. **Manual code generation** from the start
+3. **Consider DAOs** if heavy cross-context usage
+4. **Enable strict concurrency** early
+
+## Common Mistakes
+
+### ❌ Passing managed objects
+
+```swift
+func process(article: Article) async {
+    // ❌ Article not Sendable
+}
+```
+
+### ❌ Accessing context from wrong thread
+
+```swift
+func background() async {
+    let articles = viewContext.fetch(request) // ❌ Not on main thread
+}
+```
+
+### ❌ Using @unchecked Sendable
+
+```swift
+extension Article: @unchecked Sendable {} // ❌ Doesn't make it safe
+```
+
+### ❌ Not using perform
+
+```swift
+func save() async {
+    backgroundContext.save() // ❌ Not on context's thread
+}
+```
+
+## Related References
+
+- See `threading.md` for general Core Data threading patterns
+- See `batch-operations.md` for async batch operation patterns
+- See `stack-setup.md` for container setup with async/await
+- See `testing.md` for testing async Core Data code
+
+## Further Learning
+
+For Core Data best practices, migration strategies, and advanced patterns:
+- [Core Data Best Practices Repository](https://github.com/avanderlee/CoreDataBestPractices)
+- [Swift Concurrency Course](https://www.swiftconcurrencycourse.com)

--- a/.agents/skills/core-data-expert/references/fetch-requests.md
+++ b/.agents/skills/core-data-expert/references/fetch-requests.md
@@ -1,0 +1,643 @@
+# Fetch Requests and Querying
+
+Optimizing fetch requests is crucial for app performance. This guide covers best practices for querying Core Data efficiently, from basic fetches to advanced aggregations.
+
+## Basic Fetch Request
+
+```swift
+let fetchRequest: NSFetchRequest<Article> = Article.fetchRequest()
+let articles = try context.fetch(fetchRequest)
+```
+
+## Optimization Strategies
+
+### 1. Limit Properties Fetched
+
+Only fetch the properties you actually need:
+
+```swift
+let fetchRequest = Article.fetchRequest()
+fetchRequest.propertiesToFetch = ["name", "creationDate"]
+
+// For list view, you might only need:
+fetchRequest.propertiesToFetch = ["name", "categoryName", "views"]
+```
+
+**SQL Impact:**
+```sql
+-- Without propertiesToFetch
+SELECT * FROM ZARTICLE
+
+-- With propertiesToFetch
+SELECT Z_PK, ZNAME, ZCREATIONDATE FROM ZARTICLE
+```
+
+**Benefits:**
+- Reduces memory usage
+- Faster query execution
+- Less data transferred from disk
+
+### 2. Use Batch Fetching
+
+Fetch objects in batches to avoid loading everything at once:
+
+```swift
+let fetchRequest = Article.fetchRequest()
+fetchRequest.fetchBatchSize = 20
+```
+
+**How it works:**
+- Initially fetches only 20 objects
+- Fetches next batch when needed (scrolling, iteration)
+- Keeps memory usage predictable
+
+**When to use:**
+- List views (table/collection views)
+- Large datasets
+- Scrollable content
+
+### 3. Set Fetch Limit
+
+When you only need a specific number of results:
+
+```swift
+let fetchRequest = Article.fetchRequest()
+fetchRequest.fetchLimit = 1 // Only fetch one result
+```
+
+**Common use cases:**
+```swift
+// Get newest article
+fetchRequest.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
+fetchRequest.fetchLimit = 1
+
+// Get top 10 most viewed
+fetchRequest.sortDescriptors = [NSSortDescriptor(key: "views", ascending: false)]
+fetchRequest.fetchLimit = 10
+```
+
+### 4. Fetch Only Object IDs
+
+For counting or checking existence, fetch only IDs:
+
+```swift
+let fetchRequest = Article.fetchRequest()
+fetchRequest.resultType = .managedObjectIDResultType
+
+let objectIDs = try context.fetch(fetchRequest) as! [NSManagedObjectID]
+```
+
+**Benefits:**
+- Minimal memory usage
+- Very fast
+- No faulting overhead
+
+**Use for:**
+- Counting objects
+- Checking existence
+- Batch operations
+- Validation
+
+## Sort Descriptors
+
+Always specify sort descriptors for predictable results:
+
+```swift
+let fetchRequest = Article.fetchRequest()
+fetchRequest.sortDescriptors = [
+    NSSortDescriptor(key: "creationDate", ascending: false)
+]
+```
+
+### Multiple Sort Descriptors
+
+```swift
+fetchRequest.sortDescriptors = [
+    NSSortDescriptor(key: "category.name", ascending: true),
+    NSSortDescriptor(key: "name", ascending: true)
+]
+```
+
+### Case-Insensitive Sorting
+
+```swift
+let sortDescriptor = NSSortDescriptor(
+    key: "name",
+    ascending: true,
+    selector: #selector(NSString.caseInsensitiveCompare(_:))
+)
+fetchRequest.sortDescriptors = [sortDescriptor]
+```
+
+### Localized Sorting
+
+```swift
+let sortDescriptor = NSSortDescriptor(
+    key: "name",
+    ascending: true,
+    selector: #selector(NSString.localizedStandardCompare(_:))
+)
+fetchRequest.sortDescriptors = [sortDescriptor]
+```
+
+## Predicates
+
+Filter results using predicates:
+
+### Basic Predicates
+
+```swift
+// Exact match
+fetchRequest.predicate = NSPredicate(format: "name == %@", "SwiftLee")
+
+// Contains
+fetchRequest.predicate = NSPredicate(format: "name CONTAINS[cd] %@", "swift")
+// [c] = case insensitive, [d] = diacritic insensitive
+
+// Begins with
+fetchRequest.predicate = NSPredicate(format: "name BEGINSWITH[c] %@", "Swift")
+
+// Greater than
+fetchRequest.predicate = NSPredicate(format: "views > %d", 100)
+
+// Date range
+let startDate = Calendar.current.startOfDay(for: Date())
+let endDate = Calendar.current.date(byAdding: .day, value: 1, to: startDate)!
+fetchRequest.predicate = NSPredicate(
+    format: "creationDate >= %@ AND creationDate < %@",
+    startDate as NSDate,
+    endDate as NSDate
+)
+```
+
+### Compound Predicates
+
+```swift
+// AND
+let predicate1 = NSPredicate(format: "views > %d", 100)
+let predicate2 = NSPredicate(format: "category.name == %@", "Swift")
+fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate1, predicate2])
+
+// OR
+fetchRequest.predicate = NSCompoundPredicate(orPredicateWithSubpredicates: [predicate1, predicate2])
+
+// NOT
+fetchRequest.predicate = NSCompoundPredicate(notPredicateWithSubpredicate: predicate1)
+```
+
+### Relationship Predicates
+
+```swift
+// Articles with a specific category
+fetchRequest.predicate = NSPredicate(format: "category.name == %@", "Swift")
+
+// Articles with any attachments
+fetchRequest.predicate = NSPredicate(format: "attachments.@count > 0")
+
+// Articles with more than 5 attachments
+fetchRequest.predicate = NSPredicate(format: "attachments.@count > 5")
+
+// Using ANY
+fetchRequest.predicate = NSPredicate(format: "ANY attachments.size > %d", 1000000)
+
+// Using ALL
+fetchRequest.predicate = NSPredicate(format: "ALL attachments.isDownloaded == YES")
+```
+
+### IN Predicate
+
+```swift
+let names = ["Swift", "iOS", "Core Data"]
+fetchRequest.predicate = NSPredicate(format: "name IN %@", names)
+```
+
+## NSFetchedResultsController
+
+For table and collection views, use `NSFetchedResultsController` for automatic updates:
+
+```swift
+class ArticlesViewController: UIViewController {
+    var fetchedResultsController: NSFetchedResultsController<Article>!
+    
+    func setupFetchedResultsController() {
+        let fetchRequest = Article.fetchRequest()
+        fetchRequest.sortDescriptors = [
+            NSSortDescriptor(key: "creationDate", ascending: false)
+        ]
+        fetchRequest.fetchBatchSize = 20
+        
+        fetchedResultsController = NSFetchedResultsController(
+            fetchRequest: fetchRequest,
+            managedObjectContext: viewContext,
+            sectionNameKeyPath: nil,
+            cacheName: "ArticlesCache"
+        )
+        
+        fetchedResultsController.delegate = self
+        
+        try? fetchedResultsController.performFetch()
+    }
+}
+```
+
+### With Sections
+
+```swift
+fetchedResultsController = NSFetchedResultsController(
+    fetchRequest: fetchRequest,
+    managedObjectContext: viewContext,
+    sectionNameKeyPath: "category.name", // Group by category
+    cacheName: "ArticlesByCategoryCache"
+)
+```
+
+### Delegate Methods (UITableView)
+
+```swift
+extension ArticlesViewController: NSFetchedResultsControllerDelegate {
+    func controllerWillChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
+        tableView.beginUpdates()
+    }
+    
+    func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>,
+                   didChange anObject: Any,
+                   at indexPath: IndexPath?,
+                   for type: NSFetchedResultsChangeType,
+                   newIndexPath: IndexPath?) {
+        switch type {
+        case .insert:
+            if let indexPath = newIndexPath {
+                tableView.insertRows(at: [indexPath], with: .automatic)
+            }
+        case .delete:
+            if let indexPath = indexPath {
+                tableView.deleteRows(at: [indexPath], with: .automatic)
+            }
+        case .update:
+            if let indexPath = indexPath {
+                tableView.reloadRows(at: [indexPath], with: .automatic)
+            }
+        case .move:
+            if let indexPath = indexPath, let newIndexPath = newIndexPath {
+                tableView.deleteRows(at: [indexPath], with: .automatic)
+                tableView.insertRows(at: [newIndexPath], with: .automatic)
+            }
+        @unknown default:
+            break
+        }
+    }
+    
+    func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
+        tableView.endUpdates()
+    }
+}
+```
+
+## Diffable Data Sources (iOS 13+)
+
+Modern approach using `NSDiffableDataSourceSnapshot`:
+
+```swift
+class ArticlesViewController: UICollectionViewController {
+    private var dataSource: UICollectionViewDiffableDataSource<String, NSManagedObjectID>!
+    private var fetchedResultsController: NSFetchedResultsController<Article>!
+    
+    func setupDataSource() {
+        dataSource = UICollectionViewDiffableDataSource<String, NSManagedObjectID>(
+            collectionView: collectionView
+        ) { collectionView, indexPath, objectID in
+            let cell = collectionView.dequeueReusableCell(
+                withReuseIdentifier: "ArticleCell",
+                for: indexPath
+            ) as! ArticleCell
+            
+            if let article = try? self.viewContext.existingObject(with: objectID) as? Article {
+                cell.configure(with: article)
+            }
+            
+            return cell
+        }
+    }
+    
+    func setupFetchedResultsController() {
+        let fetchRequest = Article.fetchRequest()
+        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "name", ascending: true)]
+        
+        fetchedResultsController = NSFetchedResultsController(
+            fetchRequest: fetchRequest,
+            managedObjectContext: viewContext,
+            sectionNameKeyPath: nil,
+            cacheName: nil
+        )
+        
+        fetchedResultsController.delegate = self
+        try? fetchedResultsController.performFetch()
+    }
+}
+
+extension ArticlesViewController: NSFetchedResultsControllerDelegate {
+    func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>,
+                   didChangeContentWith snapshot: NSDiffableDataSourceSnapshotReference) {
+        let snapshot = snapshot as NSDiffableDataSourceSnapshot<String, NSManagedObjectID>
+        dataSource.apply(snapshot, animatingDifferences: true)
+    }
+}
+```
+
+## Aggregate Fetching with NSExpression
+
+For statistics and aggregations:
+
+### Count
+
+```swift
+// Simple count
+let count = try context.count(for: Article.fetchRequest())
+
+// Count with predicate
+let fetchRequest = Article.fetchRequest()
+fetchRequest.predicate = NSPredicate(format: "views > %d", 100)
+let count = try context.count(for: fetchRequest)
+```
+
+### Sum, Average, Min, Max
+
+```swift
+let fetchRequest = Article.fetchRequest()
+fetchRequest.resultType = .dictionaryResultType
+
+// Sum of views
+let sumExpression = NSExpression(format: "@sum.views")
+let sumDescription = NSExpressionDescription()
+sumDescription.name = "totalViews"
+sumDescription.expression = sumExpression
+sumDescription.expressionResultType = .integer64AttributeType
+
+fetchRequest.propertiesToFetch = [sumDescription]
+
+let results = try context.fetch(fetchRequest) as! [[String: Any]]
+if let totalViews = results.first?["totalViews"] as? Int {
+    print("Total views: \(totalViews)")
+}
+```
+
+### Group By with Aggregates
+
+```swift
+let fetchRequest = Article.fetchRequest()
+fetchRequest.resultType = .dictionaryResultType
+
+// Category name
+let categoryExpression = NSExpression(forKeyPath: "category.name")
+let categoryDescription = NSExpressionDescription()
+categoryDescription.name = "categoryName"
+categoryDescription.expression = categoryExpression
+categoryDescription.expressionResultType = .stringAttributeType
+
+// Sum of views per category
+let sumExpression = NSExpression(format: "@sum.views")
+let sumDescription = NSExpressionDescription()
+sumDescription.name = "totalViews"
+sumDescription.expression = sumExpression
+sumDescription.expressionResultType = .integer64AttributeType
+
+fetchRequest.propertiesToFetch = [categoryDescription, sumDescription]
+fetchRequest.propertiesToGroupBy = ["category.name"]
+fetchRequest.sortDescriptors = [NSSortDescriptor(key: "categoryName", ascending: true)]
+
+let results = try context.fetch(fetchRequest) as! [[String: Any]]
+for result in results {
+    let category = result["categoryName"] as? String ?? "Unknown"
+    let views = result["totalViews"] as? Int ?? 0
+    print("\(category): \(views) views")
+}
+```
+
+### Count Per Group
+
+```swift
+let fetchRequest = Article.fetchRequest()
+fetchRequest.resultType = .dictionaryResultType
+
+let categoryExpression = NSExpression(forKeyPath: "category.name")
+let categoryDescription = NSExpressionDescription()
+categoryDescription.name = "categoryName"
+categoryDescription.expression = categoryExpression
+categoryDescription.expressionResultType = .stringAttributeType
+
+let countExpression = NSExpression(forFunction: "count:", arguments: [NSExpression(forKeyPath: "objectID")])
+let countDescription = NSExpressionDescription()
+countDescription.name = "count"
+countDescription.expression = countExpression
+countDescription.expressionResultType = .integer64AttributeType
+
+fetchRequest.propertiesToFetch = [categoryDescription, countDescription]
+fetchRequest.propertiesToGroupBy = ["category.name"]
+
+let results = try context.fetch(fetchRequest) as! [[String: Any]]
+```
+
+## Typed Fetch Requests with Managed Protocol
+
+Create a protocol for type-safe fetch requests:
+
+```swift
+protocol Managed: NSManagedObject {
+    static var entityName: String { get }
+}
+
+extension Managed {
+    static var entityName: String {
+        return String(describing: self)
+    }
+    
+    static func fetchRequest<T: NSManagedObject>() -> NSFetchRequest<T> {
+        return NSFetchRequest<T>(entityName: entityName)
+    }
+}
+
+// Conform your entities
+extension Article: Managed {}
+
+// Usage
+let fetchRequest: NSFetchRequest<Article> = Article.fetchRequest()
+```
+
+## Asynchronous Fetching
+
+For large datasets, fetch asynchronously:
+
+```swift
+let fetchRequest = Article.fetchRequest()
+let asyncFetchRequest = NSAsynchronousFetchRequest(fetchRequest: fetchRequest) { result in
+    guard let articles = result.finalResult else { return }
+    
+    DispatchQueue.main.async {
+        // Update UI with articles
+    }
+}
+
+try? context.execute(asyncFetchRequest)
+```
+
+## Faulting Control
+
+### Prefetching Relationships
+
+```swift
+let fetchRequest = Article.fetchRequest()
+fetchRequest.relationshipKeyPathsForPrefetching = ["category", "attachments"]
+```
+
+**Benefits:**
+- Reduces number of database trips
+- Improves performance when accessing relationships
+- Prevents N+1 query problem
+
+### Returning Faults
+
+```swift
+fetchRequest.returnsObjectsAsFaults = false
+```
+
+**When to use:**
+- You know you'll access all properties immediately
+- Small result sets
+- Avoid for large datasets (high memory usage)
+
+## Common Patterns
+
+### Fetch Single Object by ID
+
+```swift
+func fetchArticle(withID id: NSManagedObjectID) -> Article? {
+    return try? context.existingObject(with: id) as? Article
+}
+```
+
+### Fetch or Create
+
+```swift
+func fetchOrCreateArticle(withName name: String) -> Article {
+    let fetchRequest = Article.fetchRequest()
+    fetchRequest.predicate = NSPredicate(format: "name == %@", name)
+    fetchRequest.fetchLimit = 1
+    
+    if let existing = try? context.fetch(fetchRequest).first {
+        return existing
+    }
+    
+    let article = Article(context: context)
+    article.name = name
+    return article
+}
+```
+
+### Check Existence
+
+```swift
+func articleExists(withName name: String) -> Bool {
+    let fetchRequest = Article.fetchRequest()
+    fetchRequest.predicate = NSPredicate(format: "name == %@", name)
+    fetchRequest.fetchLimit = 1
+    fetchRequest.resultType = .countResultType
+    
+    let count = (try? context.count(for: fetchRequest)) ?? 0
+    return count > 0
+}
+```
+
+## Performance Tips
+
+### ❌ Don't Fetch Everything
+
+```swift
+// Bad: Fetches all properties, all objects
+let articles = try context.fetch(Article.fetchRequest())
+let count = articles.count
+```
+
+### ✅ Use Count Request
+
+```swift
+// Good: Only counts, doesn't fetch objects
+let count = try context.count(for: Article.fetchRequest())
+```
+
+### ❌ Don't Access Relationships in Loops
+
+```swift
+// Bad: Fires fault for each article
+for article in articles {
+    print(article.category?.name) // Fault!
+}
+```
+
+### ✅ Prefetch Relationships
+
+```swift
+// Good: Prefetches all categories at once
+let fetchRequest = Article.fetchRequest()
+fetchRequest.relationshipKeyPathsForPrefetching = ["category"]
+let articles = try context.fetch(fetchRequest)
+
+for article in articles {
+    print(article.category?.name) // No fault!
+}
+```
+
+### ❌ Don't Fetch in Loops
+
+```swift
+// Bad: Multiple fetch requests
+for name in names {
+    let fetchRequest = Article.fetchRequest()
+    fetchRequest.predicate = NSPredicate(format: "name == %@", name)
+    let articles = try? context.fetch(fetchRequest)
+}
+```
+
+### ✅ Use IN Predicate
+
+```swift
+// Good: Single fetch request
+let fetchRequest = Article.fetchRequest()
+fetchRequest.predicate = NSPredicate(format: "name IN %@", names)
+let articles = try context.fetch(fetchRequest)
+```
+
+## Debugging Fetch Requests
+
+### Enable SQL Debug
+
+Add launch argument:
+```
+-com.apple.CoreData.SQLDebug 1
+```
+
+**Output:**
+```sql
+CoreData: sql: SELECT Z_PK, ZNAME, ZVIEWS FROM ZARTICLE WHERE ZVIEWS > ? ORDER BY ZCREATIONDATE DESC LIMIT 20
+```
+
+### Measure Fetch Performance
+
+```swift
+let startTime = CFAbsoluteTimeGetCurrent()
+let articles = try context.fetch(fetchRequest)
+let timeElapsed = CFAbsoluteTimeGetCurrent() - startTime
+print("Fetch took \(timeElapsed) seconds")
+```
+
+## Summary
+
+1. **Use `propertiesToFetch`** to limit fetched properties
+2. **Set `fetchBatchSize`** for large datasets (typically 20-50)
+3. **Use `fetchLimit`** when you only need a few results
+4. **Always specify sort descriptors** for predictable results
+5. **Use predicates** to filter at the database level
+6. **Use `NSFetchedResultsController`** for list views
+7. **Prefetch relationships** to avoid N+1 queries
+8. **Use count requests** instead of fetching for counts
+9. **Use aggregate expressions** for statistics
+10. **Enable SQL debug** to understand query performance

--- a/.agents/skills/core-data-expert/references/glossary.md
+++ b/.agents/skills/core-data-expert/references/glossary.md
@@ -1,0 +1,233 @@
+# Core Data Glossary
+
+Quick reference for Core Data terminology.
+
+## Core Concepts
+
+**Core Data**
+Apple's framework for object graph management and persistence.
+
+**Persistent Store**
+The underlying storage (typically SQLite database) where data is saved.
+
+**Managed Object Model**
+Describes your data schema (entities, attributes, relationships).
+
+**Entity**
+A class definition in your data model (like a database table).
+
+**Attribute**
+A property of an entity (like a database column).
+
+**Relationship**
+A connection between entities (one-to-one, one-to-many, many-to-many).
+
+## Stack Components
+
+**NSPersistentContainer**
+Encapsulates the Core Data stack (model, coordinator, contexts).
+
+**NSPersistentCloudKitContainer**
+Extends NSPersistentContainer with CloudKit sync capabilities.
+
+**NSPersistentStoreCoordinator**
+Manages one or more persistent stores and coordinates access.
+
+**NSManagedObjectContext**
+Scratch pad for working with managed objects. Changes aren't persisted until saved.
+
+**NSManagedObject**
+Base class for Core Data objects. Represents a row in a database table.
+
+**NSManagedObjectID**
+Unique, immutable identifier for a managed object. Thread-safe.
+
+## Context Types
+
+**View Context**
+Main queue context for UI operations. Runs on main thread.
+
+**Background Context**
+Private queue context for heavy work. Runs on background thread.
+
+**Child Context**
+Context with a parent context. Saves push changes to parent, not to disk.
+
+## Fetching
+
+**NSFetchRequest**
+Describes a search for objects in the persistent store.
+
+**NSFetchedResultsController**
+Manages fetch results for table/collection views with automatic updates.
+
+**Predicate**
+Filter condition for fetch requests (like SQL WHERE clause).
+
+**Sort Descriptor**
+Defines ordering for fetch results (like SQL ORDER BY).
+
+**Faulting**
+Lazy loading mechanism. Object data loaded only when accessed.
+
+**Prefetching**
+Loading related objects eagerly to avoid faulting.
+
+## Operations
+
+**Save**
+Persists changes from context to persistent store.
+
+**Fetch**
+Retrieves objects from persistent store.
+
+**Insert**
+Creates new object in context.
+
+**Delete**
+Marks object for deletion. Removed on save.
+
+**Refresh**
+Reloads object from persistent store, discarding in-memory changes.
+
+**Reset**
+Clears all objects from context, freeing memory.
+
+**Rollback**
+Discards all unsaved changes in context.
+
+## Batch Operations
+
+**NSBatchInsertRequest**
+Inserts multiple objects at SQL level (iOS 14+).
+
+**NSBatchDeleteRequest**
+Deletes multiple objects at SQL level.
+
+**NSBatchUpdateRequest**
+Updates multiple objects at SQL level.
+
+## Advanced Features
+
+**Persistent History Tracking**
+Records all changes in a transaction log for cross-context synchronization.
+
+**Derived Attribute**
+Computed attribute stored in database (e.g., `articles.@count`).
+
+**Transformable**
+Custom type stored using value transformer.
+
+**Constraint**
+Ensures attribute uniqueness (requires merge policy).
+
+**Merge Policy**
+Determines how conflicts are resolved when saving.
+
+## Migration
+
+**Lightweight Migration**
+Automatic migration for simple model changes.
+
+**Staged Migration**
+Complex migration decomposed into steps (iOS 17+).
+
+**Deferred Migration**
+Delays cleanup work for better performance (iOS 14+).
+
+**Composite Attribute**
+Structured data within single attribute (iOS 17+).
+
+**Mapping Model**
+Describes how to migrate from one model version to another.
+
+**Version Hash**
+Checksum identifying a specific model version.
+
+## Threading
+
+**perform**
+Executes block asynchronously on context's queue.
+
+**performAndWait**
+Executes block synchronously on context's queue (blocks calling thread).
+
+**Thread Confinement**
+Each context must be accessed only from its queue.
+
+**automaticallyMergesChangesFromParent**
+Context automatically receives changes from parent context.
+
+## Validation
+
+**validateForInsert**
+Called before inserting object.
+
+**validateForUpdate**
+Called before updating object.
+
+**validateForDelete**
+Called before deleting object.
+
+## Lifecycle
+
+**awakeFromInsert**
+Called once when object first inserted.
+
+**awakeFromFetch**
+Called when object loaded from store.
+
+**willSave**
+Called before each save.
+
+**didSave**
+Called after save completes.
+
+**prepareForDeletion**
+Called when object marked for deletion.
+
+## CloudKit
+
+**Container Identifier**
+Unique ID for CloudKit container (e.g., `iCloud.com.example.app`).
+
+**Development Environment**
+CloudKit environment for testing (schema mutable).
+
+**Production Environment**
+CloudKit environment for released apps (schema immutable).
+
+**Schema Initialization**
+First run creates CloudKit schema from Core Data model.
+
+**Event Notification**
+Notification sent when CloudKit sync events occur.
+
+## Debugging
+
+**SQL Debug**
+Launch argument to log SQL queries: `-com.apple.CoreData.SQLDebug 1`
+
+**Concurrency Debug**
+Launch argument to catch threading violations: `-com.apple.CoreData.ConcurrencyDebug 1`
+
+**Migration Debug**
+Launch argument to log migration steps: `-com.apple.CoreData.MigrationDebug 1`
+
+## Common Acronyms
+
+**CD** - Core Data
+**MOC** - Managed Object Context (NSManagedObjectContext)
+**MO** - Managed Object (NSManagedObject)
+**FRC** - Fetched Results Controller (NSFetchedResultsController)
+**PSC** - Persistent Store Coordinator (NSPersistentStoreCoordinator)
+**MOD** - Managed Object Model (NSManagedObjectModel)
+
+## Quick Reference
+
+**Thread-safe:** NSManagedObjectID, NSPersistentStoreCoordinator
+**Not thread-safe:** NSManagedObject, NSManagedObjectContext
+**Main thread only:** View context operations
+**Background thread:** Background context operations
+**Automatic:** Lightweight migration (with NSPersistentContainer)
+**Manual:** Staged migration, custom mapping models

--- a/.agents/skills/core-data-expert/references/migration.md
+++ b/.agents/skills/core-data-expert/references/migration.md
@@ -1,0 +1,393 @@
+# Schema Migration
+
+Schema migration is the process of updating your Core Data model as your app evolves. Core Data provides three migration strategies: lightweight, staged (iOS 17+), and deferred (iOS 14+).
+
+## When Migration is Required
+
+Core Data refuses to open a store when the model doesn't match:
+
+```
+Error: NSPersistentStoreIncompatibleVersionHashError
+```
+
+**This means:** Your data model changed, and you need to migrate.
+
+## Lightweight Migration (Recommended)
+
+Lightweight migration is automatic and handles most common changes.
+
+### Enabling Lightweight Migration
+
+With `NSPersistentContainer` (automatic):
+```swift
+let container = NSPersistentContainer(name: "Model")
+// Lightweight migration enabled by default
+```
+
+With `NSPersistentStoreDescription` (automatic):
+```swift
+let description = NSPersistentStoreDescription(url: storeURL)
+// Lightweight migration enabled by default
+```
+
+Manual setup (if needed):
+```swift
+let options = [
+    NSMigratePersistentStoresAutomaticallyOption: true,
+    NSInferMappingModelAutomaticallyOption: true
+]
+try coordinator.addPersistentStore(
+    ofType: NSSQLiteStoreType,
+    configurationName: nil,
+    at: storeURL,
+    options: options
+)
+```
+
+### Supported Operations
+
+**Attributes:**
+- Add attribute
+- Remove attribute
+- Make optional attribute non-optional (with default value)
+- Make non-optional attribute optional
+- Rename attribute (using renaming identifier)
+
+**Relationships:**
+- Add relationship
+- Remove relationship
+- Rename relationship (using renaming identifier)
+- Change cardinality (to-one ↔ to-many)
+- Change ordering (ordered ↔ non-ordered)
+
+**Entities:**
+- Add entity
+- Remove entity
+- Rename entity (using renaming identifier)
+- Create parent/child entity
+- Move attributes up/down hierarchy
+- Move entities in/out of hierarchy
+
+**Cannot do:**
+- Merge entity hierarchies (entities without common parent can't share parent)
+
+### Renaming Attributes/Entities
+
+Set the renaming identifier to the **old name**:
+
+```swift
+// In Data Model Editor:
+// 1. Rename attribute from "color" to "paintColor"
+// 2. Set Renaming Identifier to "color"
+```
+
+This allows chaining renames across versions:
+- V1: `color`
+- V2: `paintColor` (renaming ID: `color`)
+- V3: `primaryColor` (renaming ID: `paintColor`)
+
+Migration works: V1→V2, V2→V3, and V1→V3.
+
+### Testing Lightweight Migration
+
+```swift
+// Check if migration is possible
+let sourceModel = // ... load V1 model
+let destinationModel = // ... load V2 model
+
+if let mappingModel = try? NSMappingModel.inferredMappingModel(
+    forSourceModel: sourceModel,
+    destinationModel: destinationModel
+) {
+    print("Lightweight migration possible")
+} else {
+    print("Lightweight migration not possible")
+}
+```
+
+## Composite Attributes (iOS 17+)
+
+New in iOS 17: Structured data within a single attribute.
+
+### Creating Composite Attributes
+
+In Data Model Editor:
+1. Add Composite Attribute
+2. Add elements (String, Int, Date, etc.)
+3. Can nest composite attributes
+
+```swift
+// Example: ColorScheme composite
+// - primary: String
+// - secondary: String
+// - tertiary: String
+
+class Aircraft: NSManagedObject {
+    @NSManaged var colorScheme: [String: Any]
+}
+
+// Usage
+aircraft.colorScheme = [
+    "primary": "Red",
+    "secondary": "White",
+    "tertiary": "Blue"
+]
+
+// Querying
+fetchRequest.predicate = NSPredicate(format: "colorScheme.primary == %@", "Red")
+```
+
+### Benefits
+
+- No transformable code needed
+- Supports predicates with keypaths
+- Better than flattened attributes
+- Can prevent faulting across relationships
+
+## Staged Migration (iOS 17+)
+
+For complex migrations that exceed lightweight capabilities.
+
+### When to Use
+
+- Changes don't fit lightweight patterns
+- Need to run custom code during migration
+- Need to decompose complex changes into steps
+
+### Key Classes
+
+- `NSStagedMigrationManager` - Manages migration event loop
+- `NSCustomMigrationStage` - Custom code execution
+- `NSLightweightMigrationStage` - Lightweight-eligible changes
+- `NSManagedObjectModelReference` - Model references with checksums
+
+### Example: Denormalizing Data
+
+**Problem:** Move `flightData` attribute to separate entity.
+
+**Solution:** Decompose into stages:
+
+**Stage 1 (Lightweight):** Add new entity and relationship
+```swift
+// ModelV1 → ModelV2
+// Add FlightData entity
+// Add flightParameters relationship to Aircraft
+```
+
+**Stage 2 (Custom):** Copy data
+- Fetch rows using generic `NSManagedObject` / `NSFetchRequestResult` types.
+- Create new entities and copy data inside the migration stage handler.
+- Ensure the custom logic is restartable if the process is interrupted.
+
+**Stage 3 (Lightweight):** Remove old attribute
+```swift
+// ModelV3 → ModelV4
+// Remove flightData attribute from Aircraft
+```
+
+### Getting Version Checksum
+
+From Xcode build log:
+```
+Compile data model Model.xcdatamodeld
+version checksum: ABC123...
+```
+
+## Deferred Migration (iOS 14+)
+
+Defer cleanup work to keep app responsive.
+
+### When to Use
+
+- Removing attributes/relationships
+- Changing relationship hierarchy
+- Changing relationship ordering
+- Any migration with expensive cleanup
+
+### How It Works
+
+1. Migration runs synchronously (fast)
+2. Cleanup (indices, column drops) is deferred
+3. App uses latest schema immediately
+4. Finish cleanup when resources available
+
+### Enabling Deferred Migration
+
+```swift
+let description = NSPersistentStoreDescription(url: storeURL)
+description.setOption(
+    true as NSNumber,
+    forKey: NSPersistentStoreDeferredLightweightMigrationOptionKey
+)
+```
+
+### Checking for Pending Work
+
+```swift
+let metadata = try NSPersistentStoreCoordinator.metadataForPersistentStore(
+    ofType: NSSQLiteStoreType,
+    at: storeURL
+)
+
+if let hasDeferredWork = metadata[NSPersistentStoreDeferredLightweightMigrationOptionKey] as? Bool,
+   hasDeferredWork {
+    print("Deferred migration work pending")
+}
+```
+
+### Finishing Deferred Migration
+
+```swift
+func finishDeferredMigration() {
+    let coordinator = container.persistentStoreCoordinator
+    
+    do {
+        try coordinator.finishDeferredLightweightMigration()
+        print("Deferred migration completed")
+    } catch {
+        print("Failed to finish deferred migration: \(error)")
+    }
+}
+```
+
+### Scheduling with Background Tasks
+
+```swift
+import BackgroundTasks
+
+// Register task
+BGTaskScheduler.shared.register(
+    forTaskWithIdentifier: "com.example.app.migration",
+    using: nil
+) { task in
+    self.handleMigrationTask(task as! BGProcessingTask)
+}
+
+// Schedule task
+func scheduleMigration() {
+    let request = BGProcessingTaskRequest(identifier: "com.example.app.migration")
+    request.requiresNetworkConnectivity = false
+    request.requiresExternalPower = false
+    
+    try? BGTaskScheduler.shared.submit(request)
+}
+
+// Handle task
+func handleMigrationTask(_ task: BGProcessingTask) {
+    task.expirationHandler = {
+        task.setTaskCompleted(success: false)
+    }
+    
+    finishDeferredMigration()
+    task.setTaskCompleted(success: true)
+}
+```
+
+## Migration Debugging
+
+### Enable Migration Debug
+
+```
+-com.apple.CoreData.MigrationDebug 1
+```
+
+**Output:**
+```
+CoreData: annotation: Migration: Migrating from version 1 to version 2
+CoreData: annotation: Migration: Inferred mapping model
+CoreData: annotation: Migration: Completed successfully
+```
+
+### Common Errors
+
+**NSPersistentStoreIncompatibleVersionHashError**
+- Model changed, migration required
+- Enable lightweight migration or create mapping model
+
+**NSMigrationMissingSourceModelError**
+- Can't find source model
+- Ensure all model versions are in bundle
+
+**NSMigrationError**
+- Migration failed
+- Check if changes are lightweight-compatible
+- Use staged migration for complex changes
+
+## Best Practices
+
+1. **Test migrations thoroughly** - Test upgrade paths from all previous versions
+2. **Keep model versions** - Don't delete old .xcdatamodel files
+3. **Use lightweight when possible** - Simplest and most reliable
+4. **Decompose complex changes** - Use staged migration for non-lightweight changes
+5. **Defer expensive cleanup** - Use deferred migration for large datasets
+6. **Version your models** - Create new model version for each release
+7. **Test on real data** - Migration behavior differs with large datasets
+8. **Document changes** - Keep migration notes for future reference
+
+## Testing Migrations
+
+```swift
+func testMigration() throws {
+    // 1. Create store with old model
+    let oldModelURL = Bundle.main.url(forResource: "ModelV1", withExtension: "momd")!
+    let oldModel = NSManagedObjectModel(contentsOf: oldModelURL)!
+    
+    let coordinator = NSPersistentStoreCoordinator(managedObjectModel: oldModel)
+    try coordinator.addPersistentStore(
+        ofType: NSSQLiteStoreType,
+        configurationName: nil,
+        at: storeURL,
+        options: nil
+    )
+    
+    // 2. Add test data
+    let context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+    context.persistentStoreCoordinator = coordinator
+    
+    let entity = NSEntityDescription.insertNewObject(forEntityName: "Article", into: context)
+    entity.setValue("Test", forKey: "name")
+    try context.save()
+    
+    // 3. Close store
+    try coordinator.remove(coordinator.persistentStores.first!)
+    
+    // 4. Migrate with new model
+    let newModelURL = Bundle.main.url(forResource: "ModelV2", withExtension: "momd")!
+    let newModel = NSManagedObjectModel(contentsOf: newModelURL)!
+    
+    let newCoordinator = NSPersistentStoreCoordinator(managedObjectModel: newModel)
+    let options = [
+        NSMigratePersistentStoresAutomaticallyOption: true,
+        NSInferMappingModelAutomaticallyOption: true
+    ]
+    try newCoordinator.addPersistentStore(
+        ofType: NSSQLiteStoreType,
+        configurationName: nil,
+        at: storeURL,
+        options: options
+    )
+    
+    // 5. Verify data
+    let newContext = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+    newContext.persistentStoreCoordinator = newCoordinator
+    
+    let fetchRequest = NSFetchRequest<NSManagedObject>(entityName: "Article")
+    let results = try newContext.fetch(fetchRequest)
+    
+    XCTAssertEqual(results.count, 1)
+    XCTAssertEqual(results.first?.value(forKey: "name") as? String, "Test")
+}
+```
+
+## Summary
+
+1. **Use lightweight migration** - Handles most common changes automatically
+2. **Enable by default** - NSPersistentContainer enables it automatically
+3. **Use renaming identifiers** - For renaming attributes/entities/relationships
+4. **Use composite attributes (iOS 17+)** - For structured data
+5. **Use staged migration (iOS 17+)** - For complex, non-lightweight changes
+6. **Use deferred migration (iOS 14+)** - For expensive cleanup operations
+7. **Test thoroughly** - Verify all upgrade paths
+8. **Keep all model versions** - Required for migration
+9. **Enable migration debug** - Helps diagnose issues
+10. **Document changes** - Track what changed in each version

--- a/.agents/skills/core-data-expert/references/model-configuration.md
+++ b/.agents/skills/core-data-expert/references/model-configuration.md
@@ -1,0 +1,597 @@
+# Model Configuration
+
+Core Data's data model offers powerful configuration options beyond basic attributes and relationships. This guide covers constraints, derived attributes, transformables, validation, and lifecycle events.
+
+## Constraints
+
+Constraints ensure uniqueness of attribute values. When combined with the correct merge policy, Core Data automatically handles duplicates.
+
+### Setting Up Constraints
+
+In Xcode's Data Model Editor:
+1. Select your entity
+2. In the Data Model Inspector, find "Constraints"
+3. Click "+" and add attribute names
+
+**Example:** Make `name` unique in the `Category` entity.
+
+### Required Merge Policy
+
+```swift
+viewContext.mergePolicy = NSMergeByPropertyStoreTrumpMergePolicy
+```
+
+**Without this merge policy, constraint violations will crash your app.**
+
+### How Constraints Work
+
+```swift
+// First save
+let category1 = Category(context: context)
+category1.name = "Swift"
+try context.save() // Saves successfully
+
+// Duplicate attempt
+let category2 = Category(context: context)
+category2.name = "Swift" // Same name
+try context.save() // With correct merge policy: keeps first, discards second
+```
+
+### Multiple Constraints
+
+```swift
+// Constraints on multiple attributes
+// In model: constraints = ["email", "username"]
+
+// Both must be unique
+user1.email = "test@example.com"
+user1.username = "testuser"
+```
+
+### Compound Constraints
+
+```swift
+// Unique combination of attributes
+// In model: constraints = ["firstName,lastName"]
+
+// These are different (unique combinations)
+person1.firstName = "John"
+person1.lastName = "Doe"
+
+person2.firstName = "John"
+person2.lastName = "Smith" // Different combination, allowed
+```
+
+## Derived Attributes
+
+Derived attributes are computed from other attributes or relationships and stored in the database. They're calculated on save or refresh.
+
+### Benefits
+
+- No need to manually update computed values
+- Better performance than accessing relationships
+- Optimized for queries
+
+### Common Derivations
+
+#### 1. Count of Relationships
+
+```swift
+// In Data Model Editor:
+// Derived attribute: articlesCount
+// Derivation: articles.@count
+```
+
+**Why this is better than `articles.count`:**
+- Doesn't fire faults
+- Faster queries
+- Always up-to-date after save
+
+#### 2. Related Object Property
+
+```swift
+// Derived attribute: categoryName
+// Derivation: category.name
+```
+
+**Use case:** Avoid firing faults when displaying list views.
+
+#### 3. Current Timestamp
+
+```swift
+// Derived attribute: lastModified
+// Derivation: now()
+```
+
+**Automatically updates on every save.**
+
+#### 4. Canonical String (Search Optimization)
+
+```swift
+// Derived attribute: searchName
+// Derivation: canonical:(name)
+```
+
+**What it does:**
+- Converts to lowercase
+- Removes diacritics
+- Perfect for case-insensitive, diacritic-insensitive searches
+
+**Example:**
+```swift
+// name = "Café"
+// searchName = "cafe"
+
+// Search query
+fetchRequest.predicate = NSPredicate(format: "searchName CONTAINS %@", "cafe")
+// Matches "Café", "CAFE", "café", etc.
+```
+
+#### 5. Sum of Related Values
+
+```swift
+// Derived attribute: totalViews
+// Derivation: @sum.articles.views
+```
+
+### Important Notes
+
+- Derived attributes are calculated **on save** or **refresh**
+- In-memory changes don't update derived attributes until saved
+- Can't be set manually (they're computed)
+
+### Example Usage
+
+```swift
+class Article: NSManagedObject {
+    @NSManaged var name: String
+    @NSManaged var category: Category?
+    
+    // Derived from category.name
+    @NSManaged var categoryName: String?
+    
+    // Derived from canonical:(name)
+    @NSManaged var searchName: String?
+}
+
+// Usage
+article.name = "Core Data Best Practices"
+try context.save()
+
+// After save, derived attributes are updated
+print(article.searchName) // "core data best practices"
+print(article.categoryName) // "Swift"
+```
+
+## Transformables
+
+Transformables allow storing custom types that aren't natively supported by Core Data.
+
+### Creating a Value Transformer
+
+```swift
+import UIKit
+
+@objc(ColorTransformer)
+class ColorTransformer: ValueTransformer {
+    override class func transformedValueClass() -> AnyClass {
+        return NSData.self
+    }
+    
+    override class func allowsReverseTransformation() -> Bool {
+        return true
+    }
+    
+    override func transformedValue(_ value: Any?) -> Any? {
+        guard let color = value as? UIColor else { return nil }
+        
+        do {
+            let data = try NSKeyedArchiver.archivedData(
+                withRootObject: color,
+                requiringSecureCoding: true
+            )
+            return data
+        } catch {
+            print("Failed to transform color: \(error)")
+            return nil
+        }
+    }
+    
+    override func reverseTransformedValue(_ value: Any?) -> Any? {
+        guard let data = value as? Data else { return nil }
+        
+        do {
+            let color = try NSKeyedUnarchiver.unarchivedObject(
+                ofClass: UIColor.self,
+                from: data
+            )
+            return color
+        } catch {
+            print("Failed to reverse transform color: \(error)")
+            return nil
+        }
+    }
+}
+```
+
+### Registering the Transformer
+
+```swift
+// In your stack setup, before loading stores
+ValueTransformer.setValueTransformer(
+    ColorTransformer(),
+    forName: NSValueTransformerName("ColorTransformer")
+)
+```
+
+### Configuring in Data Model
+
+1. Select the attribute
+2. Set Type to "Transformable"
+3. Set "Custom Class" to your type (e.g., `UIColor`)
+4. Set "Transformer" to your transformer name (e.g., `ColorTransformer`)
+
+### Using Transformable Attributes
+
+```swift
+class Article: NSManagedObject {
+    @NSManaged var color: UIColor?
+}
+
+// Usage
+article.color = .systemBlue
+try context.save()
+
+// Retrieval
+let color = article.color // UIColor
+```
+
+### NSSecureCoding Requirement
+
+Modern Core Data requires secure coding:
+
+```swift
+// Make your custom type conform to NSSecureCoding
+extension CustomType: NSSecureCoding {
+    static var supportsSecureCoding: Bool { return true }
+    
+    func encode(with coder: NSCoder) {
+        // Encode properties
+    }
+    
+    required init?(coder: NSCoder) {
+        // Decode properties
+    }
+}
+```
+
+## Validation
+
+Core Data provides built-in validation that runs before saving.
+
+### Model-Level Validation
+
+Set in Data Model Editor:
+
+**String Validation:**
+- Minimum Length
+- Maximum Length
+- Regular Expression
+
+**Numeric Validation:**
+- Minimum Value
+- Maximum Value
+
+**Example:**
+```
+Attribute: name
+Type: String
+Min Length: 3
+Max Length: 100
+```
+
+### Code-Level Validation
+
+Override validation methods in your `NSManagedObject` subclass:
+
+```swift
+class Article: NSManagedObject {
+    @NSManaged var name: String?
+    
+    // Validate before insert
+    override func validateForInsert() throws {
+        try super.validateForInsert()
+        try validateName()
+    }
+    
+    // Validate before update
+    override func validateForUpdate() throws {
+        try super.validateForUpdate()
+        try validateName()
+    }
+    
+    // Validate before delete
+    override func validateForDelete() throws {
+        try super.validateForDelete()
+        
+        // Example: Can't delete if has related objects
+        if let attachments = attachments, !attachments.isEmpty {
+            throw NSError(
+                domain: "ArticleValidation",
+                code: 1001,
+                userInfo: [NSLocalizedDescriptionKey: "Cannot delete article with attachments"]
+            )
+        }
+    }
+    
+    // Custom validation
+    private func validateName() throws {
+        guard let name = name, !name.isEmpty else {
+            throw NSError(
+                domain: "ArticleValidation",
+                code: 1000,
+                userInfo: [NSLocalizedDescriptionKey: "Name cannot be empty"]
+            )
+        }
+        
+        // Check for protected names
+        let protectedNames = ["Admin", "System", "Root"]
+        if protectedNames.contains(name) {
+            throw NSError(
+                domain: "ArticleValidation",
+                code: 1002,
+                userInfo: [NSLocalizedDescriptionKey: "'\(name)' is a protected name"]
+            )
+        }
+    }
+}
+```
+
+### Property-Level Validation
+
+```swift
+class Article: NSManagedObject {
+    @NSManaged var name: String?
+    
+    override func validateName(_ value: AutoreleasingUnsafeMutablePointer<AnyObject?>) throws {
+        guard let name = value.pointee as? String, !name.isEmpty else {
+            throw NSError(
+                domain: "ArticleValidation",
+                code: 1000,
+                userInfo: [NSLocalizedDescriptionKey: "Name cannot be empty"]
+            )
+        }
+    }
+}
+```
+
+### Handling Validation Errors
+
+```swift
+do {
+    try context.save()
+} catch let error as NSError {
+    if error.domain == NSCocoaErrorDomain {
+        switch error.code {
+        case NSValidationStringTooShortError:
+            print("String too short")
+        case NSValidationStringTooLongError:
+            print("String too long")
+        case NSManagedObjectValidationError:
+            print("Validation failed")
+        default:
+            print("Other error: \(error.localizedDescription)")
+        }
+    }
+}
+```
+
+## Lifecycle Events
+
+Override lifecycle methods to perform actions at specific points in an object's life.
+
+### awakeFromInsert()
+
+Called once when object is first inserted into context.
+
+```swift
+override func awakeFromInsert() {
+    super.awakeFromInsert()
+    
+    // Set default values
+    setPrimitiveValue(Date(), forKey: #keyPath(Article.creationDate))
+    setPrimitiveValue(Date(), forKey: #keyPath(Article.lastModified))
+    setPrimitiveValue(0, forKey: #keyPath(Article.views))
+}
+```
+
+**Use `setPrimitiveValue` to avoid:**
+- KVO notifications
+- Marking object as changed
+- Infinite loops
+
+### willSave()
+
+Called before every save. Use for updating modification dates or cleaning up.
+
+```swift
+override func willSave() {
+    super.willSave()
+    
+    // Update modification date
+    setPrimitiveValue(Date(), forKey: #keyPath(Article.lastModified))
+    
+    // Delete local files if object is deleted
+    if isDeleted, let localResource = localResourceURL {
+        try? FileManager.default.removeItem(at: localResource)
+    }
+}
+```
+
+**Caution:** Don't call `save()` inside `willSave()` - infinite loop!
+
+### didSave()
+
+Called after save completes.
+
+```swift
+override func didSave() {
+    super.didSave()
+    
+    // Post notification, update cache, etc.
+    NotificationCenter.default.post(
+        name: .articleDidSave,
+        object: self
+    )
+}
+```
+
+### prepareForDeletion()
+
+Called when object is marked for deletion (before save).
+
+```swift
+override func prepareForDeletion() {
+    super.prepareForDeletion()
+    
+    // Cancel ongoing operations
+    downloadTask?.cancel()
+    
+    // Don't delete files here! Use willSave() instead
+    // (prepareForDeletion is called even if save is rolled back)
+}
+```
+
+**Important:** Don't delete files in `prepareForDeletion()`. The deletion might be rolled back, leaving your data inconsistent.
+
+### awakeFromFetch()
+
+Called when object is fetched from store.
+
+```swift
+override func awakeFromFetch() {
+    super.awakeFromFetch()
+    
+    // Initialize transient properties
+    setupObservers()
+}
+```
+
+### Complete Lifecycle Example
+
+```swift
+class Article: NSManagedObject {
+    @NSManaged var name: String?
+    @NSManaged var creationDate: Date?
+    @NSManaged var lastModified: Date?
+    @NSManaged var localResourceURL: URL?
+    
+    override func awakeFromInsert() {
+        super.awakeFromInsert()
+        
+        // Set creation date once
+        setPrimitiveValue(Date(), forKey: #keyPath(Article.creationDate))
+        setPrimitiveValue(Date(), forKey: #keyPath(Article.lastModified))
+    }
+    
+    override func willSave() {
+        super.willSave()
+        
+        // Update modification date on every save
+        if !isDeleted && changedValues().keys.contains("name") {
+            setPrimitiveValue(Date(), forKey: #keyPath(Article.lastModified))
+        }
+        
+        // Clean up files when deleted
+        if isDeleted, let url = localResourceURL {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+    
+    override func prepareForDeletion() {
+        super.prepareForDeletion()
+        
+        // Cancel ongoing operations
+        // Don't delete files here!
+    }
+}
+```
+
+## Common Pitfalls
+
+### ❌ Not Setting Merge Policy with Constraints
+
+```swift
+// Constraint violation will crash
+let category = Category(context: context)
+category.name = "Duplicate"
+try context.save() // CRASH!
+```
+
+### ❌ Manually Setting Derived Attributes
+
+```swift
+// Derived attributes are read-only
+article.categoryName = "Swift" // Ignored!
+```
+
+### ❌ Using KVO Methods in Lifecycle Events
+
+```swift
+override func awakeFromInsert() {
+    super.awakeFromInsert()
+    
+    // ❌ Triggers KVO, marks as changed
+    self.creationDate = Date()
+    
+    // ✅ Use primitive values
+    setPrimitiveValue(Date(), forKey: #keyPath(Article.creationDate))
+}
+```
+
+### ❌ Deleting Files in prepareForDeletion
+
+```swift
+override func prepareForDeletion() {
+    super.prepareForDeletion()
+    
+    // ❌ Bad: Deletion might be rolled back
+    try? FileManager.default.removeItem(at: fileURL)
+}
+```
+
+### ✅ Correct Approaches
+
+```swift
+// Set merge policy
+viewContext.mergePolicy = NSMergeByPropertyStoreTrumpMergePolicy
+
+// Let derived attributes compute themselves
+article.name = "New Name"
+try context.save()
+print(article.searchName) // Automatically updated
+
+// Use primitive values in lifecycle events
+setPrimitiveValue(Date(), forKey: #keyPath(Article.creationDate))
+
+// Delete files in willSave when isDeleted
+override func willSave() {
+    super.willSave()
+    if isDeleted {
+        try? FileManager.default.removeItem(at: fileURL)
+    }
+}
+```
+
+## Summary
+
+1. **Use constraints for uniqueness** - Requires NSMergeByPropertyStoreTrumpMergePolicy
+2. **Use derived attributes** - Better performance than accessing relationships
+3. **Use canonical: for search** - Case and diacritic insensitive
+4. **Use transformables for custom types** - With NSSecureCoding
+5. **Validate in code** - For complex business rules
+6. **Use awakeFromInsert for defaults** - Called once on creation
+7. **Use willSave for updates** - Called before every save
+8. **Use setPrimitiveValue** - Avoid KVO in lifecycle events
+9. **Delete files in willSave** - When isDeleted is true
+10. **Don't save in willSave** - Causes infinite loop

--- a/.agents/skills/core-data-expert/references/performance.md
+++ b/.agents/skills/core-data-expert/references/performance.md
@@ -1,0 +1,300 @@
+# Performance Optimization
+
+Optimizing Core Data performance requires understanding where bottlenecks occur and applying targeted solutions.
+
+## Profiling with Instruments
+
+### Time Profiler
+
+1. In Xcode: Product → Profile
+2. Select Time Profiler
+3. Record while using app
+4. Find heaviest stack traces
+
+**Look for:**
+- Excessive faulting
+- Slow fetch requests
+- Save operations taking too long
+
+### Allocations Instrument
+
+1. Product → Profile
+2. Select Allocations
+3. Monitor memory growth
+4. Identify retained objects
+
+**Look for:**
+- Unbounded memory growth
+- Objects not being released
+- Large allocations
+
+## SQL Debug Logging
+
+Enable SQL logging:
+```
+-com.apple.CoreData.SQLDebug 1
+```
+
+**Output:**
+```sql
+CoreData: sql: SELECT Z_PK, ZNAME FROM ZARTICLE WHERE ZVIEWS > ? LIMIT 20
+CoreData: annotation: sql execution time: 0.0023s
+```
+
+**Analyze:**
+- Query complexity
+- Execution time
+- Number of queries (N+1 problem)
+
+## Common Performance Issues
+
+### 1. N+1 Query Problem
+
+**Problem:**
+```swift
+// Fetches articles
+let articles = try context.fetch(Article.fetchRequest())
+
+// Each access fires a fault (N queries)
+for article in articles {
+    print(article.category?.name) // Fault!
+}
+```
+
+**Solution:**
+```swift
+let fetchRequest = Article.fetchRequest()
+fetchRequest.relationshipKeyPathsForPrefetching = ["category"]
+let articles = try context.fetch(fetchRequest)
+
+// No faults fired
+for article in articles {
+    print(article.category?.name) // Already loaded
+}
+```
+
+### 2. Fetching Too Much Data
+
+**Problem:**
+```swift
+// Fetches all properties of all objects
+let articles = try context.fetch(Article.fetchRequest())
+let count = articles.count
+```
+
+**Solution:**
+```swift
+// Only counts, doesn't fetch objects
+let count = try context.count(for: Article.fetchRequest())
+```
+
+### 3. Not Using Batch Sizes
+
+**Problem:**
+```swift
+// Loads 10,000 objects into memory
+let fetchRequest = Article.fetchRequest()
+let articles = try context.fetch(fetchRequest)
+```
+
+**Solution:**
+```swift
+fetchRequest.fetchBatchSize = 20
+// Only loads 20 at a time
+```
+
+### 4. Fetching Unnecessary Properties
+
+**Problem:**
+```swift
+// Fetches all properties
+let fetchRequest = Article.fetchRequest()
+```
+
+**Solution:**
+```swift
+fetchRequest.propertiesToFetch = ["name", "creationDate"]
+// Only fetches needed properties
+```
+
+### 5. Saving Too Frequently
+
+**Problem:**
+```swift
+for item in items {
+    item.processed = true
+    try? context.save() // Very slow!
+}
+```
+
+**Solution:**
+```swift
+for item in items {
+    item.processed = true
+}
+try? context.save() // Save once
+```
+
+### 6. Not Resetting Context
+
+**Problem:**
+```swift
+// Context accumulates objects
+for i in 0..<10000 {
+    let article = Article(context: context)
+    // Memory grows unbounded
+}
+```
+
+**Solution:**
+```swift
+for i in 0..<10000 {
+    let article = Article(context: context)
+    
+    if i % 100 == 0 {
+        try? context.save()
+        context.reset() // Clear memory
+    }
+}
+```
+
+## Memory Management
+
+### Context Reset
+
+```swift
+context.reset()
+```
+
+**When to use:**
+- After processing large batches
+- When context accumulates many objects
+- To free memory
+
+**Caution:** Invalidates all fetched objects from this context.
+
+### Refresh Objects
+
+```swift
+context.refresh(article, mergeChanges: false)
+```
+
+**When to use:**
+- Discard in-memory changes
+- Free memory for specific object
+- Reload from database
+
+### Turn Objects into Faults
+
+```swift
+context.refreshAllObjects()
+```
+
+**When to use:**
+- Free memory across all objects
+- After large operations
+- When memory is constrained
+
+## Fetch Request Optimization
+
+### Checklist
+
+```swift
+let fetchRequest = Article.fetchRequest()
+
+// ✅ Set batch size
+fetchRequest.fetchBatchSize = 20
+
+// ✅ Limit properties
+fetchRequest.propertiesToFetch = ["name", "views"]
+
+// ✅ Prefetch relationships
+fetchRequest.relationshipKeyPathsForPrefetching = ["category"]
+
+// ✅ Use predicate to filter
+fetchRequest.predicate = NSPredicate(format: "views > %d", 100)
+
+// ✅ Set fetch limit if applicable
+fetchRequest.fetchLimit = 10
+
+// ✅ Specify sort descriptors
+fetchRequest.sortDescriptors = [NSSortDescriptor(key: "name", ascending: true)]
+```
+
+## Batch Operations
+
+For large-scale operations, use batch requests:
+
+```swift
+// Instead of:
+for article in articles {
+    article.isRead = true
+}
+try context.save()
+
+// Use:
+let batchUpdate = NSBatchUpdateRequest(entityName: "Article")
+batchUpdate.propertiesToUpdate = ["isRead": true]
+try context.execute(batchUpdate)
+```
+
+**Benefits:**
+- 10-20x faster
+- Lower memory usage
+- SQL-level operations
+
+## Data Generators for Testing
+
+Create reproducible test datasets:
+
+```swift
+class DataGenerator {
+    func generate(count: Int, in context: NSManagedObjectContext) {
+        for i in 0..<count {
+            let article = Article(context: context)
+            article.name = "Article \(i)"
+            
+            if i % 100 == 0 {
+                try? context.save()
+                context.reset()
+            }
+        }
+        try? context.save()
+    }
+}
+
+// Usage
+let generator = DataGenerator()
+generator.generate(count: 10000, in: backgroundContext)
+```
+
+## Profiling Checklist
+
+1. **Enable SQL debug** - See actual queries
+2. **Profile with Time Profiler** - Find slow operations
+3. **Profile with Allocations** - Find memory issues
+4. **Test with realistic data** - Small datasets hide problems
+5. **Monitor on device** - Simulator performance differs
+6. **Test on older devices** - Performance varies
+
+## Quick Wins
+
+1. **Use `count(for:)` instead of fetching** - 100x faster
+2. **Set `fetchBatchSize`** - Reduces memory
+3. **Prefetch relationships** - Eliminates N+1 queries
+4. **Use `propertiesToFetch`** - Reduces data transfer
+5. **Reset context periodically** - Frees memory
+6. **Use batch operations** - 10-20x faster for bulk changes
+7. **Save conditionally** - Check `hasPersistentChanges`
+8. **Use background contexts** - Keep UI responsive
+
+## Summary
+
+1. **Profile first** - Measure before optimizing
+2. **Use Instruments** - Time Profiler and Allocations
+3. **Enable SQL debug** - Understand query behavior
+4. **Optimize fetch requests** - Batch size, properties, prefetching
+5. **Use batch operations** - For large-scale changes
+6. **Reset contexts** - Free memory periodically
+7. **Test with real data** - Small datasets hide issues
+8. **Monitor on devices** - Real-world performance matters

--- a/.agents/skills/core-data-expert/references/persistent-history.md
+++ b/.agents/skills/core-data-expert/references/persistent-history.md
@@ -1,0 +1,553 @@
+# Persistent History Tracking
+
+Persistent history tracking enables Core Data to track changes across contexts, app extensions, and batch operations. This is essential for keeping your UI synchronized and supporting multi-target apps.
+
+## Why Persistent History Tracking?
+
+**Without persistent history tracking:**
+- Batch operations don't update UI
+- App extensions can't notify main app of changes
+- Multiple contexts don't stay synchronized
+
+**With persistent history tracking:**
+- All changes are recorded in a transaction log
+- Changes can be merged into any context
+- Works across app targets (main app, extensions, etc.)
+
+## Enabling Persistent History Tracking
+
+### In NSPersistentContainer
+
+```swift
+class PersistentContainer: NSPersistentContainer {
+    override init(name: String, managedObjectModel model: NSManagedObjectModel) {
+        super.init(name: name, managedObjectModel: model)
+        
+        guard let description = persistentStoreDescriptions.first else {
+            fatalError("No store description")
+        }
+        
+        // Enable persistent history tracking
+        description.setOption(true as NSNumber,
+                            forKey: NSPersistentHistoryTrackingKey)
+        
+        // Enable remote change notifications
+        description.setOption(true as NSNumber,
+                            forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
+        
+        loadPersistentStores { description, error in
+            if let error = error {
+                fatalError("Failed to load store: \(error)")
+            }
+        }
+    }
+}
+```
+
+### For App Groups (Extensions)
+
+```swift
+let storeURL = FileManager.default.containerURL(
+    forSecurityApplicationGroupIdentifier: "group.com.example.app"
+)?.appendingPathComponent("Shared.sqlite")
+
+let description = NSPersistentStoreDescription(url: storeURL!)
+description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
+description.setOption(true as NSNumber, forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
+
+container.persistentStoreDescriptions = [description]
+```
+
+## The Four Components
+
+Persistent history tracking typically involves four components:
+
+1. **Observer** - Listens for remote change notifications
+2. **Fetcher** - Retrieves relevant transactions
+3. **Merger** - Merges transactions into view context
+4. **Cleaner** - Removes old transactions
+
+## 1. Observer: Listening for Changes
+
+```swift
+final class PersistentHistoryObserver {
+    private let coordinator: NSPersistentStoreCoordinator
+    private let historyContext: NSManagedObjectContext
+    private let merger: PersistentHistoryMerger
+
+    init(container: NSPersistentContainer, viewContext: NSManagedObjectContext) {
+        self.coordinator = container.persistentStoreCoordinator
+        self.historyContext = container.newBackgroundContext()
+        self.historyContext.name = "PersistentHistoryContext"
+        self.historyContext.transactionAuthor = "PersistentHistory"
+        self.merger = PersistentHistoryMerger(historyContext: historyContext, viewContext: viewContext)
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(processStoreRemoteChanges),
+            name: .NSPersistentStoreRemoteChange,
+            object: coordinator
+        )
+    }
+
+    @objc private func processStoreRemoteChanges(_ notification: Notification) {
+        merger.merge()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+}
+```
+
+## 2. Fetcher: Retrieving Transactions
+
+```swift
+class PersistentHistoryFetcher {
+    private let context: NSManagedObjectContext
+    private let lastToken: NSPersistentHistoryToken?
+    
+    init(context: NSManagedObjectContext, lastToken: NSPersistentHistoryToken?) {
+        self.context = context
+        self.lastToken = lastToken
+    }
+    
+    func fetch() throws -> [NSPersistentHistoryTransaction] {
+        let fetchRequest = createFetchRequest()
+        
+        guard let historyResult = try context.execute(fetchRequest) as? NSPersistentHistoryResult,
+              let transactions = historyResult.result as? [NSPersistentHistoryTransaction] else {
+            return []
+        }
+        
+        return transactions
+    }
+    
+    private func createFetchRequest() -> NSPersistentHistoryChangeRequest {
+        let request: NSPersistentHistoryChangeRequest
+        
+        if let token = lastToken {
+            request = NSPersistentHistoryChangeRequest.fetchHistory(after: token)
+        } else {
+            request = NSPersistentHistoryChangeRequest.fetchHistory(after: Date.distantPast)
+        }
+        
+        // Filter out transactions from this app target
+        if let fetchRequest = request.fetchRequest {
+            fetchRequest.predicate = NSPredicate(
+                format: "author != %@",
+                "MainApp" // Your app's transaction author
+            )
+        }
+        
+        return request
+    }
+}
+```
+
+## 3. Merger: Applying Changes
+
+```swift
+final class PersistentHistoryMerger {
+    private let historyContext: NSManagedObjectContext
+    private let viewContext: NSManagedObjectContext
+    private var lastToken: NSPersistentHistoryToken?
+
+    init(historyContext: NSManagedObjectContext, viewContext: NSManagedObjectContext) {
+        self.historyContext = historyContext
+        self.viewContext = viewContext
+        self.lastToken = loadLastToken()
+    }
+
+    func merge() {
+        historyContext.perform {
+            do {
+                let fetcher = PersistentHistoryFetcher(
+                    context: self.historyContext,
+                    lastToken: self.lastToken
+                )
+
+                let transactions = try fetcher.fetch()
+                guard !transactions.isEmpty else { return }
+
+                self.viewContext.perform {
+                    self.mergeTransactions(transactions)
+                }
+
+                if let newToken = transactions.last?.token {
+                    self.lastToken = newToken
+                    self.saveLastToken(newToken)
+                }
+            } catch {
+                print("Failed to merge history: \(error)")
+            }
+        }
+    }
+
+    private func mergeTransactions(_ transactions: [NSPersistentHistoryTransaction]) {
+        for transaction in transactions {
+            guard let userInfo = transaction.objectIDNotification().userInfo else { continue }
+            NSManagedObjectContext.mergeChanges(fromRemoteContextSave: userInfo, into: [viewContext])
+        }
+    }
+    
+    private func loadLastToken() -> NSPersistentHistoryToken? {
+        guard let data = UserDefaults.standard.data(forKey: "lastHistoryToken") else {
+            return nil
+        }
+        return try? NSKeyedUnarchiver.unarchivedObject(
+            ofClass: NSPersistentHistoryToken.self,
+            from: data
+        )
+    }
+    
+    private func saveLastToken(_ token: NSPersistentHistoryToken) {
+        if let data = try? NSKeyedArchiver.archivedData(
+            withRootObject: token,
+            requiringSecureCoding: true
+        ) {
+            UserDefaults.standard.set(data, forKey: "lastHistoryToken")
+        }
+    }
+}
+```
+
+## 4. Cleaner: Removing Old Transactions
+
+```swift
+class PersistentHistoryCleaner {
+    private let context: NSManagedObjectContext
+    private let targets: [AppTarget]
+    
+    enum AppTarget {
+        case mainApp
+        case shareExtension
+        case widgetExtension
+        
+        var lastTokenKey: String {
+            switch self {
+            case .mainApp: return "mainApp.lastHistoryToken"
+            case .shareExtension: return "shareExtension.lastHistoryToken"
+            case .widgetExtension: return "widgetExtension.lastHistoryToken"
+            }
+        }
+    }
+    
+    init(context: NSManagedObjectContext, targets: [AppTarget]) {
+        self.context = context
+        self.targets = targets
+    }
+    
+    func clean() {
+        context.perform {
+            // Find the oldest token across all targets
+            guard let oldestToken = self.findOldestToken() else { return }
+            
+            // Delete history before that token
+            let deleteRequest = NSPersistentHistoryChangeRequest.deleteHistory(before: oldestToken)
+            
+            do {
+                try self.context.execute(deleteRequest)
+            } catch {
+                print("Failed to clean history: \(error)")
+            }
+        }
+    }
+    
+    private func findOldestToken() -> NSPersistentHistoryToken? {
+        var oldestDate: Date?
+        var oldestToken: NSPersistentHistoryToken?
+        
+        for target in targets {
+            guard let token = loadToken(for: target) else { continue }
+            
+            // Get timestamp from token (requires fetching transaction)
+            let historyRequest = NSPersistentHistoryChangeRequest.fetchHistory(after: token)
+            historyRequest.fetchRequest?.fetchLimit = 1
+            
+            guard let result = try? context.execute(historyRequest) as? NSPersistentHistoryResult,
+                  let transactions = result.result as? [NSPersistentHistoryTransaction],
+                  let transaction = transactions.first else {
+                continue
+            }
+            
+            let date = transaction.timestamp
+            if oldestDate == nil || date < oldestDate! {
+                oldestDate = date
+                oldestToken = token
+            }
+        }
+        
+        return oldestToken
+    }
+    
+    private func loadToken(for target: AppTarget) -> NSPersistentHistoryToken? {
+        guard let data = UserDefaults.standard.data(forKey: target.lastTokenKey) else {
+            return nil
+        }
+        return try? NSKeyedUnarchiver.unarchivedObject(
+            ofClass: NSPersistentHistoryToken.self,
+            from: data
+        )
+    }
+}
+```
+
+## Complete Integration Example
+
+```swift
+class CoreDataStack {
+    static let shared = CoreDataStack()
+    
+    lazy var persistentContainer: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: "Model")
+        
+        // Configure store
+        guard let description = container.persistentStoreDescriptions.first else {
+            fatalError("No store description")
+        }
+        
+        // Enable persistent history tracking
+        description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
+        description.setOption(true as NSNumber, forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
+        
+        container.loadPersistentStores { description, error in
+            if let error = error {
+                fatalError("Failed to load store: \(error)")
+            }
+
+            self.setupHistoryTracking(container: container)
+        }
+        
+        // Configure view context
+        container.viewContext.automaticallyMergesChangesFromParent = true
+        container.viewContext.name = "ViewContext"
+        container.viewContext.transactionAuthor = "MainApp"
+        
+        return container
+    }()
+    
+    private var historyObserver: PersistentHistoryObserver?
+    
+    private init() {}
+    
+    private func setupHistoryTracking(container: NSPersistentContainer) {
+        historyObserver = PersistentHistoryObserver(container: container, viewContext: container.viewContext)
+        cleanHistoryPeriodically(container: container)
+    }
+    
+    private func cleanHistoryPeriodically(container: NSPersistentContainer) {
+        Timer.scheduledTimer(withTimeInterval: 3600, repeats: true) { _ in
+            let context = container.newBackgroundContext()
+            let cleaner = PersistentHistoryCleaner(
+                context: context,
+                targets: [.mainApp, .shareExtension]
+            )
+            cleaner.clean()
+        }
+    }
+}
+```
+
+## Transaction Authors
+
+Set unique transaction authors for each app target:
+
+```swift
+// Main app
+viewContext.transactionAuthor = "MainApp"
+
+// Share extension
+viewContext.transactionAuthor = "ShareExtension"
+
+// Widget extension
+viewContext.transactionAuthor = "WidgetExtension"
+```
+
+**Why this matters:**
+- Filter out your own transactions (avoid redundant merges)
+- Identify which target made changes
+- Debug multi-target issues
+
+## Filtering Transactions
+
+### By Author
+
+```swift
+let fetchRequest = NSPersistentHistoryChangeRequest.fetchHistory(after: lastToken)
+if let request = fetchRequest.fetchRequest {
+    request.predicate = NSPredicate(format: "author != %@", "MainApp")
+}
+```
+
+### By Date
+
+```swift
+let cutoffDate = Calendar.current.date(byAdding: .day, value: -7, to: Date())!
+let fetchRequest = NSPersistentHistoryChangeRequest.fetchHistory(after: cutoffDate)
+```
+
+### By Entity
+
+```swift
+let fetchRequest = NSPersistentHistoryChangeRequest.fetchHistory(after: lastToken)
+if let request = fetchRequest.fetchRequest {
+    request.predicate = NSPredicate(format: "ANY changes.changedObjectID.entity.name == %@", "Article")
+}
+```
+
+## Batch Operations Integration
+
+Persistent history tracking is **required** for batch operations to update the UI:
+
+```swift
+// 1. Enable persistent history tracking
+description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
+
+// 2. Perform batch operation
+let context = container.newBackgroundContext()
+context.perform {
+    let batchInsert = NSBatchInsertRequest(entity: Article.entity()) { object in
+        // Insert logic
+        return false
+    }
+    try? context.execute(batchInsert)
+}
+
+// 3. UI updates automatically via persistent history tracking
+// The observer detects the change and merges it into the view context
+```
+
+## Testing Persistent History
+
+```swift
+func testPersistentHistory() throws {
+    // Enable persistent history
+    let description = container.persistentStoreDescriptions.first!
+    description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
+    
+    // Create object in background
+    let backgroundContext = container.newBackgroundContext()
+    backgroundContext.transactionAuthor = "Test"
+    
+    let expectation = XCTestExpectation(description: "Save")
+    
+    backgroundContext.perform {
+        let article = Article(context: backgroundContext)
+        article.name = "Test"
+        try? backgroundContext.save()
+        expectation.fulfill()
+    }
+    
+    wait(for: [expectation], timeout: 5.0)
+    
+    // Fetch history
+    let fetchRequest = NSPersistentHistoryChangeRequest.fetchHistory(after: Date.distantPast)
+    let result = try container.viewContext.execute(fetchRequest) as? NSPersistentHistoryResult
+    let transactions = result?.result as? [NSPersistentHistoryTransaction]
+    
+    XCTAssertNotNil(transactions)
+    XCTAssertFalse(transactions!.isEmpty)
+}
+```
+
+## Common Pitfalls
+
+### ❌ Not Enabling Remote Change Notifications
+
+```swift
+// Only this isn't enough
+description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
+
+// Need both!
+description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
+description.setOption(true as NSNumber, forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
+```
+
+### ❌ Not Filtering Own Transactions
+
+```swift
+// Merges own transactions (redundant)
+let fetchRequest = NSPersistentHistoryChangeRequest.fetchHistory(after: lastToken)
+```
+
+### ❌ Not Cleaning Old Transactions
+
+```swift
+// History grows unbounded, wastes space
+// Always implement cleaning!
+```
+
+### ❌ Not Setting Transaction Authors
+
+```swift
+// Can't filter transactions by source
+context.transactionAuthor = nil // Bad!
+```
+
+### ✅ Correct Approach
+
+```swift
+// 1. Enable both options
+description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
+description.setOption(true as NSNumber, forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
+
+// 2. Set transaction author
+context.transactionAuthor = "MainApp"
+
+// 3. Filter own transactions
+fetchRequest.predicate = NSPredicate(format: "author != %@", "MainApp")
+
+// 4. Clean periodically
+let cleaner = PersistentHistoryCleaner(context: context, targets: [.mainApp, .shareExtension])
+cleaner.clean()
+```
+
+## Performance Considerations
+
+### Clean History Regularly
+
+```swift
+// Clean daily
+Timer.scheduledTimer(withTimeInterval: 86400, repeats: true) { _ in
+    cleaner.clean()
+}
+
+// Or on app launch
+func applicationDidFinishLaunching() {
+    cleaner.clean()
+}
+```
+
+### Limit Fetch Range
+
+```swift
+// Don't fetch all history
+let sevenDaysAgo = Calendar.current.date(byAdding: .day, value: -7, to: Date())!
+let fetchRequest = NSPersistentHistoryChangeRequest.fetchHistory(after: sevenDaysAgo)
+```
+
+### Batch Merge Changes
+
+```swift
+// Merge multiple transactions at once
+let transactions = try fetcher.fetch()
+for transaction in transactions {
+    let userInfo = transaction.objectIDNotification().userInfo
+    NSManagedObjectContext.mergeChanges(
+        fromRemoteContextSave: userInfo!,
+        into: [viewContext]
+    )
+}
+```
+
+## Summary
+
+1. **Enable persistent history tracking** - Required for batch operations and multi-target apps
+2. **Enable remote change notifications** - Required for cross-context updates
+3. **Set transaction authors** - Identify change sources
+4. **Filter own transactions** - Avoid redundant merges
+5. **Implement all four components** - Observer, Fetcher, Merger, Cleaner
+6. **Clean history regularly** - Prevent unbounded growth
+7. **Use with batch operations** - Essential for UI updates
+8. **Test thoroughly** - Verify history tracking works across targets

--- a/.agents/skills/core-data-expert/references/project-audit.md
+++ b/.agents/skills/core-data-expert/references/project-audit.md
@@ -1,0 +1,60 @@
+# Project Audit (Core Data)
+
+Use this checklist to quickly discover how a project uses Core Data and which constraints apply (platform availability, CloudKit, history tracking, etc.).
+
+## Determine platform constraints
+
+- Find the deployment target (iOS/macOS version). Many recommendations depend on this (e.g. staged migration and composite attributes require iOS 17+/macOS 14+).
+- Note whether the project is Swift 6 / strict concurrency enabled (Sendable and isolation warnings change the advice).
+
+## Inspect the data model
+
+- Open the model XML (`*.xcdatamodeld/*/contents`) and check:
+  - entities, attributes, relationships, constraints
+  - versioning setup (multiple model versions)
+  - renaming identifiers (for lightweight migration)
+  - composite attributes (iOS 17+)
+
+## Identify stack setup
+
+Search for:
+
+- `NSPersistentContainer` vs `NSPersistentCloudKitContainer`
+- `loadPersistentStores` configuration
+- `persistentStoreDescriptions` (migration options, history tracking, CloudKit options)
+- `viewContext` configuration (merge policy, `automaticallyMergesChangesFromParent`, query generations)
+- background context creation (`newBackgroundContext`, `performBackgroundTask`)
+
+Then consult:
+
+- `stack-setup.md` for recommended defaults and merge policies
+- `cloudkit-integration.md` if CloudKit is enabled
+
+## Check for persistent history tracking (required for some flows)
+
+Search for:
+
+- `NSPersistentHistoryTrackingKey`
+- `NSPersistentStoreRemoteChangeNotificationPostOptionKey`
+- remote change notifications and history processing/merging
+
+Then consult:
+
+- `persistent-history.md` for the Observer/Fetcher/Merger/Cleaner pattern
+
+## Spot risky concurrency patterns
+
+Search for:
+
+- cross-thread access to managed objects (look for passing `NSManagedObject` into async tasks/closures)
+- `performAndWait` usage (risk of deadlocks / UI blocking)
+- `@unchecked Sendable` applied to Core Data types (usually hides a real problem)
+
+Then consult:
+
+- `threading.md` and `concurrency.md`
+
+## Useful debugging flags (for repro builds only)
+
+- `-com.apple.CoreData.ConcurrencyDebug 1` (threading violations)
+- `-com.apple.CoreData.SQLDebug 1` (SQL logging)

--- a/.agents/skills/core-data-expert/references/saving.md
+++ b/.agents/skills/core-data-expert/references/saving.md
@@ -1,0 +1,574 @@
+# Saving in Core Data
+
+Saving data efficiently is crucial for app performance and user experience. This guide covers best practices for when, how, and where to save your Core Data changes.
+
+## The Problem with Always Saving
+
+Calling `save()` unconditionally has performance costs:
+
+```swift
+// ❌ Bad: Always saving, even when nothing changed
+func updateUI() {
+    article.lastViewed = Date()
+    try? context.save() // Expensive even if nothing changed!
+}
+```
+
+**Problems:**
+- Writes to disk even when no changes exist
+- Triggers merge notifications unnecessarily
+- Wastes CPU and battery
+- Slows down your app
+
+## Conditional Saving with hasChanges
+
+The first improvement is checking `hasChanges`:
+
+```swift
+// ✅ Better: Only save if there are changes
+if context.hasChanges {
+    try context.save()
+}
+```
+
+**Benefits:**
+- Avoids unnecessary disk writes
+- Faster performance
+- Still simple to use
+
+**Limitation:**
+- `hasChanges` returns `true` for transient properties too
+- Transient changes don't need to be persisted
+
+## Best Practice: hasPersistentChanges
+
+Check for **persistent** changes only, excluding transient properties:
+
+```swift
+extension NSManagedObjectContext {
+    var hasPersistentChanges: Bool {
+        return !insertedObjects.isEmpty || 
+               !deletedObjects.isEmpty || 
+               updatedObjects.contains(where: { $0.hasPersistentChangedValues })
+    }
+    
+    func saveIfNeeded() throws {
+        guard hasPersistentChanges else { return }
+        try save()
+    }
+}
+
+// Usage
+try context.saveIfNeeded()
+```
+
+**Why this is better:**
+- Excludes transient property changes
+- Only saves when data actually needs persisting
+- Most efficient approach
+
+### Understanding hasPersistentChangedValues
+
+```swift
+extension NSManagedObject {
+    var hasPersistentChangedValues: Bool {
+        return !changedValues().isEmpty
+    }
+}
+```
+
+This checks if the object has **any** changed values. For more granular control:
+
+```swift
+extension NSManagedObject {
+    var hasPersistentChangedValues: Bool {
+        let changedKeys = Set(changedValues().keys)
+        let persistentKeys = Set(entity.attributesByName.keys)
+            .union(entity.relationshipsByName.keys)
+            .subtracting(entity.transientAttributeNames)
+        return !changedKeys.intersection(persistentKeys).isEmpty
+    }
+}
+
+extension NSEntityDescription {
+    var transientAttributeNames: Set<String> {
+        return Set(attributesByName.filter { $0.value.isTransient }.map { $0.key })
+    }
+}
+```
+
+## When to Save
+
+### Save on App Lifecycle Events
+
+```swift
+// AppDelegate or SceneDelegate
+func applicationWillTerminate(_ application: UIApplication) {
+    try? CoreDataStack.shared.viewContext.saveIfNeeded()
+}
+
+func sceneDidEnterBackground(_ scene: UIScene) {
+    try? CoreDataStack.shared.viewContext.saveIfNeeded()
+}
+```
+
+### Save After User Actions
+
+```swift
+// After user completes an action
+@IBAction func saveButtonTapped(_ sender: UIButton) {
+    article.name = nameTextField.text
+    article.content = contentTextView.text
+    
+    do {
+        try context.saveIfNeeded()
+        dismiss(animated: true)
+    } catch {
+        // Handle error
+        showError(error)
+    }
+}
+```
+
+### Save Periodically for Long-Running Operations
+
+```swift
+func importLargeDataset() {
+    let context = container.newBackgroundContext()
+    context.perform {
+        for (index, data) in largeDataset.enumerated() {
+            let article = Article(context: context)
+            article.name = data.name
+            
+            // Save every 100 objects
+            if index % 100 == 0 {
+                try? context.saveIfNeeded()
+            }
+        }
+        
+        // Final save
+        try? context.saveIfNeeded()
+    }
+}
+```
+
+### Don't Save Too Frequently
+
+```swift
+// ❌ Bad: Saving on every keystroke
+func textFieldDidChange(_ textField: UITextField) {
+    article.name = textField.text
+    try? context.save() // Too frequent!
+}
+
+// ✅ Better: Save when editing ends
+func textFieldDidEndEditing(_ textField: UITextField) {
+    article.name = textField.text
+    try? context.saveIfNeeded()
+}
+
+// ✅ Best: Use debouncing for auto-save
+private var saveWorkItem: DispatchWorkItem?
+
+func textFieldDidChange(_ textField: UITextField) {
+    article.name = textField.text
+    
+    // Cancel previous save
+    saveWorkItem?.cancel()
+    
+    // Schedule new save after 2 seconds of inactivity
+    let workItem = DispatchWorkItem { [weak self] in
+        try? self?.context.saveIfNeeded()
+    }
+    saveWorkItem = workItem
+    DispatchQueue.main.asyncAfter(deadline: .now() + 2, execute: workItem)
+}
+```
+
+## Error Handling
+
+### Basic Error Handling
+
+```swift
+do {
+    try context.save()
+} catch {
+    print("Failed to save: \(error)")
+}
+```
+
+### Detailed Error Handling
+
+```swift
+do {
+    try context.save()
+} catch let error as NSError {
+    print("Failed to save context: \(error)")
+    print("User info: \(error.userInfo)")
+    
+    // Check for specific errors
+    if error.domain == NSCocoaErrorDomain {
+        switch error.code {
+        case NSValidationStringTooShortError:
+            print("String too short")
+        case NSValidationStringTooLongError:
+            print("String too long")
+        case NSManagedObjectValidationError:
+            print("Validation error")
+        case NSManagedObjectConstraintValidationError:
+            print("Constraint violation")
+        default:
+            print("Other error: \(error.code)")
+        }
+    }
+}
+```
+
+### User-Friendly Error Messages
+
+```swift
+extension NSError {
+    var userFriendlyMessage: String {
+        guard domain == NSCocoaErrorDomain else {
+            return localizedDescription
+        }
+        
+        switch code {
+        case NSValidationStringTooShortError:
+            return "The text is too short. Please enter at least 3 characters."
+        case NSValidationStringTooLongError:
+            return "The text is too long. Please keep it under 100 characters."
+        case NSManagedObjectConstraintValidationError:
+            return "This item already exists. Please use a different name."
+        case NSManagedObjectValidationError:
+            return "Please check your input and try again."
+        default:
+            return "Failed to save: \(localizedDescription)"
+        }
+    }
+}
+
+// Usage
+do {
+    try context.save()
+} catch let error as NSError {
+    showAlert(message: error.userFriendlyMessage)
+}
+```
+
+## Saving in Different Contexts
+
+### View Context (Main Thread)
+
+```swift
+// Always on main thread
+let context = container.viewContext
+
+// Simple save
+try? context.saveIfNeeded()
+
+// With error handling
+do {
+    try context.saveIfNeeded()
+} catch {
+    print("Failed to save: \(error)")
+}
+```
+
+### Background Context
+
+```swift
+let context = container.newBackgroundContext()
+context.perform {
+    // Make changes
+    let article = Article(context: context)
+    article.name = "New Article"
+    
+    // Save within perform block
+    do {
+        try context.saveIfNeeded()
+    } catch {
+        print("Failed to save: \(error)")
+    }
+}
+```
+
+### Nested Contexts (Advanced)
+
+```swift
+// Parent context (view context)
+let parentContext = container.viewContext
+
+// Child context for editing
+let childContext = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+childContext.parent = parentContext
+
+// Make changes in child
+let article = childContext.object(with: articleID) as! Article
+article.name = "Updated"
+
+// Save child (pushes to parent, not to disk)
+try? childContext.save()
+
+// Save parent to persist to disk
+try? parentContext.save()
+```
+
+**Use nested contexts for:**
+- Cancellable editing (discard child without saving parent)
+- Temporary changes
+- Complex forms
+
+## Saving with Validation
+
+Core Data validates objects before saving. Handle validation errors appropriately:
+
+```swift
+do {
+    try context.save()
+} catch let error as NSError {
+    if error.code == NSValidationMultipleErrorsError {
+        // Multiple validation errors
+        if let errors = error.userInfo[NSDetailedErrorsKey] as? [NSError] {
+            for validationError in errors {
+                print("Validation error: \(validationError.localizedDescription)")
+                
+                // Get the object that failed validation
+                if let object = validationError.userInfo[NSValidationObjectErrorKey] as? NSManagedObject {
+                    print("Failed object: \(object)")
+                }
+                
+                // Get the property that failed
+                if let key = validationError.userInfo[NSValidationKeyErrorKey] as? String {
+                    print("Failed property: \(key)")
+                }
+            }
+        }
+    }
+}
+```
+
+## Optimizing Save Performance
+
+### Batch Saves During Import
+
+```swift
+func importArticles(_ articles: [ArticleData]) {
+    let context = container.newBackgroundContext()
+    context.perform {
+        for (index, data) in articles.enumerated() {
+            let article = Article(context: context)
+            article.name = data.name
+            article.content = data.content
+            
+            // Save every 100 objects to avoid memory buildup
+            if index % 100 == 0 && context.hasChanges {
+                try? context.save()
+                context.reset() // Clear memory
+            }
+        }
+        
+        // Final save
+        try? context.save()
+    }
+}
+```
+
+### Avoid Saving in Loops
+
+```swift
+// ❌ Bad: Saving inside loop
+for data in dataArray {
+    let article = Article(context: context)
+    article.name = data.name
+    try? context.save() // Very slow!
+}
+
+// ✅ Good: Save once after loop
+for data in dataArray {
+    let article = Article(context: context)
+    article.name = data.name
+}
+try? context.save() // Much faster!
+```
+
+### Use Batch Operations for Bulk Changes
+
+For large-scale operations, use batch requests instead of saving individual objects:
+
+```swift
+// Instead of:
+for article in articles {
+    article.isRead = true
+}
+try? context.save()
+
+// Use batch update:
+let batchUpdate = NSBatchUpdateRequest(entityName: "Article")
+batchUpdate.predicate = NSPredicate(format: "isRead == NO")
+batchUpdate.propertiesToUpdate = ["isRead": true]
+try? context.execute(batchUpdate)
+```
+
+See `batch-operations.md` for more details.
+
+## Checking for Unsaved Changes
+
+### Before Dismissing a View
+
+```swift
+func dismiss() {
+    if context.hasChanges {
+        let alert = UIAlertController(
+            title: "Unsaved Changes",
+            message: "Do you want to save your changes?",
+            preferredStyle: .alert
+        )
+        
+        alert.addAction(UIAlertAction(title: "Save", style: .default) { _ in
+            try? self.context.save()
+            self.dismissView()
+        })
+        
+        alert.addAction(UIAlertAction(title: "Discard", style: .destructive) { _ in
+            self.context.rollback()
+            self.dismissView()
+        })
+        
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        
+        present(alert, animated: true)
+    } else {
+        dismissView()
+    }
+}
+```
+
+### Rollback Unsaved Changes
+
+```swift
+// Discard all unsaved changes
+context.rollback()
+
+// Refresh a specific object to discard its changes
+context.refresh(article, mergeChanges: false)
+```
+
+## Save Notifications
+
+Observe save notifications to respond to changes:
+
+```swift
+NotificationCenter.default.addObserver(
+    self,
+    selector: #selector(contextDidSave),
+    name: .NSManagedObjectContextDidSave,
+    object: context
+)
+
+@objc func contextDidSave(_ notification: Notification) {
+    guard let userInfo = notification.userInfo else { return }
+    
+    if let inserts = userInfo[NSInsertedObjectsKey] as? Set<NSManagedObject> {
+        print("Inserted: \(inserts.count) objects")
+    }
+    
+    if let updates = userInfo[NSUpdatedObjectsKey] as? Set<NSManagedObject> {
+        print("Updated: \(updates.count) objects")
+    }
+    
+    if let deletes = userInfo[NSDeletedObjectsKey] as? Set<NSManagedObject> {
+        print("Deleted: \(deletes.count) objects")
+    }
+}
+```
+
+## Testing Saves
+
+### In Unit Tests
+
+```swift
+func testSaveArticle() throws {
+    let context = testContainer.viewContext
+    
+    let article = Article(context: context)
+    article.name = "Test Article"
+    
+    XCTAssertTrue(context.hasChanges)
+    
+    try context.save()
+    
+    XCTAssertFalse(context.hasChanges)
+    
+    // Verify saved
+    let fetchRequest = Article.fetchRequest()
+    let results = try context.fetch(fetchRequest)
+    XCTAssertEqual(results.count, 1)
+    XCTAssertEqual(results.first?.name, "Test Article")
+}
+```
+
+## Common Pitfalls
+
+### ❌ Not Checking for Changes
+
+```swift
+// Wastes resources
+try? context.save()
+```
+
+### ❌ Saving Too Frequently
+
+```swift
+// In a loop - very slow
+for item in items {
+    item.processed = true
+    try? context.save()
+}
+```
+
+### ❌ Ignoring Errors
+
+```swift
+// Silent failures
+try? context.save()
+```
+
+### ❌ Saving on Wrong Thread
+
+```swift
+// Crash! Background context on main thread
+let context = container.newBackgroundContext()
+try? context.save() // Not in perform block!
+```
+
+### ✅ Correct Approach
+
+```swift
+// Check for changes
+guard context.hasPersistentChanges else { return }
+
+// Handle errors
+do {
+    try context.save()
+} catch {
+    print("Save failed: \(error)")
+    // Handle appropriately
+}
+
+// Use correct thread
+context.perform {
+    try? context.save()
+}
+```
+
+## Summary
+
+1. **Use `saveIfNeeded()` with `hasPersistentChanges`** - Most efficient approach
+2. **Save at appropriate times** - App lifecycle events, after user actions, periodically
+3. **Don't save too frequently** - Debounce auto-saves, avoid saving in loops
+4. **Handle errors properly** - Don't ignore save failures
+5. **Use correct context type** - View context for UI, background for heavy work
+6. **Always use `perform` with background contexts** - Thread safety
+7. **Consider batch operations** - For large-scale updates
+8. **Test your saves** - Verify data persists correctly

--- a/.agents/skills/core-data-expert/references/stack-setup.md
+++ b/.agents/skills/core-data-expert/references/stack-setup.md
@@ -1,0 +1,625 @@
+# Core Data Stack Setup
+
+Setting up your Core Data stack correctly is foundational to a well-architected app. This guide covers best practices for configuring `NSPersistentContainer`, managing contexts, and establishing patterns that scale.
+
+## Custom NSPersistentContainer
+
+Create a custom subclass instead of configuring everything in `AppDelegate`. This keeps your stack configuration organized and testable.
+
+```swift
+import CoreData
+
+class PersistentContainer: NSPersistentContainer {
+    static let shared = PersistentContainer(name: "DataModel")
+    
+    private override init(name: String, managedObjectModel model: NSManagedObjectModel) {
+        super.init(name: name, managedObjectModel: model)
+        configure()
+    }
+    
+    convenience init(name: String) {
+        guard let modelURL = Bundle.main.url(forResource: name, withExtension: "momd"),
+              let model = NSManagedObjectModel(contentsOf: modelURL) else {
+            fatalError("Failed to load data model")
+        }
+        self.init(name: name, managedObjectModel: model)
+    }
+    
+    private func configure() {
+        // Set merge policy for constraint handling
+        viewContext.mergePolicy = NSMergeByPropertyStoreTrumpMergePolicy
+        
+        // Enable automatic merging from parent
+        viewContext.automaticallyMergesChangesFromParent = true
+        
+        // Name the view context for debugging
+        viewContext.name = "ViewContext"
+
+        // Configure store options before loading
+        configureStoreDescription()
+        
+        // Load persistent stores
+        loadPersistentStores { description, error in
+            if let error = error {
+                // Handle error appropriately
+                fatalError("Failed to load persistent store: \(error)")
+            }
+        }
+    }
+    
+    private func configureStoreDescription() {
+        guard let description = persistentStoreDescriptions.first else { return }
+
+        description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
+        description.setOption(true as NSNumber, forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
+    }
+}
+```
+
+## Singleton Pattern vs Dependency Injection
+
+### Singleton Pattern (Recommended for Most Apps)
+
+```swift
+class PersistentContainer: NSPersistentContainer {
+    static let shared = PersistentContainer(name: "DataModel")
+    
+    // Prevent external initialization
+    private override init(name: String, managedObjectModel model: NSManagedObjectModel) {
+        super.init(name: name, managedObjectModel: model)
+    }
+}
+
+// Usage
+let context = PersistentContainer.shared.viewContext
+```
+
+**Pros:**
+- Simple, consistent access across the app
+- No need to pass container through the app
+- Works well with SwiftUI environment
+
+**Cons:**
+- Harder to test with different configurations
+- Global state
+
+### Dependency Injection (Better for Testing)
+
+```swift
+class DataController {
+    let container: NSPersistentContainer
+    
+    init(inMemory: Bool = false) {
+        container = NSPersistentContainer(name: "DataModel")
+        
+        if inMemory {
+            container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")
+        }
+        
+        container.loadPersistentStores { description, error in
+            if let error = error {
+                fatalError("Failed to load store: \(error)")
+            }
+        }
+    }
+    
+    var viewContext: NSManagedObjectContext {
+        container.viewContext
+    }
+}
+
+// Usage
+let dataController = DataController()
+let context = dataController.viewContext
+
+// Testing
+let testController = DataController(inMemory: true)
+```
+
+**Pros:**
+- Easier to test with in-memory stores
+- More flexible configuration
+- Better for unit testing
+
+**Cons:**
+- Must pass controller through the app
+- More boilerplate
+
+## Merge Policies
+
+Merge policies determine how Core Data resolves conflicts when saving. Choose based on your app's needs.
+
+### NSMergeByPropertyStoreTrumpMergePolicy (Recommended)
+
+Store values win over in-memory values. **Required for constraints to work.**
+
+```swift
+viewContext.mergePolicy = NSMergeByPropertyStoreTrumpMergePolicy
+```
+
+**Use when:**
+- Using unique constraints
+- Store data should take precedence
+- Multiple contexts might modify the same objects
+
+### NSMergeByPropertyObjectTrumpMergePolicy
+
+In-memory values win over store values.
+
+```swift
+viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+```
+
+**Use when:**
+- User edits should always win
+- In-memory changes are more important
+
+### NSOverwriteMergePolicy
+
+In-memory object completely replaces store object.
+
+```swift
+viewContext.mergePolicy = NSOverwriteMergePolicy
+```
+
+**Use when:**
+- You want complete replacement
+- Conflicts should never occur
+
+### NSRollbackMergePolicy
+
+Discard in-memory changes, keep store values.
+
+```swift
+viewContext.mergePolicy = NSRollbackMergePolicy
+```
+
+**Use when:**
+- Store is source of truth
+- In-memory changes should be discarded on conflict
+
+### NSErrorMergePolicy (Default)
+
+Throws an error on conflict. You must handle manually.
+
+```swift
+viewContext.mergePolicy = NSErrorMergePolicy
+
+do {
+    try context.save()
+} catch let error as NSError {
+    if error.code == NSManagedObjectMergeError {
+        // Handle merge conflict
+    }
+}
+```
+
+**Use when:**
+- You need custom conflict resolution
+- Conflicts should be explicitly handled
+
+## Context Configuration
+
+### View Context
+
+The view context runs on the main thread and should be used for all UI operations.
+
+```swift
+let viewContext = container.viewContext
+viewContext.name = "ViewContext"
+viewContext.automaticallyMergesChangesFromParent = true
+viewContext.mergePolicy = NSMergeByPropertyStoreTrumpMergePolicy
+```
+
+**Best Practices:**
+- Only use for UI-related fetches and updates
+- Keep operations lightweight
+- Enable automatic merging from parent
+- Set a descriptive name for debugging
+
+### Background Context
+
+Background contexts run on private queues and should be used for heavy work.
+
+```swift
+override func newBackgroundContext() -> NSManagedObjectContext {
+    let context = super.newBackgroundContext()
+    context.name = "BackgroundContext"
+    context.transactionAuthor = "BackgroundAuthor"
+    context.mergePolicy = NSMergeByPropertyStoreTrumpMergePolicy
+    context.automaticallyMergesChangesFromParent = true
+    return context
+}
+
+// Usage
+let context = container.newBackgroundContext()
+context.perform {
+    // Heavy work here
+    try? context.save()
+}
+```
+
+**Best Practices:**
+- Use for imports, exports, batch operations
+- Always wrap work in `perform { }`
+- Set transaction author for persistent history tracking
+- Enable automatic merging
+
+### Context Naming and Transaction Authors
+
+Naming contexts helps with debugging and persistent history tracking.
+
+```swift
+context.name = "ImportContext"
+context.transactionAuthor = "ImportAuthor"
+```
+
+**Benefits:**
+- Identify contexts in Instruments
+- Filter persistent history transactions
+- Debug threading issues more easily
+- Track which part of app made changes
+
+**Example with App Extensions:**
+
+```swift
+// Main app
+mainContext.transactionAuthor = "MainApp"
+
+// Share extension
+shareContext.transactionAuthor = "ShareExtension"
+
+// Filter transactions by author
+let fetchRequest = NSPersistentHistoryChangeRequest.fetchHistory(after: lastToken)
+if let historyFetch = fetchRequest as? NSPersistentHistoryChangeRequest {
+    historyFetch.fetchRequest?.predicate = NSPredicate(
+        format: "author != %@", "MainApp"
+    )
+}
+```
+
+## Understanding Store Loading Behavior
+
+The `loadPersistentStores` method is **always asynchronous** - it uses a completion handler that's called when loading finishes. There is no synchronous version of this API.
+
+### Standard Pattern (Recommended)
+
+```swift
+container.loadPersistentStores { description, error in
+    if let error = error {
+        fatalError("Failed to load store: \(error)")
+    }
+}
+// Code here executes immediately, before stores finish loading
+// However, in typical setup() methods, the app waits for completion
+```
+
+**Characteristics:**
+- Completion handler called asynchronously when loading finishes
+- Code after `loadPersistentStores` executes immediately
+- App typically waits for stores to load before showing UI
+- Most common and recommended pattern
+
+**When to use:**
+- Standard app initialization
+- When you control the setup flow
+- When you can ensure UI doesn't appear until stores are ready
+
+### Modern async/await Pattern (iOS 15+)
+
+```swift
+extension NSPersistentContainer {
+    func loadPersistentStores() async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            self.loadPersistentStores { description, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: ())
+                }
+            }
+        }
+    }
+}
+
+// Usage in async context
+func setupCoreData() async throws {
+    let container = NSPersistentContainer(name: "Model")
+    try await container.loadPersistentStores()
+    // Stores are guaranteed loaded here
+}
+```
+
+**Benefits:**
+- Cleaner async/await syntax
+- Better error handling with try/catch
+- Easier to compose with other async operations
+- Explicit about async nature
+
+**When to use:**
+- iOS 15+ deployment target
+- Modern Swift concurrency codebase
+- When composing with other async operations
+
+### Deferred Loading Pattern (Advanced)
+
+For rare cases where you need the app to start before stores are loaded:
+
+```swift
+class CoreDataStack {
+    let container: NSPersistentContainer
+    private(set) var isStoreLoaded = false
+    
+    init() {
+        container = NSPersistentContainer(name: "Model")
+        loadStoresInBackground()
+    }
+    
+    private func loadStoresInBackground() {
+        container.loadPersistentStores { [weak self] description, error in
+            if let error = error {
+                print("Failed to load store: \(error)")
+                return
+            }
+            self?.isStoreLoaded = true
+            NotificationCenter.default.post(name: .storeDidLoad, object: nil)
+        }
+    }
+    
+    func waitForStoreLoad() async {
+        guard !isStoreLoaded else { return }
+        
+        await withCheckedContinuation { continuation in
+            let observer = NotificationCenter.default.addObserver(
+                forName: .storeDidLoad,
+                object: nil,
+                queue: nil
+            ) { _ in
+                continuation.resume()
+            }
+            
+            // Check again in case it loaded while setting up observer
+            if self.isStoreLoaded {
+                NotificationCenter.default.removeObserver(observer)
+                continuation.resume()
+            }
+        }
+    }
+}
+```
+
+**Cautions:**
+- Must handle "not ready" state throughout app
+- More complex error handling
+- Potential race conditions if not careful
+- Only use if you have a specific reason
+
+**When to use:**
+- Very large databases where loading takes significant time
+- Apps that can show UI before data is available
+- Background initialization scenarios
+
+### Recommendation
+
+**Use the standard pattern** with completion handler for most apps. The loading time is typically negligible (milliseconds), and waiting for stores to load before showing UI provides predictable behavior and avoids race conditions.
+
+**Use async/await** if you're on iOS 15+ and want modern Swift concurrency patterns.
+
+**Avoid deferred loading** unless you have a specific, measured need for it. The complexity and potential for bugs usually outweigh any perceived benefits.
+
+## Store Configuration Options
+
+### In-Memory Store (Testing)
+
+```swift
+let description = NSPersistentStoreDescription()
+description.type = NSInMemoryStoreType
+container.persistentStoreDescriptions = [description]
+```
+
+**Use for:**
+- Unit tests
+- Temporary data
+- Prototyping
+
+### SQLite Store (Production)
+
+```swift
+let description = NSPersistentStoreDescription(url: storeURL)
+description.type = NSSQLiteStoreType
+container.persistentStoreDescriptions = [description]
+```
+
+**Use for:**
+- Production apps
+- Persistent data
+- Most common use case
+
+### Store Location
+
+```swift
+// Default location
+let storeURL = NSPersistentContainer.defaultDirectoryURL()
+    .appendingPathComponent("Model.sqlite")
+
+// Custom location
+let storeURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+    .appendingPathComponent("MyApp.sqlite")
+
+// App Group (for extensions)
+let storeURL = FileManager.default.containerURL(
+    forSecurityApplicationGroupIdentifier: "group.com.example.app"
+)?.appendingPathComponent("Shared.sqlite")
+```
+
+## Complete Example
+
+Here's a production-ready stack setup:
+
+```swift
+import CoreData
+
+final class CoreDataStack {
+    static let shared = CoreDataStack()
+    
+    private let containerName = "DataModel"
+    
+    lazy var persistentContainer: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: containerName)
+        
+        // Configure store description
+        guard let description = container.persistentStoreDescriptions.first else {
+            fatalError("Failed to retrieve store description")
+        }
+        
+        // Enable persistent history tracking
+        description.setOption(true as NSNumber, 
+                            forKey: NSPersistentHistoryTrackingKey)
+        description.setOption(true as NSNumber,
+                            forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
+        
+        // Load stores
+        container.loadPersistentStores { storeDescription, error in
+            if let error = error as NSError? {
+                // Handle error appropriately in production
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        }
+        
+        // Configure view context
+        container.viewContext.automaticallyMergesChangesFromParent = true
+        container.viewContext.mergePolicy = NSMergeByPropertyStoreTrumpMergePolicy
+        container.viewContext.name = "ViewContext"
+        
+        return container
+    }()
+    
+    var viewContext: NSManagedObjectContext {
+        persistentContainer.viewContext
+    }
+    
+    func newBackgroundContext() -> NSManagedObjectContext {
+        let context = persistentContainer.newBackgroundContext()
+        context.name = "BackgroundContext"
+        context.transactionAuthor = "BackgroundAuthor"
+        context.mergePolicy = NSMergeByPropertyStoreTrumpMergePolicy
+        context.automaticallyMergesChangesFromParent = true
+        return context
+    }
+    
+    func performBackgroundTask(_ block: @escaping (NSManagedObjectContext) -> Void) {
+        persistentContainer.performBackgroundTask { context in
+            context.name = "BackgroundTask"
+            context.transactionAuthor = "BackgroundTaskAuthor"
+            context.mergePolicy = NSMergeByPropertyStoreTrumpMergePolicy
+            block(context)
+        }
+    }
+    
+    private init() {}
+}
+
+// Usage
+let context = CoreDataStack.shared.viewContext
+
+// Background work
+CoreDataStack.shared.performBackgroundTask { context in
+    // Heavy work here
+    try? context.save()
+}
+```
+
+## SwiftUI Integration
+
+### Environment Object Pattern
+
+```swift
+import SwiftUI
+
+@main
+struct MyApp: App {
+    let persistenceController = PersistentContainer.shared
+    
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environment(\.managedObjectContext, persistenceController.viewContext)
+        }
+    }
+}
+
+// Usage in views
+struct ContentView: View {
+    @Environment(\.managedObjectContext) private var viewContext
+    
+    @FetchRequest(
+        sortDescriptors: [NSSortDescriptor(keyPath: \Article.name, ascending: true)],
+        animation: .default)
+    private var articles: FetchedResults<Article>
+    
+    var body: some View {
+        List(articles) { article in
+            Text(article.name ?? "")
+        }
+    }
+}
+```
+
+## Common Pitfalls
+
+### ❌ Configuring in AppDelegate
+
+```swift
+// Don't do this - hard to test and maintain
+class AppDelegate: UIApplicationDelegate {
+    lazy var persistentContainer: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: "Model")
+        // Lots of configuration code here...
+        return container
+    }()
+}
+```
+
+### ❌ Not Setting Merge Policy with Constraints
+
+```swift
+// This will crash when constraints are violated
+let entity = MyEntity(context: context)
+entity.uniqueField = "duplicate" // Constraint violation
+try context.save() // CRASH!
+```
+
+### ❌ Not Naming Contexts
+
+```swift
+// Hard to debug which context has issues
+let context = container.newBackgroundContext()
+// No name, no transaction author
+```
+
+### ✅ Correct Approach
+
+```swift
+class PersistentContainer: NSPersistentContainer {
+    static let shared = PersistentContainer(name: "Model")
+    
+    override func newBackgroundContext() -> NSManagedObjectContext {
+        let context = super.newBackgroundContext()
+        context.name = "BackgroundContext"
+        context.transactionAuthor = "BackgroundAuthor"
+        context.mergePolicy = NSMergeByPropertyStoreTrumpMergePolicy
+        context.automaticallyMergesChangesFromParent = true
+        return context
+    }
+}
+```
+
+## Summary
+
+1. **Create a custom NSPersistentContainer subclass** for organized configuration
+2. **Use singleton pattern for simplicity** or dependency injection for testability
+3. **Set merge policy** to NSMergeByPropertyStoreTrumpMergePolicy (required for constraints)
+4. **Name contexts and set transaction authors** for debugging and history tracking
+5. **Enable automaticallyMergesChangesFromParent** on all contexts
+6. **Load stores using the completion handler (or async bridge)** and gate access until loading completes
+7. **Configure persistent history tracking** if using batch operations or app extensions

--- a/.agents/skills/core-data-expert/references/testing.md
+++ b/.agents/skills/core-data-expert/references/testing.md
@@ -1,0 +1,300 @@
+# Testing Core Data
+
+Testing Core Data requires special setup to avoid conflicts and ensure fast, reliable tests.
+
+## In-Memory Stores
+
+Use in-memory stores for fast, isolated tests:
+
+```swift
+class CoreDataTestCase: XCTestCase {
+    var container: NSPersistentContainer!
+    var context: NSManagedObjectContext!
+    
+    override func setUp() {
+        super.setUp()
+        
+        container = NSPersistentContainer(name: "Model", managedObjectModel: Self.sharedModel)
+        
+        let description = NSPersistentStoreDescription()
+        description.type = NSInMemoryStoreType
+        container.persistentStoreDescriptions = [description]
+        
+        container.loadPersistentStores { description, error in
+            XCTAssertNil(error)
+        }
+        
+        context = container.viewContext
+    }
+    
+    override func tearDown() {
+        context = nil
+        container = nil
+        super.tearDown()
+    }
+}
+```
+
+## Shared Model Pattern
+
+**Problem:** Multiple model instances cause entity description conflicts.
+
+**Error:**
+```
+Failed to find a unique match for an NSEntityDescription
+```
+
+**Solution:** Use shared model instance:
+
+```swift
+extension NSManagedObjectModel {
+    static let shared: NSManagedObjectModel = {
+        guard let modelURL = Bundle.main.url(forResource: "Model", withExtension: "momd"),
+              let model = NSManagedObjectModel(contentsOf: modelURL) else {
+            fatalError("Failed to load model")
+        }
+        return model
+    }()
+}
+
+// Use in tests
+container = NSPersistentContainer(name: "Model", managedObjectModel: .shared)
+```
+
+## Data Generators
+
+Create reproducible test data:
+
+```swift
+class TestDataGenerator {
+    static func createArticle(
+        name: String = "Test Article",
+        views: Int = 0,
+        in context: NSManagedObjectContext
+    ) -> Article {
+        let article = Article(context: context)
+        article.name = name
+        article.views = Int64(views)
+        article.creationDate = Date()
+        return article
+    }
+    
+    static func createArticles(
+        count: Int,
+        in context: NSManagedObjectContext
+    ) -> [Article] {
+        return (0..<count).map { i in
+            createArticle(name: "Article \(i)", in: context)
+        }
+    }
+}
+
+// Usage
+func testFetchArticles() throws {
+    let articles = TestDataGenerator.createArticles(count: 10, in: context)
+    try context.save()
+    
+    let fetchRequest = Article.fetchRequest()
+    let results = try context.fetch(fetchRequest)
+    
+    XCTAssertEqual(results.count, 10)
+}
+```
+
+## Testing Fetch Requests
+
+```swift
+func testFetchWithPredicate() throws {
+    // Setup
+    TestDataGenerator.createArticle(name: "Swift", views: 100, in: context)
+    TestDataGenerator.createArticle(name: "iOS", views: 50, in: context)
+    try context.save()
+    
+    // Test
+    let fetchRequest = Article.fetchRequest()
+    fetchRequest.predicate = NSPredicate(format: "views > %d", 75)
+    
+    let results = try context.fetch(fetchRequest)
+    
+    // Verify
+    XCTAssertEqual(results.count, 1)
+    XCTAssertEqual(results.first?.name, "Swift")
+}
+```
+
+## Testing Saves
+
+```swift
+func testSaveArticle() throws {
+    let article = TestDataGenerator.createArticle(in: context)
+    
+    XCTAssertTrue(context.hasChanges)
+    
+    try context.save()
+    
+    XCTAssertFalse(context.hasChanges)
+    
+    // Verify persistence
+    let fetchRequest = Article.fetchRequest()
+    let results = try context.fetch(fetchRequest)
+    
+    XCTAssertEqual(results.count, 1)
+    XCTAssertEqual(results.first?.name, "Test Article")
+}
+```
+
+## Testing Validation
+
+```swift
+func testValidation() {
+    let article = Article(context: context)
+    article.name = "" // Invalid
+    
+    XCTAssertThrowsError(try context.save()) { error in
+        let nsError = error as NSError
+        XCTAssertEqual(nsError.domain, NSCocoaErrorDomain)
+    }
+}
+```
+
+## Testing Relationships
+
+```swift
+func testArticleCategoryRelationship() throws {
+    let category = Category(context: context)
+    category.name = "Swift"
+    
+    let article = Article(context: context)
+    article.name = "Test"
+    article.category = category
+    
+    try context.save()
+    
+    XCTAssertEqual(article.category?.name, "Swift")
+    XCTAssertTrue(category.articles?.contains(article) ?? false)
+}
+```
+
+## Testing Threading
+
+```swift
+func testBackgroundContext() {
+    let expectation = XCTestExpectation(description: "Background save")
+    
+    let backgroundContext = container.newBackgroundContext()
+    backgroundContext.perform {
+        let article = Article(context: backgroundContext)
+        article.name = "Background Article"
+        
+        do {
+            try backgroundContext.save()
+            expectation.fulfill()
+        } catch {
+            XCTFail("Save failed: \(error)")
+        }
+    }
+    
+    wait(for: [expectation], timeout: 5.0)
+}
+```
+
+## Testing CloudKit Sync
+
+```swift
+func testCloudKitExport() {
+    let expectation = XCTestExpectation(description: "Export")
+    
+    let observer = NotificationCenter.default.addObserver(
+        forName: NSPersistentCloudKitContainer.eventChangedNotification,
+        object: container,
+        queue: nil
+    ) { notification in
+        guard let event = notification.userInfo?[NSPersistentCloudKitContainer.eventNotificationUserInfoKey]
+                as? NSPersistentCloudKitContainer.Event else {
+            return
+        }
+        
+        if event.type == .export && event.endDate != nil {
+            expectation.fulfill()
+        }
+    }
+    
+    let article = Article(context: context)
+    article.name = "Test"
+    try? context.save()
+    
+    wait(for: [expectation], timeout: 60)
+    NotificationCenter.default.removeObserver(observer)
+}
+```
+
+## Performance Testing
+
+```swift
+func testBatchInsertPerformance() {
+    measure {
+        let context = container.newBackgroundContext()
+        context.performAndWait {
+            var index = 0
+            let batchInsert = NSBatchInsertRequest(entity: Article.entity()) { object in
+                guard index < 1000 else { return true }
+                guard let article = object as? Article else { return true }
+                article.name = "Article \(index)"
+                index += 1
+                return false
+            }
+            try? context.execute(batchInsert)
+        }
+    }
+}
+```
+
+## Test Utilities
+
+```swift
+extension XCTestCase {
+    func createTestContainer() -> NSPersistentContainer {
+        let container = NSPersistentContainer(
+            name: "Model",
+            managedObjectModel: .shared
+        )
+        
+        let description = NSPersistentStoreDescription()
+        description.type = NSInMemoryStoreType
+        container.persistentStoreDescriptions = [description]
+        
+        let expectation = self.expectation(description: "Load store")
+        container.loadPersistentStores { _, error in
+            XCTAssertNil(error)
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 5.0)
+        return container
+    }
+}
+```
+
+## Best Practices
+
+1. **Use in-memory stores** - Fast, isolated tests
+2. **Use shared model** - Avoid entity description conflicts
+3. **Create data generators** - Reproducible test data
+4. **Test on background contexts** - Verify threading
+5. **Use expectations** - For asynchronous operations
+6. **Measure performance** - Use `measure` blocks
+7. **Clean up** - Reset context between tests
+8. **Test validation** - Verify business rules
+9. **Test relationships** - Ensure integrity
+10. **Test migrations** - Verify upgrade paths
+
+## Summary
+
+- Use in-memory stores for fast tests
+- Share model instance to avoid conflicts
+- Create data generators for reproducible tests
+- Test fetch requests, saves, validation, and relationships
+- Use expectations for async operations
+- Measure performance with `measure` blocks
+- Test threading with background contexts
+- Test CloudKit sync with event notifications

--- a/.agents/skills/core-data-expert/references/threading.md
+++ b/.agents/skills/core-data-expert/references/threading.md
@@ -1,0 +1,589 @@
+# Threading and Concurrency
+
+Core Data threading rules are strict but essential for data integrity. This guide covers safe multi-threading patterns, common pitfalls, and debugging techniques.
+
+## The Golden Rule
+
+**Never pass `NSManagedObject` instances between threads. Always use `NSManagedObjectID`.**
+
+```swift
+// ❌ WRONG: Passing object between contexts
+let article = viewContext.object(...)
+backgroundContext.perform {
+    article.name = "Updated" // CRASH!
+}
+
+// ✅ CORRECT: Pass object ID
+let objectID = article.objectID
+backgroundContext.perform {
+    guard let article = try? backgroundContext.existingObject(with: objectID) as? Article else { return }
+    article.name = "Updated" // Safe!
+    try? backgroundContext.save()
+}
+```
+
+## Why NSManagedObjectID is Thread-Safe
+
+`NSManagedObjectID` is immutable and thread-safe. It's a unique identifier that works across contexts and threads.
+
+```swift
+// Object IDs are thread-safe
+let objectID: NSManagedObjectID = article.objectID
+
+// Can be passed to any thread/context
+DispatchQueue.global().async {
+    let context = container.newBackgroundContext()
+    context.perform {
+        if let article = try? context.existingObject(with: objectID) as? Article {
+            // Work with article safely
+        }
+    }
+}
+```
+
+## Context Types and Concurrency
+
+### View Context (Main Queue)
+
+Runs on the main thread. Use for all UI operations.
+
+```swift
+let viewContext = container.viewContext
+viewContext.perform {
+    // Runs on main thread
+    let article = Article(context: viewContext)
+    article.name = "New Article"
+    try? viewContext.save()
+}
+```
+
+**Characteristics:**
+- Main queue concurrency type
+- Runs on main thread
+- Use for UI-related operations only
+- Keep operations lightweight
+
+### Background Context (Private Queue)
+
+Runs on a private queue. Use for heavy work.
+
+```swift
+let backgroundContext = container.newBackgroundContext()
+backgroundContext.perform {
+    // Runs on private background queue
+    for i in 0..<1000 {
+        let article = Article(context: backgroundContext)
+        article.name = "Article \(i)"
+    }
+    try? backgroundContext.save()
+}
+```
+
+**Characteristics:**
+- Private queue concurrency type
+- Runs on background thread
+- Use for imports, exports, batch operations
+- Doesn't block UI
+
+## perform vs performAndWait
+
+### perform (Asynchronous - Preferred)
+
+```swift
+context.perform {
+    // Work happens asynchronously
+    let article = Article(context: context)
+    try? context.save()
+}
+// Code here runs immediately, before perform block finishes
+```
+
+**Benefits:**
+- Non-blocking
+- Better performance
+- Recommended for most cases
+
+### performAndWait (Synchronous - Use Sparingly)
+
+```swift
+context.performAndWait {
+    // Work happens synchronously
+    let article = Article(context: context)
+    try? context.save()
+}
+// Code here runs after perform block finishes
+```
+
+**Caution:**
+- Blocks the calling thread
+- Can block main thread even for background contexts
+- Use only when you need the result immediately
+
+**Example of blocking behavior:**
+
+```swift
+// Called from main thread
+let backgroundContext = container.newBackgroundContext()
+
+// This BLOCKS the main thread!
+backgroundContext.performAndWait {
+    // Heavy work here blocks UI
+    for i in 0..<10000 {
+        let article = Article(context: backgroundContext)
+    }
+}
+```
+
+## Common Threading Patterns
+
+### Pattern 1: Background Import
+
+```swift
+func importArticles(_ data: [ArticleData]) {
+    let backgroundContext = container.newBackgroundContext()
+    backgroundContext.perform {
+        for item in data {
+            let article = Article(context: backgroundContext)
+            article.name = item.name
+            article.content = item.content
+        }
+        
+        do {
+            try backgroundContext.save()
+        } catch {
+            print("Failed to save: \(error)")
+        }
+    }
+}
+```
+
+### Pattern 2: Update Object from Background
+
+```swift
+func updateArticle(_ article: Article, newName: String) {
+    let objectID = article.objectID
+    let backgroundContext = container.newBackgroundContext()
+    
+    backgroundContext.perform {
+        guard let article = try? backgroundContext.existingObject(with: objectID) as? Article else {
+            return
+        }
+        
+        article.name = newName
+        try? backgroundContext.save()
+    }
+}
+```
+
+### Pattern 3: Fetch in Background, Update UI on Main
+
+```swift
+func loadArticles(completion: @escaping ([Article]) -> Void) {
+    let backgroundContext = container.newBackgroundContext()
+    
+    backgroundContext.perform {
+        let fetchRequest = Article.fetchRequest()
+        guard let articles = try? backgroundContext.fetch(fetchRequest) else {
+            return
+        }
+        
+        // Get object IDs (thread-safe)
+        let objectIDs = articles.map { $0.objectID }
+        
+        // Switch to main context for UI update
+        DispatchQueue.main.async {
+            let viewContext = self.container.viewContext
+            let mainArticles = objectIDs.compactMap { 
+                try? viewContext.existingObject(with: $0) as? Article 
+            }
+            completion(mainArticles)
+        }
+    }
+}
+```
+
+### Pattern 4: Batch Delete with Object IDs
+
+```swift
+func deleteArticles(_ articles: [Article]) {
+    let objectIDs = articles.map { $0.objectID }
+    let backgroundContext = container.newBackgroundContext()
+    
+    backgroundContext.perform {
+        for objectID in objectIDs {
+            guard let article = try? backgroundContext.existingObject(with: objectID) else {
+                continue
+            }
+            backgroundContext.delete(article)
+        }
+        
+        try? backgroundContext.save()
+    }
+}
+```
+
+## Context Hierarchy and Parent Contexts
+
+### Child Context Pattern
+
+```swift
+// Parent context (view context)
+let parentContext = container.viewContext
+
+// Child context for editing
+let childContext = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+childContext.parent = parentContext
+
+// Make changes in child
+let article = childContext.object(with: articleID) as! Article
+article.name = "Updated"
+
+// Save to parent (not to disk yet)
+try? childContext.save()
+
+// Save parent to persist
+try? parentContext.save()
+```
+
+**Benefits:**
+- Can discard changes by not saving child
+- Useful for forms/editing
+- Isolates changes
+
+**Caution:**
+- Adds complexity
+- Two saves required for persistence
+- Parent must be saved for changes to persist
+
+## Debugging Threading Issues
+
+### Enable Concurrency Debug
+
+Add launch argument:
+```
+-com.apple.CoreData.ConcurrencyDebug 1
+```
+
+**What it catches:**
+- Objects accessed from wrong thread
+- Contexts used from wrong queue
+- Thread safety violations
+
+**Example error:**
+```
+CoreData: error: Serious application error.
+An exception was caught from the delegate of NSFetchedResultsController during a call to -controllerDidChangeContent:.
+*** -[NSManagedObjectContext performSelector:withObject:] called from thread which is not the context's thread with userInfo (null)
+```
+
+### Common Threading Errors
+
+#### Error 1: Accessing Object from Wrong Context
+
+```swift
+// ❌ Wrong
+let article = viewContext.object(...)
+backgroundContext.perform {
+    print(article.name) // CRASH!
+}
+
+// ✅ Correct
+let objectID = article.objectID
+backgroundContext.perform {
+    if let article = try? backgroundContext.existingObject(with: objectID) as? Article {
+        print(article.name)
+    }
+}
+```
+
+#### Error 2: Not Using perform
+
+```swift
+// ❌ Wrong
+let backgroundContext = container.newBackgroundContext()
+let article = Article(context: backgroundContext) // CRASH!
+
+// ✅ Correct
+let backgroundContext = container.newBackgroundContext()
+backgroundContext.perform {
+    let article = Article(context: backgroundContext)
+}
+```
+
+#### Error 3: Passing Context Between Threads
+
+```swift
+// ❌ Wrong
+DispatchQueue.global().async {
+    try? viewContext.save() // CRASH!
+}
+
+// ✅ Correct
+viewContext.perform {
+    try? viewContext.save()
+}
+```
+
+## Merging Changes Between Contexts
+
+### Automatic Merging
+
+Enable automatic merging from parent:
+
+```swift
+context.automaticallyMergesChangesFromParent = true
+```
+
+**Benefits:**
+- Changes from other contexts automatically merge
+- No manual merge code needed
+- Recommended for most cases
+
+### Manual Merging
+
+Listen for save notifications:
+
+```swift
+NotificationCenter.default.addObserver(
+    self,
+    selector: #selector(contextDidSave),
+    name: .NSManagedObjectContextDidSave,
+    object: backgroundContext
+)
+
+@objc func contextDidSave(_ notification: Notification) {
+    viewContext.perform {
+        viewContext.mergeChanges(fromContextDidSave: notification)
+    }
+}
+```
+
+## Async/Await with Core Data (iOS 15+)
+
+### Using async/await
+
+```swift
+func fetchArticles() async throws -> [Article] {
+    let context = container.newBackgroundContext()
+    
+    return try await context.perform {
+        let fetchRequest = Article.fetchRequest()
+        return try context.fetch(fetchRequest)
+    }
+}
+
+// Usage
+Task {
+    do {
+        let articles = try await fetchArticles()
+        // Update UI with articles
+    } catch {
+        print("Failed to fetch: \(error)")
+    }
+}
+```
+
+### Saving with async/await
+
+```swift
+func saveArticle(name: String) async throws {
+    let context = container.newBackgroundContext()
+    
+    try await context.perform {
+        let article = Article(context: context)
+        article.name = name
+        try context.save()
+    }
+}
+```
+
+## Performance Considerations
+
+### Context Reuse
+
+```swift
+// ❌ Bad: Creating new context for each operation
+func updateArticle1() {
+    let context = container.newBackgroundContext()
+    context.perform { /* ... */ }
+}
+
+func updateArticle2() {
+    let context = container.newBackgroundContext() // New context!
+    context.perform { /* ... */ }
+}
+
+// ✅ Better: Reuse context for related operations
+class DataManager {
+    private lazy var backgroundContext = container.newBackgroundContext()
+    
+    func updateArticle1() {
+        backgroundContext.perform { /* ... */ }
+    }
+    
+    func updateArticle2() {
+        backgroundContext.perform { /* ... */ }
+    }
+}
+```
+
+### Context Reset
+
+For long-running contexts, periodically reset to free memory:
+
+```swift
+backgroundContext.perform {
+    for (index, data) in largeDataset.enumerated() {
+        let article = Article(context: backgroundContext)
+        article.name = data.name
+        
+        if index % 100 == 0 {
+            try? backgroundContext.save()
+            backgroundContext.reset() // Clear memory
+        }
+    }
+}
+```
+
+## Thread Confinement
+
+Each context is confined to its queue. You can call `perform` from any thread, but all Core Data work must run inside `perform`/`performAndWait` on that context.
+
+```swift
+let context = container.newBackgroundContext()
+
+// ✅ Allowed: scheduling work from anywhere
+DispatchQueue.global().async {
+    context.perform {
+        // Work executes on context's queue
+    }
+}
+
+DispatchQueue.main.async {
+    context.perform {
+        // Also executes on context's queue
+    }
+}
+
+// ❌ Wrong: touching the context or its objects outside perform
+DispatchQueue.global().async {
+    let article = Article(context: context) // Not inside perform
+    try? context.save()                     // Not inside perform
+}
+```
+
+## Common Pitfalls
+
+### ❌ Passing Objects Directly
+
+```swift
+func updateInBackground(_ article: Article) {
+    backgroundContext.perform {
+        article.name = "Updated" // CRASH!
+    }
+}
+```
+
+### ❌ Not Using perform
+
+```swift
+let backgroundContext = container.newBackgroundContext()
+let article = Article(context: backgroundContext) // CRASH!
+```
+
+### ❌ Accessing UI from Background Context
+
+```swift
+backgroundContext.perform {
+    let articles = try? backgroundContext.fetch(Article.fetchRequest())
+    tableView.reloadData() // CRASH! Wrong thread
+}
+```
+
+### ❌ Using performAndWait on Main Thread
+
+```swift
+// On main thread
+backgroundContext.performAndWait {
+    // Heavy work - blocks UI!
+}
+```
+
+### ✅ Correct Patterns
+
+```swift
+// Pass object IDs
+func updateInBackground(_ article: Article) {
+    let objectID = article.objectID
+    backgroundContext.perform {
+        guard let article = try? backgroundContext.existingObject(with: objectID) as? Article else {
+            return
+        }
+        article.name = "Updated"
+        try? backgroundContext.save()
+    }
+}
+
+// Always use perform
+let backgroundContext = container.newBackgroundContext()
+backgroundContext.perform {
+    let article = Article(context: backgroundContext)
+}
+
+// Update UI on main thread
+backgroundContext.perform {
+    let articles = try? backgroundContext.fetch(Article.fetchRequest())
+    let objectIDs = articles?.map { $0.objectID } ?? []
+    
+    DispatchQueue.main.async {
+        // Update UI with objectIDs
+    }
+}
+
+// Use perform (async) instead of performAndWait
+backgroundContext.perform {
+    // Heavy work doesn't block UI
+}
+```
+
+## Testing Threading
+
+```swift
+func testThreadSafety() {
+    let expectation = XCTestExpectation(description: "Background save")
+    
+    let objectID = article.objectID
+    let backgroundContext = container.newBackgroundContext()
+    
+    backgroundContext.perform {
+        guard let article = try? backgroundContext.existingObject(with: objectID) as? Article else {
+            XCTFail("Failed to fetch article")
+            return
+        }
+        
+        article.name = "Updated"
+        
+        do {
+            try backgroundContext.save()
+            expectation.fulfill()
+        } catch {
+            XCTFail("Failed to save: \(error)")
+        }
+    }
+    
+    wait(for: [expectation], timeout: 5.0)
+}
+```
+
+## Summary
+
+1. **Never pass NSManagedObject between contexts** - Always use NSManagedObjectID
+2. **Always use `perform` or `performAndWait`** - Never access context directly
+3. **Prefer `perform` over `performAndWait`** - Avoid blocking
+4. **Use view context for UI only** - Heavy work in background contexts
+5. **Enable `-com.apple.CoreData.ConcurrencyDebug 1`** - Catch threading violations
+6. **Enable `automaticallyMergesChangesFromParent`** - Automatic change propagation
+7. **Use async/await on iOS 15+** - Cleaner asynchronous code
+8. **Reset contexts periodically** - Free memory in long-running operations
+9. **One context per queue** - Don't share contexts across queues
+10. **Test threading behavior** - Verify thread safety in tests

--- a/.agents/skills/spm-build-analysis/SKILL.md
+++ b/.agents/skills/spm-build-analysis/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: spm-build-analysis
+description: Analyze Swift Package Manager dependencies, package plugins, module variants, and CI-oriented build overhead that slow Xcode builds. Use when a developer suspects packages, plugins, or dependency graph shape are hurting clean or incremental build performance, mentions SPM slowness, package resolution time, build plugin overhead, duplicate module builds from configuration drift, circular dependencies between modules, oversized modules needing splitting, or modularization best practices.
+---
+
+# SPM Build Analysis
+
+Use this skill when package structure, plugins, or dependency configuration are likely contributing to slow Xcode builds.
+
+## Core Rules
+
+- Treat package analysis as evidence gathering first, not a mandate to replace dependencies.
+- Separate package-graph issues from project-setting issues.
+- Do not rewrite package manifests or dependency sources without explicit approval.
+
+## What To Inspect
+
+- `Package.swift` and `Package.resolved`
+- local packages vs remote packages
+- package plugin and build-tool usage
+- binary target footprint
+- dependency layering, repeated imports, and potential cycles
+- build logs or timing summaries that show package-related work
+
+## Verification Before Recommending
+
+Before including any local package in a recommendation, verify that it is actually part of the project's dependency graph. A `Vendor/` directory may contain packages that are not linked to any target.
+
+- Check `project.pbxproj` for `XCLocalSwiftPackageReference` entries that reference the package path.
+- Check `XCSwiftPackageProductDependency` entries to confirm the package's product is linked to at least one target.
+- If a local package exists on disk but is not referenced in the project, do not include it in build-time recommendations.
+
+When recommending version pins for branch-tracked dependencies:
+
+- Use the helper script to scan all branch-pinned dependencies at once:
+  ```bash
+  python3 scripts/check_spm_pins.py --project App.xcodeproj
+  ```
+  This checks `git ls-remote --tags` for each branch-pinned package and reports which have tags available for pinning.
+- If no tags exist, recommend pinning to a specific commit revision hash for determinism instead.
+- Note which packages are branch-pinned because the upstream simply has no tags, versus packages that have tags but are intentionally tracking a branch.
+
+## Focus Areas
+
+- package graph shape and how much work changes trigger downstream
+- plugin overhead during local development and CI
+- checkout or fetch cost signals that show up in clean environments
+- configuration drift that forces duplicate module builds
+- risks from package targets that use different macros or options while sharing dependencies
+- dependency direction violations (features depending on each other instead of shared lower layers)
+- circular dependencies between modules (extract shared contracts into a protocol module)
+- oversized modules (200+ files) that widen incremental rebuild scope
+- umbrella modules using `@_exported import` that create hidden dependency chains
+- missing interface/implementation separation that blocks build parallelism
+- test targets depending on the app target instead of the module under test
+- Swift macro rebuild cascading: heavy use of Swift macros (e.g., TCA, swift-syntax-based libraries) can cause a trivial source change to cascade into near-full rebuilds because macro expansion invalidates downstream modules
+- `swift-syntax` building universally (all architectures) when no prebuilt binary is available, adding significant clean-build overhead
+- multi-platform build multiplication: adding a secondary platform target (e.g., watchOS) can cause shared SPM packages to build multiple times (e.g., iOS arm64, iOS x86_64, watchOS arm64), multiplying `SwiftCompile`, `SwiftEmitModule`, and `ScanDependencies` tasks
+
+## Modular SDK Migration Caveat
+
+Migrating a dependency from a monolithic target to a modular multi-target SDK (e.g., replacing one umbrella library with separate Core, RUM, Logs, Trace modules) does not automatically reduce build time. Modular targets increase the number of `SwiftCompile`, `SwiftEmitModule`, and `ScanDependencies` tasks because each target must be compiled, scanned, and emit its module independently. The build-time trade-off depends on the project's parallelism headroom and how many of the modular targets are actually needed.
+
+When considering a modular SDK migration:
+
+- Compare the total `SwiftCompile` task count before and after.
+- Benchmark both configurations before recommending the migration for build speed.
+- If the motivation is API surface reduction (importing only what you use), note that build time may stay flat or increase while import hygiene improves.
+- Only recommend modular SDK migration for build speed when the project currently compiles large portions of the monolithic SDK that it does not use, and the modular alternative lets it skip those unused portions entirely.
+
+## Explicit Module Dependency Angle
+
+When the same module appears multiple times in timing output, investigate whether different package or target options are forcing extra module variants. Uniform options often matter more than shaving a small amount of source code.
+
+## Reporting Format
+
+For each finding, include:
+
+- evidence
+- affected package or plugin
+- likely clean-build vs incremental-build impact
+- CI impact if relevant
+- estimated impact
+- approval requirement
+
+If the main problem is not package-related, hand off to [`xcode-project-analyzer`](../xcode-project-analyzer/SKILL.md) or [`xcode-compilation-analyzer`](../xcode-compilation-analyzer/SKILL.md) by reading the target skill's SKILL.md and applying its workflow to the same project context.
+
+## Additional Resources
+
+- For the detailed audit checklist, see [references/spm-analysis-checks.md](references/spm-analysis-checks.md)
+- For the shared recommendation structure, see [references/recommendation-format.md](references/recommendation-format.md)
+- For source citations, see [references/build-optimization-sources.md](references/build-optimization-sources.md)

--- a/.agents/skills/spm-build-analysis/references/build-optimization-sources.md
+++ b/.agents/skills/spm-build-analysis/references/build-optimization-sources.md
@@ -1,0 +1,155 @@
+# Build Optimization Sources
+
+This file stores the external sources that the README and skill docs should cite consistently.
+
+## Apple: Improving the speed of incremental builds
+
+Source:
+
+- <https://developer.apple.com/documentation/xcode/improving-the-speed-of-incremental-builds>
+
+Key takeaways:
+
+- Measure first with `Build With Timing Summary` or `xcodebuild -showBuildTimingSummary`.
+- Accurate target dependencies improve correctness and parallelism.
+- Run scripts should declare inputs and outputs so Xcode can skip unnecessary work.
+- `.xcfilelist` files are appropriate when scripts have many inputs or outputs.
+- Custom frameworks and libraries benefit from module maps, typically by enabling `DEFINES_MODULE`.
+- Module reuse is strongest when related sources compile with consistent options.
+- Breaking monolithic targets into better-scoped modules can reduce unnecessary rebuilds.
+
+## Apple: Improving build efficiency with good coding practices
+
+Source:
+
+- <https://developer.apple.com/documentation/xcode/improving-build-efficiency-with-good-coding-practices>
+
+Key takeaways:
+
+- Use framework-qualified imports when module maps are available.
+- Keep Objective-C bridging surfaces narrow.
+- Prefer explicit type information when inference becomes expensive.
+- Use explicit delegate protocols instead of overly generic delegate types.
+- Simplify complex expressions that are hard for the compiler to type-check.
+
+## Apple: Building your project with explicit module dependencies
+
+Source:
+
+- <https://developer.apple.com/documentation/xcode/building-your-project-with-explicit-module-dependencies>
+
+Key takeaways:
+
+- Explicit module builds make module work visible in the build log and improve scheduling.
+- Repeated builds of the same module often point to avoidable module variants.
+- Inconsistent build options across targets can force duplicate module builds.
+- Timing summaries can reveal option drift that prevents module reuse.
+
+## SwiftLee: Build performance analysis for speeding up Xcode builds
+
+Source:
+
+- <https://www.avanderlee.com/optimization/analysing-build-performance-xcode/>
+
+Key takeaways:
+
+- Clean and incremental builds should both be measured because they reveal different problems.
+- Build Timeline and Build Timing Summary are practical starting points for build optimization.
+- Build scripts often produce large incremental-build wins when guarded correctly.
+- `-warn-long-function-bodies` and `-warn-long-expression-type-checking` help surface compile hotspots.
+- Typical debug and release build setting mismatches are worth auditing, especially in older projects.
+
+## Apple: Xcode Release Notes -- Compilation Caching
+
+Source:
+
+- Xcode Release Notes (149700201)
+
+Key takeaways:
+
+- Compilation caching is an opt-in feature for Swift and C-family languages.
+- It caches prior compilation results and reuses them when the same source inputs are recompiled.
+- Branch switching and clean builds benefit the most.
+- Can be enabled via the "Enable Compilation Caching" build setting or per-user project settings.
+
+## Apple: Demystify explicitly built modules (WWDC24)
+
+Source:
+
+- <https://developer.apple.com/videos/play/wwdc2024/10171/>
+
+Key takeaways:
+
+- Explains how explicitly built modules divide compilation into scan, module build, and source compile stages.
+- Unrelated modules build in parallel, improving CPU utilization.
+- Module variant duplication is a key bottleneck -- uniform compiler options across targets prevent it.
+- The build log shows each module as a discrete task, making it easier to diagnose scheduling issues.
+
+## Swift Compile-Time Best Practices
+
+Well-known Swift language patterns that reduce type-checker workload during compilation:
+
+- Mark classes `final` when they are not intended for subclassing. This eliminates dynamic dispatch overhead and allows the compiler to de-virtualize method calls.
+- Restrict access control to the narrowest useful scope (`private`, `fileprivate`). Fewer visible symbols reduce the compiler's search space during type resolution.
+- Prefer value types (`struct`, `enum`) over `class` when reference semantics are not needed. Value types are simpler for the compiler to reason about.
+- Break long method chains (`.map().flatMap().filter()`) into intermediate `let` bindings with explicit type annotations. Even simple-looking chains can take seconds to type-check.
+- Provide explicit return types on closures passed to generic functions, especially in SwiftUI result-builder contexts.
+- Decompose large SwiftUI `body` properties into smaller extracted subviews. Each subview narrows the scope of the result-builder expression the type-checker must resolve.
+
+## Bitrise: Demystifying Explicitly Built Modules for Xcode
+
+Source:
+
+- <https://bitrise.io/blog/post/demystifying-explicitly-built-modules-for-xcode>
+
+Key takeaways:
+
+- Explicit module builds give `xcodebuild` visibility into smaller compilation tasks for better parallelism.
+- Enabled by default for C/Objective-C in Xcode 16+; experimental for Swift.
+- Minimizing module variants by aligning build options is the primary optimization lever.
+- Some projects see regressions from dependency scanning overhead -- benchmark before and after.
+
+## Bitrise: Xcode Compilation Cache FAQ
+
+Source:
+
+- <https://docs.bitrise.io/en/bitrise-build-cache/build-cache-for-xcode/xcode-compilation-cache-faq.html>
+
+Key takeaways:
+
+- Granular caching is controlled by `SWIFT_ENABLE_COMPILE_CACHE` and `CLANG_ENABLE_COMPILE_CACHE`, under the umbrella `COMPILATION_CACHE_ENABLE_CACHING` setting.
+- Non-cacheable tasks include `CompileStoryboard`, `CompileXIB`, `CompileAssetCatalogVariant`, `PhaseScriptExecution`, `DataModelCompile`, `CopyPNGFile`, `GenerateDSYMFile`, and `Ld`.
+- SPM dependencies are not yet cacheable as of Xcode 26 beta.
+
+## RocketSim Docs: Build Insights
+
+Sources:
+
+- <https://www.rocketsim.app/docs/features/build-insights/build-insights/>
+- <https://www.rocketsim.app/docs/features/build-insights/team-build-insights/>
+
+Key takeaways:
+
+- RocketSim automatically tracks clean vs incremental builds over time without build scripts.
+- It reports build counts, duration trends, and percentile-based metrics such as p75 and p95.
+- Team Build Insights adds machine, Xcode, and macOS comparisons for cross-team visibility.
+- This repository is best positioned as the point-in-time analyze-and-improve toolkit, while RocketSim is the monitor-over-time companion.
+
+## Swift Forums: Slow incremental builds because of planning swift module
+
+Source:
+
+- <https://forums.swift.org/t/slow-incremental-builds-because-of-planning-swift-module/84803>
+
+Key takeaways:
+
+- "Planning Swift module" can dominate incremental builds (up to 30s per module), sometimes exceeding clean build time.
+- Replanning every module without scheduling compiles is a sign that build inputs are being modified unexpectedly (e.g., a misconfigured linter touching file timestamps).
+- Enable **Task Backtraces** (Xcode 16.4+: Scheme Editor > Build > Build Debugging) to see why each task re-ran in an incremental build.
+- Heavy Swift macro usage (e.g., TCA / swift-syntax) can cause trivial changes to cascade into near-full rebuilds.
+- `swift-syntax` builds universally (all architectures) when no prebuilt binary is available, adding significant overhead.
+- `SwiftEmitModule` can take 60s+ after a single-line change in large modules.
+- Asset catalog compilation is single-threaded per target; splitting assets into separate bundles across targets enables parallel compilation.
+- Multi-platform targets (e.g., adding watchOS) can cause SPM packages to build 3x (iOS arm64, iOS x86_64, watchOS arm64).
+- Zero-change incremental builds still incur ~10s of fixed overhead: compute dependencies, send project description, create build description, script phases, codesigning, and validation.
+- Codesigning and validation run even when output has not changed.

--- a/.agents/skills/spm-build-analysis/references/recommendation-format.md
+++ b/.agents/skills/spm-build-analysis/references/recommendation-format.md
@@ -1,0 +1,85 @@
+# Recommendation Format
+
+All optimization skills should report recommendations in a shared structure so the orchestrator can merge and prioritize them cleanly.
+
+## Required Fields
+
+Each recommendation should include:
+
+- `title`
+- `wait_time_impact` -- plain-language statement of expected wall-clock impact, e.g. "Expected to reduce your clean build by ~3s", "Reduces parallel compile work but unlikely to reduce build wait time", or "Impact on wait time is uncertain -- re-benchmark to confirm"
+- `actionability` -- classifies how fixable the issue is from the project (see values below)
+- `category`
+- `observed_evidence`
+- `estimated_impact`
+- `confidence`
+- `approval_required`
+- `benchmark_verification_status`
+
+### Actionability Values
+
+Every recommendation must include an `actionability` classification:
+
+- `repo-local` -- Fix lives entirely in project files, source code, or local configuration. The developer can apply it without side effects outside the repo.
+- `package-manager` -- Requires CocoaPods or SPM configuration changes that may have broad side effects (e.g., linkage mode, dependency restructuring). These should be benchmarked before and after.
+- `xcode-behavior` -- Observed cost is driven by Xcode internals and is not suppressible from the project. Report the finding for awareness but do not promise a fix.
+- `upstream` -- Requires changes in a third-party dependency or external tool. The developer cannot fix it locally.
+
+## Suggested Optional Fields
+
+- `scope`
+- `affected_files`
+- `affected_targets`
+- `affected_packages`
+- `implementation_notes`
+- `risk_level`
+
+## JSON Example
+
+```json
+{
+  "recommendations": [
+    {
+      "title": "Guard a release-only symbol upload script",
+      "wait_time_impact": "Expected to reduce your incremental build by approximately 6 seconds.",
+      "actionability": "repo-local",
+      "category": "project",
+      "observed_evidence": [
+        "Incremental builds spend 6.3 seconds in a run script phase.",
+        "The script runs for Debug builds even though the output is only needed in Release."
+      ],
+      "estimated_impact": "High incremental-build improvement",
+      "confidence": "High",
+      "approval_required": true,
+      "benchmark_verification_status": "Not yet verified",
+      "scope": "Target build phase",
+      "risk_level": "Low"
+    }
+  ]
+}
+```
+
+## Markdown Rendering Guidance
+
+When rendering for human review, preserve the same field order:
+
+1. title
+2. wait-time impact
+3. actionability
+4. observed evidence
+5. estimated impact
+6. confidence
+7. approval required
+8. benchmark verification status
+
+That makes it easier for the developer to approve or reject specific items quickly.
+
+## Verification Status Values
+
+Recommended values:
+
+- `Not yet verified`
+- `Queued for verification`
+- `Verified improvement`
+- `No measurable improvement`
+- `Inconclusive due to benchmark noise`

--- a/.agents/skills/spm-build-analysis/references/spm-analysis-checks.md
+++ b/.agents/skills/spm-build-analysis/references/spm-analysis-checks.md
@@ -1,0 +1,105 @@
+# SPM Analysis Checks
+
+Use this reference when package dependencies or package plugins are suspected build bottlenecks.
+
+## Package Graph Checks
+
+- Identify large umbrella packages that trigger widespread rebuilds.
+- Look for dependency layering that forces many downstream targets to recompile.
+- Flag local package arrangements that cause broad invalidation after small edits.
+
+## Package Plugin Checks
+
+- List build-tool and command plugins involved in the build.
+- Measure whether plugins run during incremental builds even when no relevant input changed.
+- Call out plugins that return quickly but still add fixed overhead to every build.
+
+## Package Reference Verification
+
+- Before including any local package in a build-time recommendation, confirm it appears in the project's `XCLocalSwiftPackageReference` section of `project.pbxproj`.
+- A package existing under `Vendor/` or as a directory in the repo does not mean it is linked. Only referenced packages affect build time.
+- For remote packages, confirm the `XCRemoteSwiftPackageReference` entry exists and at least one `XCSwiftPackageProductDependency` links its product to a target.
+
+## Version Pin Feasibility
+
+- When recommending a switch from `branch:` to a tagged version, verify tags exist via `git ls-remote --tags <url>`.
+- If no tags exist, recommend pinning to a specific `revision:` hash for deterministic resolution.
+- Note the distinction: branch pins force network checks on every fresh resolve; revision pins are fully deterministic but do not benefit from semver range resolution.
+
+## Binary And Remote Dependency Checks
+
+- Note binary target size and extraction overhead for clean environments.
+- Highlight remote checkout or fetch costs that matter for CI or fresh machines.
+- Compare remote vs local package tradeoffs when iteration speed matters more than distribution convenience.
+
+## Module Variant Checks
+
+- Look for the same dependency module being built with different options.
+- Compare macros, language mode, and configuration-sensitive options across dependents.
+- Prefer configuration alignment when it reduces repeated module builds safely.
+
+## Layered Architecture Validation
+
+- Enforce a clear dependency direction: Common/Core --> Services/Domain --> Features/UI. Dependencies must flow in one direction only (inward/downward).
+- Features should never depend on each other directly. If two features share types, move those types to a lower-layer module.
+- Validate that `Package.swift` target dependency lists match the intended layer hierarchy.
+
+## Circular Dependency Detection
+
+- SPM supports cyclic *package* dependencies (since May 2024) but not cyclic *target* dependencies.
+- Circular module dependencies should always be refactored: extract the shared contract (protocols, DTOs) into a separate module that both sides depend on.
+- Check for hidden cycles through transitive dependencies by tracing the full dependency graph.
+
+## Module Sizing Guidance
+
+- Modules larger than roughly 200 files increase incremental build scope unnecessarily -- a single file change recompiles more than needed.
+- Recommend splitting oversized modules by feature area or responsibility.
+- Each module should have a clear, single-purpose responsibility. If a module's name requires "And" or "Utils" to describe, it likely needs splitting.
+
+## Transitive Dependency Minimization
+
+- Each module should depend only on what it directly uses. Unnecessary transitive dependencies widen the rebuild surface.
+- Avoid "umbrella" modules that re-export everything via `@_exported import` -- they create hidden dependency chains where a change in any re-exported module triggers rebuilds in all importers.
+- Use `@_exported import` sparingly and only for genuine convenience wrappers.
+
+## Interface/Implementation Separation
+
+- Define protocols and public types in lightweight "interface" modules (e.g., `NetworkingInterface`).
+- Put implementations in separate modules (e.g., `NetworkingImpl`).
+- Feature modules compile against the interface without waiting for the full implementation to build, improving parallelism.
+- This pattern is most valuable when the implementation module has many files or heavy dependencies that would block downstream compilation.
+
+## Test Target Isolation
+
+- Test targets should depend on the module under test, not the entire app target. Depending on the app target forces a full app build before tests can compile.
+- Shared test utilities (mocks, fixtures, helpers) belong in a dedicated `TestHelpers` module rather than being duplicated across test targets.
+- Keep test-only dependencies out of production target dependency lists.
+
+## Swift Macro Rebuild Impact
+
+- Projects that heavily use Swift macros (e.g., TCA, swift-syntax-based libraries) are susceptible to incremental build cascading where a trivial change rebuilds most of the app.
+- Macro expansion can invalidate downstream modules even when the expanded output has not changed, because the build system treats the macro input as a dependency.
+- Check whether `swift-syntax` is building universally (all architectures) when no prebuilt binary is available. This adds significant overhead to clean builds and CI. Verify with the build log whether the `swift-syntax` target compiles for more architectures than `ONLY_ACTIVE_ARCH` would suggest.
+- If macro-heavy packages dominate incremental build time, consider whether the macro-using code can be isolated into fewer, more stable modules to limit the invalidation blast radius.
+
+## Multi-Platform Build Multiplication
+
+- Adding a secondary platform target (e.g., watchOS, macOS Catalyst) can cause shared SPM packages to build multiple times -- once per platform and architecture combination.
+- A project with iOS and watchOS targets may build shared packages 3x: iOS arm64, iOS x86_64 (simulator), and watchOS arm64.
+- Check the build log for duplicate `SwiftCompile`, `SwiftEmitModule`, and `ScanDependencies` tasks for the same package across different platform/architecture slices.
+- If multi-platform multiplication is a significant contributor, consider whether secondary platform targets can use a subset of shared packages, or whether packages can be prebuilt as binary targets for secondary platforms.
+
+## CI-Specific Checks
+
+- Fresh checkout cost
+- plugin invocation cost
+- cache hit sensitivity
+- redundant package resolution work
+
+## Recommendation Prioritization
+
+Qualify every estimated impact with wall-clock framing. High-priority items should be those likely to reduce the developer's actual wait time, not just cumulative task totals. If the impact on wait time is uncertain, say so.
+
+- High: package plugins or graph structure repeatedly inflating incremental builds, circular dependencies, umbrella re-exports causing cascading rebuilds, Swift macro cascading that causes near-full rebuilds from trivial changes.
+- Medium: configuration drift that causes duplicate module variants, oversized modules, missing interface/implementation separation, multi-platform build multiplication, `swift-syntax` building universally without prebuilt binary.
+- Low: clean-environment checkout costs that barely affect local iteration, minor transitive dependency cleanup.

--- a/.agents/skills/spm-build-analysis/scripts/check_spm_pins.py
+++ b/.agents/skills/spm-build-analysis/scripts/check_spm_pins.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+"""Scan a project.pbxproj for branch-pinned SPM dependencies and check tag availability."""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+_PKG_REF_RE = re.compile(
+    r"(/\*\s*XCRemoteSwiftPackageReference\s+\"(?P<name>[^\"]+)\"\s*\*/\s*=\s*\{[^}]*?"
+    r"repositoryURL\s*=\s*\"(?P<url>[^\"]+)\"[^}]*?"
+    r"requirement\s*=\s*\{(?P<req>[^}]*)\})",
+    re.DOTALL,
+)
+
+_KIND_RE = re.compile(r"kind\s*=\s*(\w+)\s*;")
+_BRANCH_RE = re.compile(r"branch\s*=\s*(\w+)\s*;")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Check branch-pinned SPM dependencies for available tags."
+    )
+    parser.add_argument(
+        "--project",
+        required=True,
+        help="Path to the .xcodeproj directory",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output results as JSON",
+    )
+    return parser.parse_args()
+
+
+def find_branch_pins(pbxproj: str) -> List[Dict[str, str]]:
+    results: List[Dict[str, str]] = []
+    for match in _PKG_REF_RE.finditer(pbxproj):
+        name = match.group("name")
+        url = match.group("url")
+        req = match.group("req")
+        kind_match = _KIND_RE.search(req)
+        if not kind_match:
+            continue
+        kind = kind_match.group(1)
+        if kind != "branch":
+            continue
+        branch_match = _BRANCH_RE.search(req)
+        branch = branch_match.group(1) if branch_match else "unknown"
+        results.append({"name": name, "url": url, "branch": branch})
+    return results
+
+
+def check_tags(url: str) -> List[str]:
+    try:
+        result = subprocess.run(
+            ["git", "ls-remote", "--tags", url],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            return []
+        tags: List[str] = []
+        for line in result.stdout.strip().splitlines():
+            ref = line.split("\t")[-1] if "\t" in line else ""
+            if ref.startswith("refs/tags/") and not ref.endswith("^{}"):
+                tags.append(ref.replace("refs/tags/", ""))
+        return tags
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return []
+
+
+def main() -> int:
+    args = parse_args()
+    pbxproj_path = Path(args.project) / "project.pbxproj"
+    if not pbxproj_path.exists():
+        sys.stderr.write(f"Not found: {pbxproj_path}\n")
+        return 1
+
+    pbxproj = pbxproj_path.read_text()
+    pins = find_branch_pins(pbxproj)
+
+    if not pins:
+        print("No branch-pinned SPM dependencies found.")
+        return 0
+
+    results: List[Dict] = []
+    for pin in pins:
+        tags = check_tags(pin["url"])
+        entry = {
+            "name": pin["name"],
+            "url": pin["url"],
+            "branch": pin["branch"],
+            "tags_available": len(tags) > 0,
+            "latest_tags": tags[-5:] if tags else [],
+        }
+        results.append(entry)
+
+    if args.json:
+        print(json.dumps(results, indent=2))
+    else:
+        for r in results:
+            status = "tags available" if r["tags_available"] else "no tags (pin to revision)"
+            latest = f" (latest: {', '.join(r['latest_tags'])})" if r["latest_tags"] else ""
+            print(f"  {r['name']}: branch={r['branch']} -> {status}{latest}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/swift-concurrency/SKILL.md
+++ b/.agents/skills/swift-concurrency/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: swift-concurrency
+description: 'Diagnose data races, convert callback-based code to async/await, implement actor isolation patterns, resolve Sendable conformance issues, and guide Swift 6 migration. Use when developers mention: (1) Swift Concurrency, async/await, actors, or tasks, (2) "use Swift Concurrency" or "modern concurrency patterns", (3) migrating to Swift 6, (4) data races or thread safety issues, (5) refactoring closures to async/await, (6) @MainActor, Sendable, or actor isolation, (7) concurrent code architecture or performance optimization, (8) concurrency-related linter warnings (SwiftLint or similar; e.g. async_without_await, Sendable/actor isolation/MainActor lint).'
+---
+# Swift Concurrency
+
+## Fast Path
+
+Before proposing a fix:
+
+1. Analyze `Package.swift` or `.pbxproj` to determine Swift language mode, strict concurrency level, default isolation, and upcoming features. Do this always, not only for migration work.
+2. Capture the exact diagnostic and offending symbol.
+3. Determine the isolation boundary: `@MainActor`, custom actor, actor instance isolation, or `nonisolated`.
+4. Confirm whether the code is UI-bound or intended to run off the main actor. For delayed retries, timers, and backoff tasks, separate the waiting from the UI mutation. The sleep often belongs off the main actor even when the final state update belongs on it.
+
+Project settings that change concurrency behavior:
+
+| Setting | SwiftPM (`Package.swift`) | Xcode (`.pbxproj`) |
+|---|---|---|
+| Language mode | `swiftLanguageVersions` or `-swift-version` (`// swift-tools-version:` is not a reliable proxy) | Swift Language Version |
+| Strict concurrency | `.enableExperimentalFeature("StrictConcurrency=targeted")` | `SWIFT_STRICT_CONCURRENCY` |
+| Default isolation | `.defaultIsolation(MainActor.self)` | `SWIFT_DEFAULT_ACTOR_ISOLATION` |
+| Upcoming features | `.enableUpcomingFeature("NonisolatedNonsendingByDefault")` | `SWIFT_UPCOMING_FEATURE_*` |
+
+If any of these are unknown, ask the developer to confirm them before giving migration-sensitive guidance. Do not guess.
+
+Guardrails:
+
+- Do not recommend `@MainActor` as a blanket fix. Justify why the code is truly UI-bound.
+- Prefer structured concurrency over unstructured tasks. Use `Task.detached` only with a clear reason.
+- If recommending `@preconcurrency`, `@unchecked Sendable`, or `nonisolated(unsafe)`, require a documented safety invariant and a follow-up removal plan.
+- Optimize for the smallest safe change. Do not refactor unrelated architecture during migration.
+- Course references are for deeper learning only. Use them sparingly and only when they clearly help answer the developer's question.
+
+## Quick Fix Mode
+
+Use Quick Fix Mode when all of these are true:
+
+- The issue is localized to one file or one type.
+- The isolation boundary is clear.
+- The fix can be explained in 1-2 behavior-preserving steps.
+
+Skip Quick Fix Mode when any of these are true:
+
+- Build settings or default isolation are unknown.
+- The issue crosses module boundaries or changes public API behavior.
+- The likely fix depends on unsafe escape hatches.
+
+## Common Diagnostics
+
+| Diagnostic | First check | Smallest safe fix | Escalate to |
+|---|---|---|---|
+| `Main actor-isolated ... cannot be used from a nonisolated context` | Is this truly UI-bound? | Isolate the caller to `@MainActor` or use `await MainActor.run { ... }` only when main-actor ownership is correct. | `references/actors.md`, `references/threading.md` |
+| `Actor-isolated type does not conform to protocol` | Must the requirement run on the actor? | Prefer isolated conformance (e.g., `extension Foo: @MainActor SomeProtocol`); use `nonisolated` only for truly nonisolated requirements. | `references/actors.md` |
+| `Sending value of non-Sendable type ... risks causing data races` | What isolation boundary is being crossed? | Keep access inside one actor, or convert the transferred value to an immutable/value type. | `references/sendable.md`, `references/threading.md` |
+| `SwiftLint async_without_await` | Is `async` actually required by protocol, override, or `@concurrent`? | Remove `async`, or use a narrow suppression with rationale. Never add fake awaits. | `references/linting.md` |
+| `wait(...) is unavailable from asynchronous contexts` | Is this legacy XCTest async waiting? | Replace with `await fulfillment(of:)` or Swift Testing equivalents. | `references/testing.md` |
+| Core Data concurrency warnings | Are `NSManagedObject` instances crossing contexts or actors? | Pass `NSManagedObjectID` or map to a Sendable value type. | `references/core-data.md` |
+| `Thread.current` unavailable from asynchronous contexts | Are you debugging by thread instead of isolation? | Reason in terms of isolation and use Instruments/debugger instead. | `references/threading.md` |
+| SwiftLint concurrency-related warnings | Which specific lint rule triggered? | Use `references/linting.md` for rule intent and preferred fixes; avoid dummy awaits. | `references/linting.md` |
+
+## When Quick Fixes Fail
+
+1. Gather project settings if not already confirmed.
+2. Re-evaluate which isolation boundaries the type crosses.
+3. Route to the matching reference file for a deeper fix.
+4. If the fix may change behavior, document the invariant and add verification steps.
+
+## Smallest Safe Fixes
+
+Prefer changes that preserve behavior while satisfying data-race safety:
+
+- **UI-bound state**: isolate the type or member to `@MainActor`.
+- **Shared mutable state**: move it behind an `actor`, or use `@MainActor` only if the state is UI-owned.
+- **Background work**: when work must hop off caller isolation, use an `async` API marked `@concurrent`; when work can safely inherit caller isolation, use `nonisolated` without `@concurrent`. If a task mostly waits or retries before one UI-bound mutation, keep the delay off `@MainActor` and hop back only for the final update.
+- **Sendability issues**: prefer immutable values and explicit boundaries over `@unchecked Sendable`.
+
+## Concurrency Tool Selection
+
+| Need | Tool | Key Guidance |
+|---|---|---|
+| Single async operation | `async/await` | Default choice for sequential async work |
+| Fixed parallel operations | `async let` | Known count at compile time; auto-cancelled on throw |
+| Dynamic parallel operations | `withTaskGroup` | Unknown count; structured — cancels children on scope exit |
+| Sync → async bridge | `Task { }` | Inherits actor context; use `Task.detached` only with documented reason |
+| Shared mutable state | `actor` | Prefer over locks/queues; keep isolated sections small |
+| UI-bound state | `@MainActor` | Only for truly UI-related code; justify isolation |
+
+### Common Scenarios
+
+**Network request with UI update**
+```swift
+Task { @concurrent in
+    let data = try await fetchData()
+    await MainActor.run { self.updateUI(with: data) }
+}
+```
+
+**Processing array items in parallel**
+```swift
+await withTaskGroup(of: ProcessedItem.self) { group in
+    for item in items {
+        group.addTask { await process(item) }
+    }
+    for await result in group {
+        results.append(result)
+    }
+}
+```
+
+## Swift 6 Migration Quick Guide
+
+Key changes in Swift 6:
+- **Strict concurrency checking** enabled by default
+- **Complete data-race safety** at compile time
+- **Sendable requirements** enforced on boundaries
+- **Isolation checking** for all async boundaries
+
+### Migration Validation Loop
+
+Apply this cycle for each migration change:
+
+1. **Build** — Run `swift build` or Xcode build to surface new diagnostics
+2. **Fix** — Address one category of error at a time (e.g., all Sendable issues first)
+3. **Rebuild** — Confirm the fix compiles cleanly before moving on
+4. **Test** — Run the test suite to catch regressions (`swift test` or Cmd+U)
+5. **Only proceed** to the next file/module when all diagnostics are resolved
+
+If a fix introduces new warnings, resolve them before continuing. Never batch multiple unrelated fixes — keep commits small and reviewable.
+
+For detailed migration steps, see `references/migration.md`.
+
+## Reference Router
+
+Open the smallest reference that matches the question:
+
+- Foundations
+  - `references/async-await-basics.md` — async/await syntax, execution order, async let, URLSession patterns
+  - `references/tasks.md` — Task lifecycle, cancellation, priorities, task groups, structured vs unstructured
+  - `references/actors.md` — Actor isolation, @MainActor, global actors, reentrancy, custom executors, Mutex
+  - `references/sendable.md` — Sendable conformance, value/reference types, @unchecked, region isolation
+  - `references/threading.md` — Execution model, suspension points, Swift 6.2 isolation behavior
+- Streams
+  - `references/async-sequences.md` — AsyncSequence, AsyncStream, when to use vs regular async methods
+  - `references/async-algorithms.md` — Debounce, throttle, merge, combineLatest, channels, timers
+- Applied topics
+  - `references/testing.md` — Swift Testing first, XCTest fallback, leak checks
+  - `references/performance.md` — Profiling with Instruments, reducing suspension points, execution strategies
+  - `references/memory-management.md` — Retain cycles in tasks, memory safety patterns
+  - `references/core-data.md` — NSManagedObject sendability, custom executors, isolation conflicts
+- Migration and tooling
+  - `references/migration.md` — Swift 6 migration strategy, closure-to-async conversion, @preconcurrency, FRP migration
+  - `references/linting.md` — Concurrency-focused lint rules and SwiftLint `async_without_await`
+- Glossary
+  - `references/glossary.md` — Quick definitions of core concurrency terms
+
+## Verification Checklist
+
+When changing concurrency code:
+
+1. Re-check build settings before interpreting diagnostics.
+2. Build and clear one category of errors before moving on. Do not batch unrelated fixes into the same change.
+3. Run tests, especially actor-, lifetime-, and cancellation-sensitive tests.
+4. Use Instruments for performance claims instead of guessing.
+5. Verify deallocation and cancellation behavior for long-lived tasks.
+6. Check `Task.isCancelled` in long-running operations.
+7. Never use semaphores or ad hoc locking in async contexts when actor isolation or `Mutex` would express ownership more safely.
+
+---
+
+**Note**: This skill is based on the comprehensive [Swift Concurrency Course](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=skill-footer) by Antoine van der Lee.

--- a/.agents/skills/swift-concurrency/references/_index.md
+++ b/.agents/skills/swift-concurrency/references/_index.md
@@ -1,0 +1,50 @@
+# Reference Index
+
+Quick navigation for the Swift Concurrency skill.
+
+## Foundations
+
+| File | Use it for |
+|---|---|
+| `async-await-basics.md` | closure-to-async bridges and foundational async/await usage |
+| `tasks.md` | `Task`, cancellation, task groups, structured vs unstructured work |
+| `actors.md` | actor isolation, `@MainActor`, reentrancy, isolated conformances |
+| `sendable.md` | `Sendable`, `@Sendable`, region isolation, escape hatches |
+| `threading.md` | execution model, suspension points, Swift 6.2 isolation behavior |
+
+## Streams
+
+| File | Use it for |
+|---|---|
+| `async-sequences.md` | deciding between `AsyncSequence`, `AsyncStream`, and one-shot async APIs |
+| `async-algorithms.md` | debounce, throttle, merge, `combineLatest`, channels, timers |
+
+## Applied Topics
+
+| File | Use it for |
+|---|---|
+| `testing.md` | Swift Testing first, XCTest fallback, leak checks |
+| `performance.md` | Instruments workflow, actor hops, suspension cost |
+| `memory-management.md` | retain cycles, long-lived tasks, cleanup |
+| `core-data.md` | `NSManagedObjectID`, `perform`, default isolation conflicts |
+
+## Migration and Tooling
+
+| File | Use it for |
+|---|---|
+| `migration.md` | rollout order, build settings, migration guardrails |
+| `linting.md` | concurrency-focused lint rules |
+| `glossary.md` | quick definitions |
+
+## Problem Router
+
+- "I need to fix a compiler error quickly" → `../SKILL.md`
+- "I need to replace a callback with async/await" → `async-await-basics.md`
+- "I need to protect shared mutable state" → `actors.md`
+- "I need to pass data safely across boundaries" → `sendable.md`
+- "I need stream operators" → `async-algorithms.md`
+- "I need to understand why code runs where it runs" → `threading.md`
+- "I need to stop a leak or lifetime issue" → `memory-management.md`
+- "I need to migrate to Swift 6" → `migration.md`
+- "I need to test async code" → `testing.md`
+- "I need to optimize slow async code" → `performance.md`

--- a/.agents/skills/swift-concurrency/references/actors.md
+++ b/.agents/skills/swift-concurrency/references/actors.md
@@ -1,0 +1,660 @@
+# Actors
+
+Use this when:
+
+- You need to protect class-based mutable state from concurrent access.
+- You are choosing between `actor`, `@MainActor`, `nonisolated`, or `Mutex`.
+- You are resolving protocol conformance issues on actor-isolated types.
+
+Skip this file if:
+
+- You mainly need to make a value safe to transfer across boundaries. Use `sendable.md`.
+- You are debugging execution threads or suspension behavior. Use `threading.md`.
+
+Jump to:
+
+- Actor Isolation
+- Global Actors / @MainActor
+- Isolated vs Nonisolated
+- Actor Reentrancy
+- Isolated Deinit / Isolated Conformances (Swift 6.2+)
+- `#isolation` Macro
+- Mutex: Alternative to Actors
+- Decision Tree
+
+## What is an Actor?
+
+Actors protect mutable state by ensuring only one task accesses it at a time. They're reference types with automatic synchronization.
+
+```swift
+actor Counter {
+    var value = 0
+    
+    func increment() {
+        value += 1
+    }
+}
+```
+
+**Key guarantee**: Only one task can access mutable state at a time (serialized access).
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 5.1: Understanding actors in Swift Concurrency](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Actor Isolation
+
+### Enforced by compiler
+
+```swift
+actor BankAccount {
+    var balance: Int = 0
+    
+    func deposit(_ amount: Int) {
+        balance += amount
+    }
+}
+
+let account = BankAccount()
+account.balance += 1 // ❌ Error: can't mutate from outside
+await account.deposit(1) // ✅ Must use actor's methods
+```
+
+### Reading properties
+
+```swift
+let account = BankAccount()
+await account.deposit(100)
+print(await account.balance) // Must await reads too
+```
+
+Always use `await` when accessing actor properties/methods—you don't know if another task is inside.
+
+## Actors vs Classes
+
+### Similarities
+
+- Reference types (copies share same instance)
+- Can have properties, methods, initializers
+- Can conform to protocols
+
+### Differences
+
+- **No inheritance** (except `NSObject` for Objective-C interop)
+- **Automatic isolation** (no manual locks needed)
+- **Implicit Sendable** conformance
+
+```swift
+// ❌ Can't inherit from actors
+actor Base {}
+actor Child: Base {} // Error
+
+// ✅ NSObject exception
+actor Example: NSObject {} // OK for Objective-C
+```
+
+## Global Actors
+
+Shared isolation domain across types, functions, and properties.
+
+### @MainActor
+
+Ensures execution on main thread:
+
+```swift
+@MainActor
+final class ViewModel {
+    var items: [Item] = []
+}
+
+@MainActor
+func updateUI() {
+    // Always runs on main thread
+}
+
+@MainActor
+var title: String = ""
+```
+
+### Custom global actors
+
+```swift
+@globalActor
+actor ImageProcessing {
+    static let shared = ImageProcessing()
+    private init() {} // Prevent duplicate instances
+}
+
+@ImageProcessing
+final class ImageCache {
+    var images: [URL: Data] = [:]
+}
+
+@ImageProcessing
+func applyFilter(_ image: UIImage) -> UIImage {
+    // All image processing serialized
+}
+```
+
+**Use private init** to prevent creating multiple executors.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 5.2: An introduction to Global Actors](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## @MainActor Best Practices
+
+### When to use
+
+UI-related code that must run on main thread:
+
+```swift
+@MainActor
+final class ContentViewModel: ObservableObject {
+    @Published var items: [Item] = []
+}
+```
+
+### Replacing DispatchQueue.main
+
+```swift
+// Old way
+DispatchQueue.main.async {
+    // Update UI
+}
+
+// Modern way
+await MainActor.run {
+    // Update UI
+}
+
+// Better: Use attribute
+@MainActor
+func updateUI() {
+    // Automatically on main thread
+}
+```
+
+### MainActor.assumeIsolated
+
+**Use sparingly** - assumes you're on main thread, crashes if not:
+
+```swift
+func methodB() {
+    assert(Thread.isMainThread) // Validate assumption
+    
+    MainActor.assumeIsolated {
+        someMainActorMethod()
+    }
+}
+```
+
+**Prefer**: Explicit `@MainActor` or `await MainActor.run` over `assumeIsolated`.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 5.3: When and how to use @MainActor](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Isolated vs Nonisolated
+
+### Default: Isolated
+
+Actor methods are isolated by default:
+
+```swift
+actor BankAccount {
+    var balance: Double
+    
+    // Implicitly isolated
+    func deposit(_ amount: Double) {
+        balance += amount
+    }
+}
+```
+
+### Isolated parameters
+
+Reduce suspension points by inheriting caller's isolation:
+
+```swift
+struct Charger {
+    static func charge(
+        amount: Double,
+        from account: isolated BankAccount
+    ) async throws -> Double {
+        // No await needed - we're isolated to account
+        try account.withdraw(amount: amount)
+        return account.balance
+    }
+}
+```
+
+### Isolated closures
+
+```swift
+actor Database {
+    func transaction<T>(
+        _ operation: @Sendable (_ db: isolated Database) throws -> T
+    ) throws -> T {
+        beginTransaction()
+        let result = try operation(self)
+        commitTransaction()
+        return result
+    }
+}
+
+// Usage: Multiple operations, one await
+try await database.transaction { db in
+    db.insert(item1)
+    db.insert(item2)
+    db.insert(item3)
+}
+```
+
+### Generic isolated extension
+
+```swift
+extension Actor {
+    func performInIsolation<T: Sendable>(
+        _ block: @Sendable (_ actor: isolated Self) throws -> T
+    ) async rethrows -> T {
+        try block(self)
+    }
+}
+
+// Usage
+try await bankAccount.performInIsolation { account in
+    try account.withdraw(amount: 20)
+    print("Balance: \(account.balance)")
+}
+```
+
+### Nonisolated
+
+Opt out of isolation for immutable data:
+
+```swift
+actor BankAccount {
+    let accountHolder: String
+    
+    nonisolated var details: String {
+        "Account: \(accountHolder)"
+    }
+}
+
+// No await needed
+print(account.details)
+```
+
+### Protocol conformance
+
+```swift
+extension BankAccount: CustomStringConvertible {
+    nonisolated var description: String {
+        "Account: \(accountHolder)"
+    }
+}
+```
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 5.4: Isolated vs. non-isolated access in actors](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Isolated Deinit (Swift 6.2+)
+
+Clean up actor state on deallocation:
+
+```swift
+actor FileDownloader {
+    var downloadTask: Task<Void, Error>?
+    
+    isolated deinit {
+        downloadTask?.cancel() // Can call isolated methods
+    }
+}
+```
+
+**Requires**: iOS 18.4+, macOS 15.4+
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 5.5: Using Isolated synchronous deinit](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Global Actor Isolated Conformance (Swift 6.2+)
+
+Protocol conformance respecting actor isolation:
+
+```swift
+@MainActor
+final class PersonViewModel {
+    let id: UUID
+    var name: String
+}
+
+extension PersonViewModel: @MainActor Equatable {
+    static func == (lhs: PersonViewModel, rhs: PersonViewModel) -> Bool {
+        lhs.id == rhs.id && lhs.name == rhs.name
+    }
+}
+```
+
+**Enable**: `InferIsolatedConformances` upcoming feature.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 5.6: Adding isolated conformance to protocols](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Actor Reentrancy
+
+**Critical**: State can change between suspension points.
+
+```swift
+actor BankAccount {
+    var balance: Double
+    
+    func deposit(amount: Double) async {
+        balance += amount
+        
+        // ⚠️ Actor unlocked during await
+        await logActivity("Deposited \(amount)")
+        
+        // ⚠️ Balance may have changed!
+        print("Balance: \(balance)")
+    }
+}
+```
+
+### Problem
+
+```swift
+async let _ = account.deposit(50)
+async let _ = account.deposit(50)
+async let _ = account.deposit(50)
+
+// May print same balance three times:
+// Balance: 150
+// Balance: 150
+// Balance: 150
+```
+
+### Solution
+
+Complete actor work before suspending:
+
+```swift
+func deposit(amount: Double) async {
+    balance += amount
+    print("Balance: \(balance)") // Before suspension
+    
+    await logActivity("Deposited \(amount)")
+}
+```
+
+**Rule**: Don't assume state is unchanged after `await`.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 5.7: Understanding actor reentrancy](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## #isolation Macro
+
+Inherit caller's isolation for generic code:
+
+```swift
+extension Collection where Element: Sendable {
+    func sequentialMap<Result: Sendable>(
+        isolation: isolated (any Actor)? = #isolation,
+        transform: (Element) async -> Result
+    ) async -> [Result] {
+        var results: [Result] = []
+        for element in self {
+            results.append(await transform(element))
+        }
+        return results
+    }
+}
+
+// Usage from @MainActor context
+Task { @MainActor in
+    let names = ["Alice", "Bob"]
+    let results = await names.sequentialMap { name in
+        await process(name) // Inherits @MainActor
+    }
+}
+```
+
+**Benefits**: Avoids unnecessary suspensions, allows non-Sendable data.
+
+### Task Closures and Isolation Inheritance
+
+When spawning unstructured `Task` closures that need to work with `non-Sendable` types, you must capture the isolation parameter to inherit the caller's isolation context.
+
+**Problem**: `Task` closures are `@Sendable`, which prevents capturing `non-Sendable` types:
+
+```swift
+func process(delegate: NonSendableDelegate) {
+  Task {
+    delegate.doWork() // ❌ Error: capturing non-Sendable type
+  }
+}
+```
+
+**Solution**: Use `#isolation` parameter and capture it inside the `Task`:
+
+```swift
+func process(
+  delegate: NonSendableDelegate,
+  isolation: isolated (any Actor)? = #isolation
+) {
+  Task {
+    _ = isolation  // Forces capture, Task inherits caller's isolation
+    delegate.doWork()  // ✅ Safe - running on caller's actor
+  }
+}
+```
+
+**Why `_ = isolation` is required**: Per [SE-0420](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0420-inheritance-of-actor-isolation.md), `Task` closures only inherit isolation when "a non-optional binding of an isolated parameter is captured by the closure." The `_ = isolation` statement forces this capture. The capture list syntax `[isolation]` should work but currently does not.
+
+**When to use this pattern**:
+- Spawning `Task`s that work with `non-Sendable` delegate objects
+- Fire-and-forget async work that needs access to caller's state
+- Bridging callback-based APIs to async streams while keeping delegates alive
+
+**Note**: This pattern keeps the `non-Sendable` value alive and accessible within the `Task`. The `Task` runs on the caller's isolation domain, so no cross-isolation "sending" occurs.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 5.8: Inheritance of actor isolation using the #isolation macro](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Custom Actor Executors
+
+**Advanced**: Control how actor schedules work.
+
+### Serial executor
+
+```swift
+final class DispatchQueueExecutor: SerialExecutor {
+    private let queue: DispatchQueue
+    
+    init(queue: DispatchQueue) {
+        self.queue = queue
+    }
+    
+    func enqueue(_ job: consuming ExecutorJob) {
+        let unownedJob = UnownedJob(job)
+        let executor = asUnownedSerialExecutor()
+        
+        queue.async {
+            unownedJob.runSynchronously(on: executor)
+        }
+    }
+}
+
+actor LoggingActor {
+    private let executor: DispatchQueueExecutor
+    
+    nonisolated var unownedExecutor: UnownedSerialExecutor {
+        executor.asUnownedSerialExecutor()
+    }
+    
+    init(queue: DispatchQueue) {
+        executor = DispatchQueueExecutor(queue: queue)
+    }
+}
+```
+
+### When to use
+
+- Integration with legacy DispatchQueue-based code
+- Specific thread requirements (e.g., C++ interop)
+- Custom scheduling logic
+
+**Default executor is usually sufficient.**
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 5.9: Using a custom actor executor](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Mutex: Alternative to Actors
+
+Synchronous locking without async/await overhead (iOS 18+, macOS 15+).
+
+### Basic usage
+
+```swift
+import Synchronization
+
+final class Counter {
+    private let count = Mutex<Int>(0)
+    
+    var currentCount: Int {
+        count.withLock { $0 }
+    }
+    
+    func increment() {
+        count.withLock { $0 += 1 }
+    }
+}
+```
+
+### Sendable access to non-Sendable types
+
+```swift
+final class TouchesCapturer: Sendable {
+    let path = Mutex<NSBezierPath>(NSBezierPath())
+    
+    func storeTouch(_ point: NSPoint) {
+        path.withLock { path in
+            path.move(to: point)
+        }
+    }
+}
+```
+
+### Error handling
+
+```swift
+func decrement() throws {
+    try count.withLock { count in
+        guard count > 0 else {
+            throw Error.reachedZero
+        }
+        count -= 1
+    }
+}
+```
+
+### Mutex vs Actor
+
+| Feature | Mutex | Actor |
+|---------|-------|-------|
+| Synchronous | ✅ | ❌ (requires await) |
+| Async support | ❌ | ✅ |
+| Thread blocking | ✅ | ❌ (cooperative) |
+| Fine-grained locking | ✅ | ❌ (whole actor) |
+| Legacy code integration | ✅ | ❌ |
+
+**Use Mutex when**:
+- Need synchronous access
+- Working with legacy non-async APIs
+- Fine-grained locking required
+- Low contention, short critical sections
+
+**Use Actor when**:
+- Can adopt async/await
+- Need logical isolation
+- Working in async context
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 5.10: Using a Mutex as an alternative to actors](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Common Patterns
+
+### View model with @MainActor
+
+```swift
+@MainActor
+final class ContentViewModel: ObservableObject {
+    @Published var items: [Item] = []
+    
+    func loadItems() async {
+        items = try await api.fetchItems()
+    }
+}
+```
+
+### Background processing with custom actor
+
+```swift
+@ImageProcessing
+final class ImageProcessor {
+    func process(_ images: [UIImage]) async -> [UIImage] {
+        images.map { applyFilters($0) }
+    }
+}
+```
+
+### Mixed isolation
+
+```swift
+actor DataStore {
+    private var items: [Item] = []
+    
+    func add(_ item: Item) {
+        items.append(item)
+    }
+    
+    nonisolated func itemCount() -> Int {
+        // ❌ Can't access items
+        return 0
+    }
+}
+```
+
+### Transaction pattern
+
+```swift
+actor Database {
+    func transaction<T>(
+        _ operation: @Sendable (_ db: isolated Database) throws -> T
+    ) throws -> T {
+        beginTransaction()
+        defer { commitTransaction() }
+        return try operation(self)
+    }
+}
+```
+
+## Best Practices
+
+1. **Prefer actors over manual locks** for async code
+2. **Use @MainActor for UI** - all view models, UI updates
+3. **Minimize work in actors** - keep critical sections short
+4. **Watch for reentrancy** - don't assume state unchanged after await
+5. **Use nonisolated sparingly** - only for truly immutable data
+6. **Avoid assumeIsolated** - prefer explicit isolation
+7. **Custom executors are rare** - default is usually best
+8. **Consider Mutex for sync code** - when async overhead not needed
+9. **Complete actor work before suspending** - prevent reentrancy bugs
+10. **Use isolated parameters** - reduce suspension points
+
+## Decision Tree
+
+```
+Need thread-safe mutable state?
+├─ Async context?
+│  ├─ Single instance? → Actor
+│  ├─ Global/shared? → Global Actor (@MainActor, custom)
+│  └─ UI-related? → @MainActor
+│
+└─ Synchronous context?
+   ├─ Can refactor to async? → Actor
+   ├─ Legacy code integration? → Mutex
+   └─ Fine-grained locking? → Mutex
+```
+
+## Further Learning
+
+For migration strategies, advanced patterns, and real-world examples, see [Swift Concurrency Course](https://www.swiftconcurrencycourse.com).
+

--- a/.agents/skills/swift-concurrency/references/async-algorithms.md
+++ b/.agents/skills/swift-concurrency/references/async-algorithms.md
@@ -1,0 +1,847 @@
+# AsyncAlgorithms Package
+
+Use this when:
+
+- You need time-based operators (debounce, throttle, timers).
+- You need to combine multiple async sequences (merge, combineLatest, zip).
+- You are migrating from Combine or RxSwift operators to Swift Concurrency equivalents.
+
+Skip this file if:
+
+- You need basic `AsyncStream` bridging for callbacks or delegates. Use `async-sequences.md`.
+- You are choosing between `Task`, `async let`, or task groups. Use `tasks.md`.
+
+Jump to:
+
+- Quick Start
+- Time-Based Operators
+- Combining Operators
+- Multi-Consumer Scenarios
+- Combine Migration Guide
+- Best Practices
+
+---
+
+## Quick Start
+
+Top 5 most common operators:
+
+```swift
+import AsyncAlgorithms
+
+// 1. Debounce rapid inputs
+for await query in searchQueryStream.debounce(for: .milliseconds(500)) {
+    await performSearch(query)
+}
+
+// 2. Throttle repeated actions
+for await _ in buttonClicks.throttle(for: .seconds(1)) {
+    await performAction()
+}
+
+// 3. Merge multiple independent streams
+for await message in chat1Messages.merge(chat2Messages) {
+    display(message)
+}
+
+// 4. Combine dependent values
+for await (username, email) in usernameStream.combineLatest(emailStream) {
+    validateForm(username: username, email: email)
+}
+
+// 5. Zip paired operations
+for await (image, metadata) in imageStream.zip(metadataStream) {
+    await cache(image: image, metadata: metadata)
+}
+```
+
+> **See**: [AsyncAlgorithms on GitHub](https://github.com/apple/swift-async-algorithms)
+
+---
+
+## Overview & Installation
+
+### What is AsyncAlgorithms?
+
+Extends Swift's AsyncSequence with time-based operators, stream combination tools, and multi-consumer primitives.
+
+**Use for**:
+- Time-based operations: debounce, throttle, timers
+- Combining streams: merge, combineLatest, zip, chain
+- Multi-consumer scenarios: AsyncChannel for backpressure
+- Specific operators: removeDuplicates, chunks, adjacentPairs, compacted
+
+**Use standard library for**:
+- Bridging callbacks: AsyncStream
+- Simple iteration: for await in sequence
+- Single-value operations: async/await
+
+### Installation
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.0.0")
+]
+
+targets: [
+    .target(
+        name: "MyTarget",
+        dependencies: [
+            .product(name: "AsyncAlgorithms", package: "swift-async-algorithms")
+        ]
+    )
+]
+```
+
+Import:
+
+```swift
+import AsyncAlgorithms
+```
+
+---
+
+## Time-Based Operators
+
+### debounce(for:tolerance:clock:)
+
+Wait for inactivity before emitting. Use for rapid inputs like search fields.
+
+#### Example: ArticleSearcher
+
+```swift
+import AsyncAlgorithms
+
+@Observable
+final class ArticleSearcher {
+    @MainActor private(set) var results: [Article] = []
+    private var searchQueryContinuation: AsyncStream<String>.Continuation?
+
+    private lazy var searchQueryStream: AsyncStream<String> = {
+        AsyncStream { continuation in
+            searchQueryContinuation = continuation
+        }
+    }()
+
+    func search(_ query: String) {
+        searchQueryContinuation?.yield(query)
+    }
+
+    func startDebouncedSearch() {
+        Task { @MainActor in
+            for await query in searchQueryStream.debounce(for: .milliseconds(500)) {
+                self.results = []
+                self.results = await APIClient.searchArticles(query)
+            }
+        }
+    }
+}
+```
+
+**Benefits**: Automatic cancellation, backpressure, cleaner than manual Task.sleep.
+
+#### ❌ Anti-Pattern
+
+```swift
+// Bad: Every keystroke spawns new task
+func search(_ query: String) {
+    Task {
+        try? await Task.sleep(for: .milliseconds(500))
+        await performSearch(query)
+    }
+}
+```
+
+**Problem**: Multiple tasks execute simultaneously, causing out-of-order results.
+
+**Solution**: Use `debounce()` for automatic backpressure.
+
+---
+
+### throttle(for:clock:reducing:)
+
+Emit at most one value per interval. Use for repeated actions like button taps.
+
+#### Example: Like Button
+
+```swift
+import AsyncAlgorithms
+
+struct LikeButton: View {
+    @State private var tapStream = AsyncStream<Void> { continuation in
+        // Continuation stored externally
+    }
+    @State private var isLiked = false
+
+    var body: some View {
+        Button(action: {
+            tapStream.continuation?.yield()
+        }) {
+            Image(systemName: isLiked ? "heart.fill" : "heart")
+        }
+        .task {
+            await handleThrottledTaps()
+        }
+    }
+
+    private func handleThrottledTaps() async {
+        for await _ in tapStream.throttle(for: .seconds(1)) {
+            await toggleLike()
+        }
+    }
+
+    private func toggleLike() async {
+        isLiked.toggle()
+        await APIClient.updateLikeStatus(isLiked: isLiked)
+    }
+}
+```
+
+#### Understanding reducing Parameter
+
+```swift
+// .latest (default): Keep most recent value
+for await value in events.throttle(for: .seconds(1)) {
+    process(value)
+}
+
+// .oldest: Keep first value
+for await value in events.throttle(for: .seconds(1), reducing: .oldest) {
+    process(value)
+}
+
+// Custom: Sum all values
+for await value in events.throttle(for: .seconds(1)) { $0 + $1 } {
+    process(value)
+}
+```
+
+---
+
+### AsyncTimerSequence
+
+Emit values at regular intervals. Use for periodic refresh or countdown timers.
+
+#### Example: Feed Refresh
+
+```swift
+import AsyncAlgorithms
+
+@MainActor @Observable
+final class FeedViewModel {
+    private(set) var articles: [Article] = []
+    private var refreshTask: Task<Void, Never>?
+
+    func startAutoRefresh() {
+        refreshTask = Task {
+            for await _ in AsyncTimerSequence(interval: .seconds(30)) {
+                await refreshFeed()
+            }
+        }
+    }
+
+    private func refreshFeed() async {
+        articles = await APIClient.fetchLatestArticles()
+    }
+}
+```
+
+#### ❌ Anti-Pattern
+
+```swift
+// Bad: Manual timer implementation
+func startTimer() {
+    Task {
+        while !Task.isCancelled {
+            performAction()
+            try? await Task.sleep(for: .seconds(1))
+        }
+    }
+}
+```
+
+**Solution**: Use `AsyncTimerSequence`.
+
+---
+
+## Combining Operators
+
+### merge(_:...)
+
+Combine sequences into one, emitting as they arrive. **Stable operator ✅**
+
+Use for independent data sources that don't depend on each other.
+
+#### Example: Multi-Room Chat
+
+```swift
+import AsyncAlgorithms
+
+actor ChatManager {
+    private var messageContinuations: [String: AsyncStream<ChatMessage>.Continuation] = [:]
+
+    func getMessagesStream(roomID: String) -> AsyncStream<ChatMessage> {
+        AsyncStream { continuation in
+            messageContinuations[roomID] = continuation
+        }
+    }
+
+    func receiveMessage(_ message: ChatMessage) {
+        messageContinuations[message.roomID]?.yield(message)
+    }
+
+    func startMonitoring(rooms: [String]) -> AsyncStream<ChatMessage> {
+        let streams = rooms.map { getMessagesStream(roomID: $0) }
+        return streams.merge()
+    }
+}
+
+// Usage
+let manager = ChatManager()
+let mergedMessages = await manager.startMonitoring(rooms: ["general", "random"])
+
+for await message in mergedMessages {
+    print("[\(message.roomID)] \(message.text)")
+}
+```
+
+**Behavior**: Values emit as they arrive from any source. Order interleaved by timing. Cancellation propagates to all sources.
+
+---
+
+### combineLatest(_:...)
+
+Combine sequences, emitting tuple when any source emits. Always uses latest values. **Stable operator ✅**
+
+Use for dependent values that need synchronization.
+
+#### Example: Form Validation
+
+```swift
+import AsyncAlgorithms
+
+struct SignupForm: View {
+    @State private var usernameStream = AsyncStream<String> { /* ... */ }
+    @State private var emailStream = AsyncStream<String> { /* ... */ }
+    @State private var passwordStream = AsyncStream<String> { /* ... */ }
+    @State private var formState = FormState.incomplete
+
+    var body: some View {
+        Form {
+            TextField("Username", text: $username)
+            TextField("Email", text: $email)
+            SecureField("Password", text: $password)
+        }
+        .task {
+            await validateForm()
+        }
+    }
+
+    private func validateForm() async {
+        for await (username, email, password) in
+                usernameStream.combineLatest(emailStream, passwordStream)
+        {
+            formState = await validate(
+                username: username,
+                email: email,
+                password: password
+            )
+        }
+    }
+}
+```
+
+#### ❌ Anti-Pattern
+
+```swift
+// Bad: Manual value combining
+actor FormValidator {
+    private var currentUsername: String = ""
+    private var currentEmail: String = ""
+
+    func updateUsername(_ username: String) {
+        currentUsername = username
+        checkForm()
+    }
+}
+```
+
+**Solution**: Use `combineLatest()`.
+
+---
+
+### zip(_:...)
+
+Combine sequences by pairing elements in order. **Stable operator ✅**
+
+#### Example: Image + Metadata
+
+```swift
+import AsyncAlgorithms
+
+struct ImageLoader {
+    func loadImagesWithMetadata(urls: [URL]) async throws -> [LoadedImage] {
+        let imageStream = AsyncThrowingStream<UIImage, Error> { continuation in
+            Task {
+                for url in urls {
+                    let image = try await downloadImage(from: url)
+                    continuation.yield(image)
+                }
+                continuation.finish()
+            }
+        }
+
+        let metadataStream = AsyncThrowingStream<ImageMetadata, Error> { continuation in
+            Task {
+                for url in urls {
+                    let metadata = try await fetchMetadata(for: url)
+                    continuation.yield(metadata)
+                }
+                continuation.finish()
+            }
+        }
+
+        var results: [LoadedImage] = []
+        for try await (image, metadata) in imageStream.zip(metadataStream) {
+            results.append(LoadedImage(image: image, metadata: metadata))
+        }
+        return results
+    }
+}
+```
+
+**Behavior**: Emits tuple when all sequences emit. Maintains order. Finishes when shortest sequence finishes.
+
+---
+
+### chain(_:...)
+
+Concatenate sequences sequentially. **Stable operator ✅**
+
+#### Example: Paginated Loading
+
+```swift
+import AsyncAlgorithms
+
+struct ArticlePaginator {
+    func loadAllArticles() -> AsyncStream<[Article]> {
+        AsyncStream { continuation in
+            Task {
+                var page = 1
+                var hasMore = true
+                while hasMore {
+                    let articles = try await fetchPage(page: page)
+                    continuation.yield(articles)
+                    hasMore = articles.count == 20
+                    page += 1
+                }
+                continuation.finish()
+            }
+        }
+    }
+}
+
+// Usage: Chain cache + network
+for await articles in loadFromCacheStream().chain(loadFromNetworkStream()) {
+    display(articles)
+}
+```
+
+**Behavior**: Emits all values from first sequence before starting second.
+
+---
+
+## Utility Operators
+
+### removeDuplicates()
+
+Remove adjacent duplicates. **Stable operator ✅**
+
+```swift
+import AsyncAlgorithms
+
+actor ChatHistory {
+    private var messageStream = AsyncStream<ChatMessage> { /* ... */ }
+
+    func getUniqueMessages() -> AsyncStream<ChatMessage> {
+        messageStream.removeDuplicates()
+    }
+}
+```
+
+---
+
+### chunks() and chunked()
+
+Collect values into batches. **Stable operator ✅**
+
+```swift
+import AsyncAlgorithms
+
+struct BatchProcessor {
+    func processLargeDataset(dataStream: AsyncStream<DataItem>) async {
+        for await batch in dataStream.chunks(count: 100) {
+            await processBatch(batch)
+        }
+    }
+
+    func chunkedByTime(dataStream: AsyncStream<DataItem>) async {
+        for await batch in dataStream.chunked(by: .seconds(5)) {
+            await processBatch(batch)
+        }
+    }
+}
+```
+
+---
+
+### compacted() and adjacentPairs()
+
+```swift
+import AsyncAlgorithms
+
+// Remove nil values
+for await value in optionalValuesStream.compacted() {
+    process(value)
+}
+
+// Pair adjacent elements
+for await (previous, current) in valuesStream.adjacentPairs() {
+    let difference = current - previous
+}
+```
+
+---
+
+## Multi-Consumer Scenarios
+
+### AsyncChannel
+
+AsyncSequence with backpressure. **Stable operator ✅**
+
+Use for producer-consumer patterns with flow control.
+
+#### Example: Message Queue
+
+```swift
+import AsyncAlgorithms
+
+actor MessageQueue {
+    private let channel = AsyncChannel<Message>()
+
+    func getMessages() -> AsyncStream<Message> {
+        channel
+    }
+
+    func enqueue(_ message: Message) async {
+        await channel.send(message)
+    }
+
+    func startProcessing() {
+        Task {
+            for await message in channel {
+                await process(message)
+            }
+        }
+    }
+}
+
+// Multiple producers
+let queue = MessageQueue()
+Task { await queue.enqueue(Message(type: .userAction, content: "tap")) }
+Task { await queue.enqueue(Message(type: .network, content: "data")) }
+queue.startProcessing()
+```
+
+#### ❌ Anti-Pattern
+
+```swift
+// Bad: Values split unpredictably
+let stream = AsyncStream<Int> { continuation in
+    for i in 1...10 {
+        continuation.yield(i)
+    }
+    continuation.finish()
+}
+
+Task { for await value in stream { print("Consumer 1: \(value)") } }
+Task { for await value in stream { print("Consumer 2: \(value)") } }
+```
+
+**Problem**: Each value goes to only one consumer.
+
+**Solution**: Use `AsyncChannel` for multi-consumer scenarios.
+
+---
+
+### AsyncThrowingChannel
+
+Like AsyncChannel but can emit errors. **Stable operator ✅**
+
+#### Example: WebSocket
+
+```swift
+import AsyncAlgorithms
+
+actor WebSocketConnection {
+    private let channel = AsyncThrowingChannel<WebSocketMessage, Error>()
+
+    func getMessages() -> AsyncThrowingStream<WebSocketMessage, Error> {
+        channel
+    }
+
+    func receiveMessage(_ message: WebSocketMessage) async {
+        await channel.send(message)
+    }
+
+    func reportError(_ error: Error) async {
+        await channel.finish(throwing: error)
+    }
+}
+
+// Usage
+do {
+    for await message in connection.getMessages() {
+        handle(message)
+    }
+} catch {
+    print("WebSocket error: \(error)")
+}
+```
+
+---
+
+## Combine Migration Guide
+
+### Operator Mapping Table
+
+| Combine | AsyncAlgorithms | Status | Alternative |
+|---------|-----------------|---------|-------------|
+| `.debounce()` | `debounce()` | ✅ Stable | - |
+| `.throttle()` | `throttle()` | ✅ Stable | - |
+| `.merge()` | `merge()` | ✅ Stable | - |
+| `.combineLatest()` | `combineLatest()` | ✅ Stable | - |
+| `.zip()` | `zip()` | ✅ Stable | - |
+| `.concat()` | `chain()` | ✅ Stable | - |
+| `.removeDuplicates()` | `removeDuplicates()` | ✅ Stable | - |
+| `.timer()` | `AsyncTimerSequence` | ✅ Stable | - |
+| `.share()` | - | - | `AsyncChannel` |
+| `.flatMap()` | - | - | `TaskGroup` |
+| `.receive(on:)` | - | - | `Task` / `@MainActor` |
+| `.eraseToAnyPublisher()` | - | - | `any AsyncSequence` |
+
+---
+
+### Migration Examples
+
+#### Example 1: ArticleSearcher
+
+**Before: Combine**
+
+```swift
+import Combine
+
+final class ArticleSearcher: ObservableObject {
+    @Published private(set) var results: [Article] = []
+    @Published var searchQuery = ""
+
+    init() {
+        $searchQuery
+            .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
+            .removeDuplicates()
+            .flatMap { query in
+                APIClient.searchArticles(query)
+                    .catch { _ in Just([]) }
+            }
+            .receive(on: DispatchQueue.main)
+            .assign(to: &$results)
+    }
+}
+```
+
+**After: AsyncAlgorithms**
+
+```swift
+import AsyncAlgorithms
+
+@Observable
+final class ArticleSearcher {
+    @MainActor private(set) var results: [Article] = []
+    private var searchQueryContinuation: AsyncStream<String>.Continuation?
+
+    private lazy var searchQueryStream: AsyncStream<String> = {
+        AsyncStream { continuation in
+            searchQueryContinuation = continuation
+        }
+    }()
+
+    func search(_ query: String) {
+        searchQueryContinuation?.yield(query)
+    }
+
+    func startDebouncedSearch() {
+        Task { @MainActor in
+            for await query in searchQueryStream
+                .debounce(for: .milliseconds(500))
+                .removeDuplicates()
+            {
+                do {
+                    self.results = try await APIClient.searchArticles(query)
+                } catch {
+                    self.results = []
+                }
+            }
+        }
+    }
+}
+```
+
+**Benefits**: Simpler error handling, no cancellables, automatic cancellation.
+
+---
+
+#### Example 2: Multi-Source Loading
+
+**Before: Combine Merge**
+
+```swift
+import Combine
+
+final class ArticleLoader: ObservableObject {
+    @Published private(set) var items: [Item] = []
+
+    func loadAllSources() {
+        let source1 = APIClient.fetchItems(from: .source1)
+        let source2 = APIClient.fetchItems(from: .source2)
+
+        Publishers.Merge(source1, source2)
+            .scan([]) { accumulated, new in
+                accumulated + new
+            }
+            .receive(on: DispatchQueue.main)
+            .assign(to: &$items)
+    }
+}
+```
+
+**After: TaskGroup**
+
+```swift
+import AsyncAlgorithms
+
+@Observable
+final class ArticleLoader {
+    @MainActor private(set) var items: [Item] = []
+
+    func loadAllSourcesParallel() async {
+        await withTaskGroup(of: [Item].self) { group in
+            group.addTask {
+                await APIClient.fetchItems(from: .source1)
+            }
+            group.addTask {
+                await APIClient.fetchItems(from: .source2)
+            }
+
+            for await newItems in group {
+                items.append(contentsOf: newItems)
+            }
+        }
+    }
+}
+```
+
+**Key difference**: For parallel execution, use `TaskGroup` instead of `flatMap`.
+
+---
+
+#### Example 3: Form Validation
+
+**Before: Combine**
+
+```swift
+import Combine
+
+final class FormValidator: ObservableObject {
+    @Published var username = ""
+    @Published var email = ""
+
+    @Published private(set) var formState: FormState = .incomplete
+
+    init() {
+        Publishers.CombineLatest2($username, $email)
+            .map { username, email in
+                validate(username: username, email: email)
+            }
+            .assign(to: &$formState)
+    }
+}
+```
+
+**After: AsyncAlgorithms or async let**
+
+```swift
+import AsyncAlgorithms
+
+@Observable
+final class FormValidator {
+    var username = ""
+    var email = ""
+
+    @MainActor private(set) var formState: FormState = .incomplete
+
+    // Option 1: combineLatest for stream-based validation
+    func startStreamValidation() {
+        Task { @MainActor in
+            for await (username, email) in
+                    usernameStream.combineLatest(emailStream)
+            {
+                self.formState = validate(
+                    username: username,
+                    email: email
+                )
+            }
+        }
+    }
+
+    // Option 2: async let for simple validation
+    func validateForm() async {
+        let (username, email) = await (username, email)
+        formState = validate(
+            username: username,
+            email: email
+        )
+    }
+}
+```
+
+**Choose**:
+- `combineLatest()`: Continuous validation as fields change
+- `async let`: One-time validation when all values available
+
+---
+
+## Common Mistakes Agents Make
+
+- **Manual debounce with `Task.sleep`**: This creates multiple concurrent tasks and risks out-of-order results. Use the stream-based `debounce(for:)` operator from AsyncAlgorithms instead.
+- **Sharing `AsyncStream` across multiple consumers**: Values split unpredictably between consumers. Use `AsyncChannel` for multi-consumer scenarios with backpressure. Note: `AsyncChannel` is point-to-point, not broadcast like Combine's `.share()`.
+- **Looking for a `.flatMap` equivalent**: Use `TaskGroup` for fan-out; the semantics differ from Combine/Rx `flatMap`.
+- **Looking for `.receive(on:)` equivalent**: Use `@MainActor` or `Task` context for isolation instead.
+
+## Best Practices
+
+1. **Use time-based operators** for rapid inputs: debounce() for search, throttle() for buttons
+2. **Combine streams** with merge/combineLatest instead of manual state management
+3. **Use AsyncChannel** for multi-consumer scenarios with backpressure
+4. **Ensure Sendable conformance** when using operators across isolation boundaries
+5. **Leverage cancellation** - Task cancellation propagates through all operators
+6. **Choose right tool**: AsyncAlgorithms for complex streams, AsyncStream for bridging callbacks
+7. **Avoid manual sleep loops** - use AsyncTimerSequence instead
+
+---
+
+## Further Learning
+
+- [AsyncAlgorithms Documentation](https://github.com/apple/swift-async-algorithms)
+- [Combine Migration Guide](migration.md)
+- [Async Sequences](async-sequences.md)
+- [Tasks](tasks.md) - Task groups and structured concurrency

--- a/.agents/skills/swift-concurrency/references/async-await-basics.md
+++ b/.agents/skills/swift-concurrency/references/async-await-basics.md
@@ -1,0 +1,266 @@
+# Async/Await Basics
+
+Use this when:
+
+- You are starting fresh with async/await and need foundational patterns.
+- You are converting callback-based code to async/await.
+- You need to understand execution order and the sync-to-async bridge.
+
+Skip this file if:
+
+- You need parallel execution with task groups or `async let`. Use `tasks.md`.
+- You need stream-based async iteration. Use `async-sequences.md`.
+
+Jump to:
+
+- Function Declaration
+- Execution Order
+- Parallel Execution with async let
+- URLSession with Async/Await
+- Migration Strategy
+
+## Function Declaration
+
+Mark functions with `async` to indicate asynchronous work:
+
+```swift
+func fetchData() async -> Data {
+    // async work
+}
+
+func fetchData() async throws -> Data {
+    // async work that can fail
+}
+```
+
+**Key benefit over closures**: The compiler enforces return values. No forgotten completion handlers.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 2.1: Introduction to async/await syntax](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Calling Async Functions
+
+### From synchronous context
+
+Use `Task` to bridge from sync to async:
+
+```swift
+Task {
+    let data = try await fetchData()
+}
+```
+
+### From async context
+
+Use `await` directly:
+
+```swift
+func processData() async throws {
+    let data = try await fetchData()
+    // process data
+}
+```
+
+## Execution Order
+
+Structured concurrency executes top-to-bottom in the order you expect:
+
+```swift
+let first = try await fetchData(1)   // Waits for completion
+let second = try await fetchData(2)  // Starts after first completes
+let third = try await fetchData(3)   // Starts after second completes
+```
+
+Code after `await` only executes once the awaited function returns.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 2.2: Understanding the order of execution](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Parallel Execution with async let
+
+Use `async let` to run multiple operations concurrently:
+
+```swift
+async let data1 = fetchData(1)
+async let data2 = fetchData(2)
+async let data3 = fetchData(3)
+
+let results = try await [data1, data2, data3]
+```
+
+### How async let works
+
+- **Starts immediately**: The function executes right away, even before `await`
+- **Structured concurrency**: Automatically canceled when leaving scope
+- **Error handling**: If one fails, others are implicitly canceled when awaiting grouped results
+- **No redundant keywords**: Don't use `try await` in the `async let` line itself
+
+```swift
+// Redundant - avoid this
+async let data = try await fetchData()
+
+// Correct - errors handled at await point
+async let data = fetchData()
+let result = try await data
+```
+
+### When to use async let
+
+**Use when:**
+- Tasks don't depend on each other
+- Number of tasks known at compile-time
+- Want automatic cancellation on scope exit
+
+**Avoid when:**
+- Tasks must run sequentially
+- Need dynamic task spawning (use `TaskGroup`)
+- Need manual cancellation control
+
+### Limitations
+
+- Cannot use at top-level declarations (only within function bodies)
+- Tasks not explicitly awaited may be canceled implicitly
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 2.3: Calling async functions in parallel using async let](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## URLSession with Async/Await
+
+URLSession provides async alternatives to closure-based APIs:
+
+```swift
+// Closure-based (old)
+URLSession.shared.dataTask(with: request) { data, response, error in
+    guard let data = data, error == nil else { return }
+    // handle response
+}.resume()
+
+// Async/await (modern)
+let (data, response) = try await URLSession.shared.data(for: request)
+```
+
+### Benefits over closures
+
+- No optional `data` or `response` to unwrap
+- Automatic error throwing
+- Compiler enforces return values
+- Simpler error handling with do-catch
+
+### Complete network request pattern
+
+```swift
+func fetchUser(id: Int) async throws -> User {
+    let url = URL(string: "https://api.example.com/users/\(id)")!
+    var request = URLRequest(url: url)
+    request.httpMethod = "GET"
+    
+    let (data, response) = try await URLSession.shared.data(for: request)
+    
+    guard let httpResponse = response as? HTTPURLResponse,
+          (200...299).contains(httpResponse.statusCode) else {
+        throw NetworkError.invalidResponse
+    }
+    
+    return try JSONDecoder().decode(User.self, from: data)
+}
+```
+
+### POST requests with JSON
+
+```swift
+func createUser(_ user: User) async throws -> User {
+    let url = URL(string: "https://api.example.com/users")!
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.httpBody = try JSONEncoder().encode(user)
+    
+    let (data, response) = try await URLSession.shared.data(for: request)
+    
+    guard let httpResponse = response as? HTTPURLResponse,
+          (200...299).contains(httpResponse.statusCode) else {
+        throw NetworkError.invalidResponse
+    }
+    
+    return try JSONDecoder().decode(User.self, from: data)
+}
+```
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 2.4: Performing network requests using URLSession and async/await](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Typed Errors (Swift 6)
+
+Specify exact error types for better API contracts:
+
+```swift
+enum NetworkError: Error {
+    case invalidResponse
+    case decodingFailed(DecodingError)
+    case requestFailed(URLError)
+}
+
+func fetchData() async throws(NetworkError) -> Data {
+    do {
+        let (data, _) = try await URLSession.shared.data(from: url)
+        return data
+    } catch let error as URLError {
+        throw .requestFailed(error)
+    } catch {
+        throw .invalidResponse
+    }
+}
+```
+
+Callers know exactly which errors to handle.
+
+## Migration Strategy
+
+When converting closure-based code:
+
+1. **Add new async method alongside old one** - keeps code compiling
+2. **Update method signature** - add `async`, remove completion parameter
+3. **Replace closure calls with await** - use URLSession async APIs
+4. **Remove optional unwrapping** - async APIs return non-optional values
+5. **Simplify error handling** - use do-catch instead of nested closures
+6. **Return directly** - compiler enforces return values
+
+## Common Patterns
+
+### Sequential execution (when order matters)
+
+```swift
+let user = try await fetchUser(id: 1)
+let posts = try await fetchPosts(userId: user.id)
+let comments = try await fetchComments(postIds: posts.map(\.id))
+```
+
+### Parallel execution (when independent)
+
+```swift
+async let user = fetchUser(id: 1)
+async let settings = fetchSettings()
+async let notifications = fetchNotifications()
+
+let (userData, settingsData, notificationsData) = try await (user, settings, notifications)
+```
+
+### Mixed execution
+
+```swift
+// Fetch user first (required for next step)
+let user = try await fetchUser(id: 1)
+
+// Then fetch related data in parallel
+async let posts = fetchPosts(userId: user.id)
+async let followers = fetchFollowers(userId: user.id)
+async let following = fetchFollowing(userId: user.id)
+
+let profile = Profile(
+    user: user,
+    posts: try await posts,
+    followers: try await followers,
+    following: try await following
+)
+```
+
+## Further Learning
+
+For in-depth coverage of async/await patterns, error handling strategies, and real-world migration scenarios, see [Swift Concurrency Course](https://www.swiftconcurrencycourse.com).
+

--- a/.agents/skills/swift-concurrency/references/async-sequences.md
+++ b/.agents/skills/swift-concurrency/references/async-sequences.md
@@ -1,0 +1,710 @@
+# Async Sequences and Streams
+
+Use this when:
+
+- You need to iterate over values that arrive over time.
+- You are bridging callback-based or delegate-based APIs to async/await.
+- You need to choose between `AsyncSequence`, `AsyncStream`, or a regular async method.
+
+Skip this file if:
+
+- You need time-based operators like debounce, throttle, or merge. Use `async-algorithms.md`.
+- You are choosing between `Task`, `async let`, or task groups. Use `tasks.md`.
+
+Jump to:
+
+- AsyncSequence Protocol
+- AsyncStream / AsyncThrowingStream
+- Bridging Callbacks and Delegates
+- Stream Lifecycle and Cleanup
+- Buffer Policies
+- Standard Library Integration
+- Limitations
+- When to Use AsyncAlgorithms
+
+## AsyncSequence
+
+Protocol for asynchronous iteration over values that become available over time.
+
+### Basic usage
+
+```swift
+for await value in someAsyncSequence {
+    print(value)
+}
+```
+
+**Key difference from Sequence**: Values may not all be available immediately.
+
+### Custom implementation
+
+```swift
+struct Counter: AsyncSequence, AsyncIteratorProtocol {
+    typealias Element = Int
+    
+    let limit: Int
+    var current = 1
+    
+    mutating func next() async -> Int? {
+        guard !Task.isCancelled else { return nil }
+        guard current <= limit else { return nil }
+        
+        let result = current
+        current += 1
+        return result
+    }
+    
+    func makeAsyncIterator() -> Counter {
+        self
+    }
+}
+
+// Usage
+for await count in Counter(limit: 5) {
+    print(count) // 1, 2, 3, 4, 5
+}
+```
+
+### Standard operators
+
+Same functional operators as regular sequences:
+
+```swift
+// Filter
+for await even in Counter(limit: 5).filter({ $0 % 2 == 0 }) {
+    print(even) // 2, 4
+}
+
+// Map
+let mapped = Counter(limit: 5).map { $0 % 2 == 0 ? "Even" : "Odd" }
+for await label in mapped {
+    print(label)
+}
+
+// Contains (awaits until found or sequence ends)
+let contains = await Counter(limit: 5).contains(3) // true
+```
+
+### Termination
+
+Return `nil` from `next()` to end iteration:
+
+```swift
+mutating func next() async -> Int? {
+    guard !Task.isCancelled else {
+        return nil // Stop on cancellation
+    }
+    
+    guard current <= limit else {
+        return nil // Stop at limit
+    }
+    
+    return current
+}
+```
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 6.1: Working with asynchronous sequences](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## AsyncStream
+
+Convenient way to create async sequences without implementing protocols.
+
+### Basic creation
+
+```swift
+let stream = AsyncStream<Int> { continuation in
+    for i in 1...5 {
+        continuation.yield(i)
+    }
+    continuation.finish()
+}
+
+for await value in stream {
+    print(value)
+}
+```
+
+### AsyncThrowingStream
+
+For streams that can fail:
+
+```swift
+let throwingStream = AsyncThrowingStream<Int, Error> { continuation in
+    continuation.yield(1)
+    continuation.yield(2)
+    continuation.finish(throwing: SomeError())
+}
+
+do {
+    for try await value in throwingStream {
+        print(value)
+    }
+} catch {
+    print("Error: \(error)")
+}
+```
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 6.2: Using AsyncStream and AsyncThrowingStream in your code](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Bridging Closures to Streams
+
+### Progress + completion handlers
+
+```swift
+// Old closure-based API
+struct FileDownloader {
+    enum Status {
+        case downloading(Float)
+        case finished(Data)
+    }
+    
+    func download(
+        _ url: URL,
+        progressHandler: @escaping (Float) -> Void,
+        completion: @escaping (Result<Data, Error>) -> Void
+    ) throws {
+        // Implementation
+    }
+}
+
+// Modern stream-based API
+extension FileDownloader {
+    func download(_ url: URL) -> AsyncThrowingStream<Status, Error> {
+        AsyncThrowingStream { continuation in
+            do {
+                try self.download(url, progressHandler: { progress in
+                    continuation.yield(.downloading(progress))
+                }, completion: { result in
+                    switch result {
+                    case .success(let data):
+                        continuation.yield(.finished(data))
+                        continuation.finish()
+                    case .failure(let error):
+                        continuation.finish(throwing: error)
+                    }
+                })
+            } catch {
+                continuation.finish(throwing: error)
+            }
+        }
+    }
+}
+
+// Usage
+for try await status in downloader.download(url) {
+    switch status {
+    case .downloading(let progress):
+        print("Progress: \(progress)")
+    case .finished(let data):
+        print("Done: \(data.count) bytes")
+    }
+}
+```
+
+### Simplified with Result
+
+```swift
+AsyncThrowingStream { continuation in
+    try self.download(url, progressHandler: { progress in
+        continuation.yield(.downloading(progress))
+    }, completion: { result in
+        continuation.yield(with: result.map { .finished($0) })
+        continuation.finish()
+    })
+}
+```
+
+## Bridging Delegates
+
+### Location updates example
+
+```swift
+final class LocationMonitor: NSObject {
+    private var continuation: AsyncThrowingStream<CLLocation, Error>.Continuation?
+    let stream: AsyncThrowingStream<CLLocation, Error>
+    
+    override init() {
+        var capturedContinuation: AsyncThrowingStream<CLLocation, Error>.Continuation?
+        stream = AsyncThrowingStream { continuation in
+            capturedContinuation = continuation
+        }
+        super.init()
+        self.continuation = capturedContinuation
+        
+        locationManager.delegate = self
+        locationManager.startUpdatingLocation()
+    }
+}
+
+extension LocationMonitor: CLLocationManagerDelegate {
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        for location in locations {
+            continuation?.yield(location)
+        }
+    }
+    
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        continuation?.finish(throwing: error)
+    }
+}
+
+// Usage
+let monitor = LocationMonitor()
+for try await location in monitor.stream {
+    print("Location: \(location.coordinate)")
+}
+```
+
+## Stream Lifecycle
+
+### Termination callback
+
+```swift
+AsyncThrowingStream<Int, Error> { continuation in
+    continuation.onTermination = { @Sendable reason in
+        print("Terminated: \(reason)")
+        // Cleanup: remove observers, cancel work, etc.
+    }
+    
+    continuation.yield(1)
+    continuation.finish()
+}
+```
+
+**Termination reasons**:
+- `.finished` - Normal completion
+- `.finished(Error?)` - Completed with error (throwing stream)
+- `.cancelled` - Task canceled
+
+### Cancellation
+
+Streams cancel when:
+- Enclosing task cancels
+- Stream goes out of scope
+
+```swift
+let task = Task {
+    for try await status in download(url) {
+        print(status)
+    }
+}
+
+task.cancel() // Triggers onTermination with .cancelled
+```
+
+**No explicit cancel method** - rely on task cancellation.
+
+## Buffer Policies
+
+Control what happens to values when no one is awaiting:
+
+### .unbounded (default)
+
+Buffers all values until consumed:
+
+```swift
+let stream = AsyncStream<Int> { continuation in
+    (0...5).forEach { continuation.yield($0) }
+    continuation.finish()
+}
+
+try await Task.sleep(for: .seconds(1))
+
+for await value in stream {
+    print(value) // Prints all: 0, 1, 2, 3, 4, 5
+}
+```
+
+### .bufferingNewest(n)
+
+Keeps only the newest N values:
+
+```swift
+let stream = AsyncStream(bufferingPolicy: .bufferingNewest(1)) { continuation in
+    (0...5).forEach { continuation.yield($0) }
+    continuation.finish()
+}
+
+try await Task.sleep(for: .seconds(1))
+
+for await value in stream {
+    print(value) // Prints only: 5
+}
+```
+
+### .bufferingOldest(n)
+
+Keeps only the oldest N values:
+
+```swift
+let stream = AsyncStream(bufferingPolicy: .bufferingOldest(1)) { continuation in
+    (0...5).forEach { continuation.yield($0) }
+    continuation.finish()
+}
+
+try await Task.sleep(for: .seconds(1))
+
+for await value in stream {
+    print(value) // Prints only: 0
+}
+```
+
+### .bufferingNewest(0)
+
+Only receives values emitted after iteration starts:
+
+```swift
+let stream = AsyncStream(bufferingPolicy: .bufferingNewest(0)) { continuation in
+    continuation.yield(1) // Discarded
+    
+    Task {
+        try await Task.sleep(for: .seconds(2))
+        continuation.yield(2) // Received
+        continuation.finish()
+    }
+}
+
+try await Task.sleep(for: .seconds(1))
+
+for await value in stream {
+    print(value) // Prints only: 2
+}
+```
+
+**Use case**: Location updates, file system changes - only care about latest.
+
+## Repeated Async Calls
+
+Use `init(unfolding:onCancel:)` for polling:
+
+```swift
+struct PingService {
+    func startPinging() -> AsyncStream<Bool> {
+        AsyncStream {
+            try? await Task.sleep(for: .seconds(5))
+            return await ping()
+        } onCancel: {
+            print("Pinging cancelled")
+        }
+    }
+    
+    func ping() async -> Bool {
+        // Network request
+        return true
+    }
+}
+
+// Usage
+for await result in pingService.startPinging() {
+    print("Ping: \(result)")
+}
+```
+
+## Standard Library Integration
+
+### NotificationCenter
+
+```swift
+let stream = NotificationCenter.default.notifications(
+    named: .NSSystemTimeZoneDidChange
+)
+
+for await notification in stream {
+    print("Time zone changed")
+}
+```
+
+### Combine publishers
+
+```swift
+let numbers = [1, 2, 3, 4, 5]
+let filtered = numbers.publisher.filter { $0 % 2 == 0 }
+
+for await number in filtered.values {
+    print(number) // 2, 4
+}
+```
+
+### Task groups
+
+```swift
+await withTaskGroup(of: Image.self) { group in
+    for url in urls {
+        group.addTask { await download(url) }
+    }
+    
+    for await image in group {
+        display(image)
+    }
+}
+```
+
+## Limitations
+
+### Single consumer only
+
+Unlike Combine, streams support one consumer at a time:
+
+```swift
+let stream = AsyncStream { continuation in
+    (0...5).forEach { continuation.yield($0) }
+    continuation.finish()
+}
+
+Task {
+    for await value in stream {
+        print("Consumer 1: \(value)")
+    }
+}
+
+Task {
+    for await value in stream {
+        print("Consumer 2: \(value)")
+    }
+}
+
+// Unpredictable output - values split between consumers
+// Consumer 1: 0
+// Consumer 2: 1
+// Consumer 1: 2
+// Consumer 2: 3
+```
+
+**Solution**: Create separate streams or use third-party libraries (AsyncExtensions).
+
+### No values after termination
+
+Once finished, stream won't emit new values:
+
+```swift
+let stream = AsyncStream<Int> { continuation in
+    continuation.finish() // Terminate immediately
+    continuation.yield(1) // Never received
+}
+
+for await value in stream {
+    print(value) // Loop exits immediately
+}
+```
+
+## Decision Guide
+
+### Use AsyncSequence when:
+
+- Implementing standard library-style protocols
+- Need fine-grained control over iteration
+- Building reusable sequence types
+- Working with existing sequence protocols
+
+**Reality**: Rarely needed in application code.
+
+### Use AsyncStream when:
+
+- Bridging delegates to async/await
+- Converting closure-based APIs
+- Emitting events manually
+- Polling or repeated async operations
+- Most common use case
+
+---
+
+## When to Use AsyncAlgorithms vs Standard Library
+
+### Use AsyncAlgorithms when:
+
+- **Time-based operations** need debounce/throttle/timer
+- **Combining multiple async sequences** (merge, combineLatest, zip)
+- **Multi-consumer scenarios** require backpressure (AsyncChannel)
+- **Complex operator chains** that Combine would handle naturally
+- **Need specific operators** not in standard library
+
+### Use Standard Library when:
+
+- **Bridging callback APIs** → AsyncStream
+- **Simple iteration** → for await in sequence
+- **Single-value operations** → async/await
+- **Basic transformations** → map/filter/contains
+
+### Quick Decision Table
+
+| Need | Solution |
+|------|----------|
+| Debounce search input | ✅ AsyncAlgorithms.debounce() |
+| Throttle button clicks | ✅ AsyncAlgorithms.throttle() |
+| Merge independent streams | ✅ AsyncAlgorithms.merge() |
+| Combine dependent values | ✅ AsyncAlgorithms.combineLatest() or async let |
+| Pair values from two sources | ✅ AsyncAlgorithms.zip() |
+| Bridge callback API | AsyncStream |
+| Multi-consumer with backpressure | ✅ AsyncChannel |
+| Periodic timer | ✅ AsyncTimerSequence |
+| Simple async iteration | for await in... |
+
+> **See**: [async-algorithms.md](async-algorithms.md) for detailed usage examples with real-world patterns.
+
+### Use regular async methods when:
+
+- Single value returned
+- No progress updates needed
+- Simple request/response pattern
+
+```swift
+// Use this
+func fetchData() async throws -> Data
+
+// Not this
+func fetchData() -> AsyncThrowingStream<Data, Error>
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 6.3: Deciding between AsyncSequence, AsyncStream, or regular asynchronous methods](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+```
+
+## Common Patterns
+
+### Progress reporting
+
+```swift
+func download(_ url: URL) -> AsyncThrowingStream<DownloadEvent, Error> {
+    AsyncThrowingStream { continuation in
+        Task {
+            do {
+                var progress: Double = 0
+                while progress < 1.0 {
+                    progress += 0.1
+                    continuation.yield(.progress(progress))
+                    try await Task.sleep(for: .milliseconds(100))
+                }
+                
+                let data = try await URLSession.shared.data(from: url).0
+                continuation.yield(.completed(data))
+                continuation.finish()
+            } catch {
+                continuation.finish(throwing: error)
+            }
+        }
+    }
+}
+```
+
+### Monitoring file system
+
+```swift
+func watchDirectory(_ path: String) -> AsyncStream<FileEvent> {
+    AsyncStream(bufferingPolicy: .bufferingNewest(1)) { continuation in
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: .write,
+            queue: .main
+        )
+        
+        source.setEventHandler {
+            continuation.yield(.fileChanged(path))
+        }
+        
+        continuation.onTermination = { _ in
+            source.cancel()
+        }
+        
+        source.resume()
+    }
+}
+```
+
+### Timer/polling
+
+```swift
+func timer(interval: Duration) -> AsyncStream<Date> {
+    AsyncStream { continuation in
+        Task {
+            while !Task.isCancelled {
+                continuation.yield(Date())
+                try? await Task.sleep(for: interval)
+            }
+            continuation.finish()
+        }
+    }
+}
+
+// Usage
+for await date in timer(interval: .seconds(1)) {
+    print("Tick: \(date)")
+}
+```
+
+## Best Practices
+
+1. **Always call finish()** - Streams stay alive until terminated
+2. **Use buffer policies wisely** - Match your use case (latest value vs all values)
+3. **Handle cancellation** - Set `onTermination` for cleanup
+4. **Single consumer** - Don't share streams across multiple consumers
+5. **Prefer streams over closures** - More composable and cancellable
+6. **Check Task.isCancelled** - Respect cancellation in custom sequences
+7. **Use throwing variant** - When operations can fail
+8. **Consider regular async** - If only returning single value
+
+## Debugging
+
+### Add termination logging
+
+```swift
+continuation.onTermination = { reason in
+    print("Stream ended: \(reason)")
+}
+```
+
+### Validate finish() calls
+
+```swift
+// ❌ Forgot to finish
+AsyncStream { continuation in
+    continuation.yield(1)
+    // Stream never ends!
+}
+
+// ✅ Always finish
+AsyncStream { continuation in
+    continuation.yield(1)
+    continuation.finish()
+}
+```
+
+### Check for dropped values
+
+```swift
+let stream = AsyncStream(bufferingPolicy: .bufferingNewest(1)) { continuation in
+    for i in 1...100 {
+        continuation.yield(i)
+        print("Yielded: \(i)")
+    }
+    continuation.finish()
+}
+
+// If consumer is slow, many values dropped
+for await value in stream {
+    print("Received: \(value)")
+    try? await Task.sleep(for: .seconds(1))
+}
+```
+
+## Common Mistakes Agents Make
+
+```swift
+// ❌ Values after finish() are silently dropped
+continuation.finish()
+continuation.yield(1) // Never received
+
+// ❌ Stream never terminates (forgot finish)
+AsyncStream { continuation in
+    continuation.yield(1)
+    // Missing: continuation.finish()
+}
+
+// ❌ Wrapping a single-value API in a stream — use a regular async function instead
+func fetchUser() -> AsyncStream<User> { ... } // Overkill for one result
+```
+
+- **Sharing a single `AsyncStream` between multiple consumers**: Values split unpredictably. There is no built-in broadcast; use `AsyncChannel` for point-to-point multi-consumer patterns.
+- **Forgetting `onTermination`** when bridging delegate or observer APIs, causing resources to leak.
+
+## Further Learning
+
+For real-world migration examples, performance patterns, and advanced stream techniques, see [Swift Concurrency Course](https://www.swiftconcurrencycourse.com).
+

--- a/.agents/skills/swift-concurrency/references/core-data.md
+++ b/.agents/skills/swift-concurrency/references/core-data.md
@@ -1,0 +1,560 @@
+# Core Data and Swift Concurrency
+
+Use this when:
+
+- You need to use Core Data with async/await or actors.
+- `NSManagedObject` instances are crossing context or actor boundaries.
+- You are resolving default `@MainActor` isolation conflicts with generated NSManagedObject subclasses.
+
+Skip this file if:
+
+- The issue is general actor isolation, not Core Data specific. Use `actors.md`.
+- You need general Sendable guidance. Use `sendable.md`.
+
+Jump to:
+
+- Core Principles
+- Data Access Objects (DAO) Pattern
+- Working Without DAOs (NSManagedObjectID)
+- Bridging Closures to Async
+- Custom Actor Executor (Advanced)
+- Default MainActor Isolation
+- SwiftUI Integration
+- Common Mistakes
+
+## Core Principles
+
+### Thread safety still matters
+
+Core Data's thread safety rules don't change with Swift Concurrency:
+- Can't pass `NSManagedObject` between threads
+- Must access objects on their context's thread
+- `NSManagedObjectID` is thread-safe (can pass around)
+
+### NSManagedObject cannot be Sendable
+
+```swift
+@objc(Article)
+public class Article: NSManagedObject {
+    @NSManaged public var title: String // ❌ Mutable, can't be Sendable
+}
+```
+
+**Don't use `@unchecked Sendable`** - hides warnings without fixing safety.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 9.1: An introduction to Swift Concurrency and Core Data](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Available Async APIs
+
+### Context perform
+
+```swift
+extension NSManagedObjectContext {
+    func perform<T>(
+        schedule: ScheduledTaskType = .immediate,
+        _ block: @escaping () throws -> T
+    ) async rethrows -> T
+}
+```
+
+### What's missing
+
+No async alternative for:
+```swift
+func loadPersistentStores(
+    completionHandler: @escaping (NSPersistentStoreDescription, Error?) -> Void
+)
+```
+
+Must bridge manually (see below).
+
+## Data Access Objects (DAO)
+
+Thread-safe value types representing managed objects.
+
+### Pattern
+
+```swift
+// Managed object (not Sendable)
+@objc(Article)
+public class Article: NSManagedObject {
+    @NSManaged public var title: String?
+    @NSManaged public var timestamp: Date?
+}
+
+// DAO (Sendable)
+struct ArticleDAO: Sendable, Identifiable {
+    let id: NSManagedObjectID
+    let title: String
+    let timestamp: Date
+    
+    init?(managedObject: Article) {
+        guard let title = managedObject.title,
+              let timestamp = managedObject.timestamp else {
+            return nil
+        }
+        self.id = managedObject.objectID
+        self.title = title
+        self.timestamp = timestamp
+    }
+}
+```
+
+### Benefits
+
+- **Sendable**: Safe to pass across isolation domains
+- **Immutable**: No accidental mutations
+- **Clear API**: Explicit data transfer
+
+### Drawbacks
+
+- **Requires rewrite**: All fetch/mutation logic
+- **Boilerplate**: DAO for each entity
+- **Complexity**: Additional layer of abstraction
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 9.2: Sendable and NSManageObjects](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Working Without DAOs
+
+Pass only `NSManagedObjectID` between contexts.
+
+### Basic pattern
+
+```swift
+@MainActor
+func fetchArticle(id: NSManagedObjectID) -> Article? {
+    viewContext.object(with: id) as? Article
+}
+
+func processInBackground(articleID: NSManagedObjectID) async throws {
+    let backgroundContext = container.newBackgroundContext()
+    try await backgroundContext.perform {
+        guard let article = backgroundContext.object(with: articleID) as? Article else {
+            return
+        }
+        // Process article
+        try backgroundContext.save()
+    }
+}
+```
+
+### NSManagedObjectID is Sendable
+
+```swift
+// Safe to pass between tasks
+let articleID = article.objectID
+
+Task {
+    await processInBackground(articleID: articleID)
+}
+```
+
+## Bridging Closures to Async
+
+### Load persistent stores
+
+```swift
+extension NSPersistentContainer {
+    func loadPersistentStores() async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            self.loadPersistentStores { description, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: ())
+                }
+            }
+        }
+    }
+}
+
+// Usage
+try await container.loadPersistentStores()
+```
+
+## Simple CoreDataStore Pattern
+
+Enforce isolation at API level:
+
+```swift
+nonisolated struct CoreDataStore {
+    static let shared = CoreDataStore()
+    
+    let persistentContainer: NSPersistentContainer
+    private var viewContext: NSManagedObjectContext {
+        persistentContainer.viewContext
+    }
+    
+    private init() {
+        persistentContainer = NSPersistentContainer(name: "MyApp")
+        persistentContainer.viewContext.automaticallyMergesChangesFromParent = true
+        
+        Task { [persistentContainer] in
+            try? await persistentContainer.loadPersistentStores()
+        }
+    }
+    
+    // View context operations (main thread)
+    @MainActor
+    func perform(_ block: (NSManagedObjectContext) throws -> Void) rethrows {
+        try block(viewContext)
+    }
+    
+    // Background operations
+    @concurrent
+    func performInBackground<T>(
+        _ block: @escaping (NSManagedObjectContext) throws -> T
+    ) async rethrows -> T {
+        let context = persistentContainer.newBackgroundContext()
+        return try await context.perform {
+            try block(context)
+        }
+    }
+}
+```
+
+### Usage
+
+```swift
+// Main thread operations
+@MainActor
+func loadArticles() throws -> [Article] {
+    try CoreDataStore.shared.perform { context in
+        let request = Article.fetchRequest()
+        return try context.fetch(request)
+    }
+}
+
+// Background operations
+func deleteAll() async throws {
+    try await CoreDataStore.shared.performInBackground { context in
+        let request = Article.fetchRequest()
+        let articles = try context.fetch(request)
+        articles.forEach { context.delete($0) }
+        try context.save()
+    }
+}
+```
+
+### Why this pattern works
+
+- **@MainActor**: Enforces view context on main thread
+- **@concurrent**: Forces background execution
+- **Compile-time safety**: Wrong isolation = error
+- **Simple**: No custom executors needed
+
+## Custom Actor Executor (Advanced)
+
+**Note**: Usually not needed. Consider simple pattern first.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 9.3: Using a custom Actor executor for Core Data (advanced)](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+### Implementation
+
+```swift
+final class NSManagedObjectContextExecutor: @unchecked Sendable, SerialExecutor {
+    private let context: NSManagedObjectContext
+    
+    init(context: NSManagedObjectContext) {
+        self.context = context
+    }
+    
+    func enqueue(_ job: consuming ExecutorJob) {
+        let unownedJob = UnownedJob(job)
+        let executor = asUnownedSerialExecutor()
+        
+        context.perform {
+            unownedJob.runSynchronously(on: executor)
+        }
+    }
+    
+    func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+        UnownedSerialExecutor(ordinary: self)
+    }
+}
+```
+
+### Actor usage
+
+```swift
+actor CoreDataStore {
+    let persistentContainer: NSPersistentContainer
+    nonisolated let modelExecutor: NSManagedObjectContextExecutor
+    
+    nonisolated var unownedExecutor: UnownedSerialExecutor {
+        modelExecutor.asUnownedSerialExecutor()
+    }
+    
+    private init() {
+        persistentContainer = NSPersistentContainer(name: "MyApp")
+        let context = persistentContainer.newBackgroundContext()
+        modelExecutor = NSManagedObjectContextExecutor(context: context)
+    }
+    
+    func deleteAll<T: NSManagedObject>(
+        using request: NSFetchRequest<T>
+    ) throws {
+        let objects = try context.fetch(request)
+        objects.forEach { context.delete($0) }
+        try context.save()
+    }
+}
+```
+
+### Drawbacks
+
+- **Hidden complexity**: Executor details obscure Core Data
+- **Forces concurrency**: Even for main thread operations
+- **Not simpler**: More code than `perform { }`
+- **Error prone**: Easy to use wrong context
+
+**Recommendation**: Use simple pattern instead.
+
+## Default MainActor Isolation
+
+### Problem with auto-generated code
+
+When default isolation set to `@MainActor`, auto-generated managed objects conflict:
+
+```swift
+// Auto-generated (can't modify)
+class Article: NSManagedObject {
+    // Inherits @MainActor, conflicts with NSManagedObject
+}
+```
+
+**Error**: `Main actor-isolated initializer has different actor isolation from nonisolated overridden declaration`
+
+### Solution: Manual code generation
+
+1. Set entity to "Manual/None" code generation
+2. Generate class definitions
+3. Mark as `nonisolated`:
+
+```swift
+nonisolated class Article: NSManagedObject {
+    @NSManaged public var title: String?
+    @NSManaged public var timestamp: Date?
+}
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 9.4: Autogenerated Core Data Objects and Default MainActor Isolation Conflicts](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+```
+
+**Benefit**: Full control over isolation.
+
+## Common Patterns
+
+### Fetch on main thread
+
+```swift
+@MainActor
+func fetchArticles() throws -> [Article] {
+    let request = Article.fetchRequest()
+    return try viewContext.fetch(request)
+}
+```
+
+### Background save
+
+```swift
+func saveInBackground() async throws {
+    let context = container.newBackgroundContext()
+    try await context.perform {
+        let article = Article(context: context)
+        article.title = "New Article"
+        try context.save()
+    }
+}
+```
+
+### Pass ID, fetch in context
+
+```swift
+@MainActor
+func displayArticle(id: NSManagedObjectID) {
+    guard let article = viewContext.object(with: id) as? Article else {
+        return
+    }
+    // Use article
+}
+
+func processArticle(id: NSManagedObjectID) async throws {
+    try await CoreDataStore.shared.performInBackground { context in
+        guard let article = context.object(with: id) as? Article else {
+            return
+        }
+        // Process article
+        try context.save()
+    }
+}
+```
+
+### Batch operations
+
+```swift
+@concurrent
+func deleteAllArticles() async throws {
+    try await CoreDataStore.shared.performInBackground { context in
+        let request = NSFetchRequest<NSFetchRequestResult>(entityName: "Article")
+        let deleteRequest = NSBatchDeleteRequest(fetchRequest: request)
+        try context.execute(deleteRequest)
+    }
+}
+```
+
+## SwiftUI Integration
+
+### Environment injection
+
+```swift
+@main
+struct MyApp: App {
+    let persistentContainer = NSPersistentContainer(name: "MyApp")
+    
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environment(\.managedObjectContext, persistentContainer.viewContext)
+        }
+    }
+}
+```
+
+### View usage
+
+```swift
+struct ContentView: View {
+    @Environment(\.managedObjectContext) private var viewContext
+    @FetchRequest(
+        sortDescriptors: [NSSortDescriptor(keyPath: \Article.timestamp, ascending: true)]
+    ) private var articles: FetchedResults<Article>
+    
+    var body: some View {
+        List(articles) { article in
+            Text(article.title ?? "")
+        }
+    }
+}
+```
+
+## Best Practices
+
+1. **Pass NSManagedObjectID only** - never managed objects
+2. **Use perform { }** - don't access context directly
+3. **@MainActor for view context** - enforce main thread
+4. **@concurrent for background** - force background execution
+5. **Manual code generation** - control isolation
+6. **Keep it simple** - avoid custom executors unless needed
+7. **Enable Core Data debugging** - catch thread violations
+8. **Merge changes automatically** - `automaticallyMergesChangesFromParent = true`
+9. **Use background contexts** - for heavy operations
+10. **Test with Thread Sanitizer** - catch violations early
+
+## Debugging
+
+### Enable Core Data concurrency debugging
+
+```swift
+// Launch argument
+-com.apple.CoreData.ConcurrencyDebug 1
+```
+
+Crashes immediately on thread violations.
+
+### Thread Sanitizer
+
+Enable in scheme settings to catch data races.
+
+### Assertions
+
+```swift
+@MainActor
+func fetchArticles() -> [Article] {
+    assert(Thread.isMainThread)
+    // Fetch from viewContext
+}
+```
+
+## Decision Tree
+
+```
+Need to access Core Data?
+├─ UI/View context?
+│  └─ Use @MainActor + viewContext
+│
+├─ Background operation?
+│  ├─ Quick operation? → perform { } on background context
+│  └─ Batch operation? → NSBatchDeleteRequest/NSBatchUpdateRequest
+│
+├─ Pass between contexts?
+│  └─ Use NSManagedObjectID only
+│
+└─ Need Sendable type?
+   ├─ Can refactor? → Use DAO pattern
+   └─ Can't refactor? → Pass NSManagedObjectID
+```
+
+## Migration Strategy
+
+### For existing projects
+
+1. **Enable manual code generation** for all entities
+2. **Mark entities as nonisolated** if using default @MainActor
+3. **Wrap Core Data access** in CoreDataStore
+4. **Use @MainActor** for view context operations
+5. **Use @concurrent** for background operations
+6. **Pass NSManagedObjectID** between contexts
+7. **Test with debugging enabled**
+
+### For new projects
+
+1. **Start with simple pattern** (CoreDataStore)
+2. **Manual code generation** from the start
+3. **Consider DAOs** if heavy cross-context usage
+4. **Enable strict concurrency** early
+
+## Common Mistakes
+
+### ❌ Passing managed objects
+
+```swift
+func process(article: Article) async {
+    // ❌ Article not Sendable
+}
+```
+
+### ❌ Accessing context from wrong thread
+
+```swift
+func background() async {
+    let articles = viewContext.fetch(request) // ❌ Not on main thread
+}
+```
+
+### ❌ Using @unchecked Sendable
+
+```swift
+extension Article: @unchecked Sendable {} // ❌ Doesn't make it safe
+```
+
+### ❌ Not using perform
+
+```swift
+func save() async {
+    backgroundContext.save() // ❌ Not on context's thread
+}
+```
+
+## Common Mistakes Agents Make
+
+- **Passing `NSManagedObject` instances across actors**: Always transfer `NSManagedObjectID` or a Sendable value snapshot instead.
+- **Using `@unchecked Sendable` on `NSManagedObject`**: This does not make it thread-safe. The object is still bound to its context's queue.
+- **Skipping `perform { }`**: All background context access must go through `perform` or `performAndWait`.
+- **Accessing `viewContext` from a background task**: The view context belongs to the main actor; access it only from `@MainActor`-isolated code.
+
+## Further Learning
+
+For Core Data best practices, migration strategies, and advanced patterns:
+- [Core Data Best Practices](https://github.com/avanderlee/CoreDataBestPractices)
+- [Swift Concurrency Course](https://www.swiftconcurrencycourse.com)
+

--- a/.agents/skills/swift-concurrency/references/glossary.md
+++ b/.agents/skills/swift-concurrency/references/glossary.md
@@ -1,0 +1,135 @@
+# Glossary
+
+Use this when:
+
+- You need a quick definition of a Swift Concurrency term.
+- You encounter unfamiliar terminology in other reference files.
+
+Skip this file if:
+
+- You need implementation patterns, not definitions. Use the relevant reference file instead.
+
+## Actor isolation
+
+A rule enforced by the compiler: actor-isolated state can only be accessed from the actor's executor. Cross-actor access requires `await`.
+
+## Global actor
+
+A shared isolation domain applied via attributes like `@MainActor` or a custom `@globalActor`. Types/functions isolated to the same global actor can interact without crossing isolation.
+
+## Default actor isolation
+
+A module/target-level setting that changes the default isolation of declarations. App targets often choose `@MainActor` as the default to reduce migration noise, but it changes behavior and diagnostics.
+
+## Strict concurrency checking
+
+Compiler enforcement levels for Sendable and isolation diagnostics (minimal/targeted/complete). Raising the level typically reveals more issues and can trigger the “concurrency rabbit hole” unless migrated incrementally.
+
+## Sendable
+
+A marker protocol that indicates a type is safe to transfer across isolation boundaries. The compiler verifies stored properties and captured values for thread-safety.
+
+## @Sendable
+
+An annotation for function types/closures that can be executed concurrently. It tightens capture rules (captured values must be Sendable or safely transferred).
+
+## Suspension point
+
+An `await` site where a task may suspend and later resume. After a suspension point, you must assume other work may have run and (for actors) state may have changed (reentrancy).
+
+## Reentrancy (actors)
+
+While an actor is suspended at an `await`, other tasks can enter the actor and mutate state. Code after `await` must not assume actor state is unchanged.
+
+## nonisolated
+
+Marks a declaration as not isolated to the surrounding actor/global actor. Use only when it truly does not touch isolated mutable state (typically immutable Sendable data).
+
+## nonisolated(nonsending) (Swift 6.2+ behavior)
+
+An opt-out to prevent “sending” non-Sendable values across isolation while still allowing an async function to run in the caller’s isolation. Used to reduce Sendable friction when you do not need to hop executors.
+
+## @concurrent (Swift 6.2+ behavior)
+
+An attribute used to explicitly opt a nonisolated async function into concurrent execution (i.e., not inheriting the caller’s actor). It is used during migration when enabling `NonisolatedNonsendingByDefault`.
+
+## @preconcurrency
+
+An annotation used to suppress Sendable-related diagnostics from a module that predates concurrency annotations. It reduces noise but shifts safety responsibility to you.
+
+## Region-based isolation / sending
+
+Mechanisms that model ownership transfer so certain non-Sendable values can be moved between regions safely. The `sending` keyword enforces that a value is no longer used after transfer.
+
+## AsyncSequence
+
+A protocol for types that provide asynchronous, sequential iteration over elements. Conforms to the `for await` loop pattern. Use for streaming data where elements arrive over time.
+
+## AsyncStream
+
+A concrete implementation of `AsyncSequence` that bridges callback-based or delegate-based APIs to async/await. Provides `yield()` to emit values and `finish()` to complete the stream.
+
+## Continuation
+
+A mechanism to bridge callback-based APIs to async/await. `withCheckedContinuation` and `withCheckedThrowingContinuation` provide safe bridging with runtime checks. `withUnsafeContinuation` variants skip checks for performance-critical code.
+
+## Task Local
+
+Task-scoped storage that propagates values through the task hierarchy automatically. Declared with `@TaskLocal` and accessed via the wrapper's static property. Child tasks inherit parent task locals.
+
+## Cooperative thread pool
+
+Swift's threading model where tasks run on a limited pool of threads managed by the runtime. Tasks yield cooperatively at suspension points, allowing other tasks to run. Avoid blocking operations that would starve the pool.
+
+## Executor
+
+The scheduling mechanism that determines where and when actor code runs. `MainActor` uses the main thread executor. Custom actors use the default executor unless a custom executor is specified.
+
+## Structured concurrency
+
+A pattern where child tasks have a well-defined relationship to parent tasks. Child tasks must complete before the parent scope exits. Provides automatic cancellation propagation and prevents orphaned tasks. Implemented via `async let` and `TaskGroup`.
+
+## Isolation domain
+
+A boundary that protects mutable state from concurrent access. Each actor instance defines its own isolation domain. The `@MainActor` global actor defines a shared isolation domain for UI work. Code must cross isolation boundaries explicitly via `await`.
+
+## Task priority
+
+A hint to the runtime about the relative importance of a task. Priorities include `.high`, `.medium`, `.low`, `.userInitiated`, `.utility`, and `.background`. Higher priority tasks are scheduled before lower priority ones. Priority can escalate when a high-priority task awaits a low-priority one.
+
+## Cancellation
+
+A cooperative mechanism to signal that a task should stop. Check `Task.isCancelled` or call `Task.checkCancellation()` (throws) in long-running work. Cancellation propagates to child tasks in structured concurrency.
+
+## Debounce
+
+Wait for a period of inactivity before emitting a value. Used to reduce API calls for rapid inputs like search fields. Implemented as `debounce(for:tolerance:clock:)` in AsyncAlgorithms.
+
+## Throttle
+
+Emit at most one value per time interval, discarding intermediate values. Used to prevent excessive calls from repeated actions like button taps. Implemented as `throttle(for:clock:reducing:)` in AsyncAlgorithms.
+
+## Merge (AsyncAlgorithms)
+
+Combine multiple asynchronous sequences into one, emitting values as they arrive from any source. Order is interleaved based on emission timing. Stable operator.
+
+## CombineLatest (AsyncAlgorithms)
+
+Combine multiple asynchronous sequences, emitting a tuple whenever any source emits a new value. Always uses the latest value from each sequence. Stable operator.
+
+## Zip (AsyncAlgorithms)
+
+Combine multiple asynchronous sequences by pairing elements in order. Waits for all sequences to emit before producing a tuple. Stable operator.
+
+## AsyncChannel
+
+An AsyncSequence with backpressure sending semantics. Allows multiple producers to send values safely to multiple consumers with flow control. Stable operator.
+
+## AsyncThrowingChannel
+
+Like AsyncChannel but can emit errors through the stream. Stable operator.
+
+## AsyncTimerSequence
+
+An AsyncSequence that emits a value at regular intervals. Replaces timer-based publishers and manual sleep loops. Stable operator.
+

--- a/.agents/skills/swift-concurrency/references/linting.md
+++ b/.agents/skills/swift-concurrency/references/linting.md
@@ -1,0 +1,155 @@
+# Linting & Concurrency
+
+Use this when:
+
+- SwiftLint flags `async_without_await` or other concurrency-related warnings.
+- You need to decide whether to suppress, fix, or reconfigure a concurrency lint rule.
+
+Skip this file if:
+
+- The issue is a compiler diagnostic, not a lint rule. Use `actors.md`, `sendable.md`, or `threading.md`.
+
+Jump to:
+
+- SwiftLint Concurrency Rules Overview
+- `async_without_await` Rule
+- Suppression Strategies
+
+## SwiftLint Concurrency Rules Overview
+
+SwiftLint provides several rules targeting async/await and concurrency patterns. Understanding when to fix vs. suppress is critical.
+
+| Rule | Default | Purpose |
+|------|---------|---------|
+| `async_without_await` | warning | Flags `async` functions that never await |
+| `unowned_variable_capture` | warning | Warns about `unowned` in closures (risky in async) |
+| `class_delegate_protocol` | warning | Ensures delegates are class-bound (AnyObject) |
+| `weak_delegate` | warning | Delegates should be weak to avoid retain cycles |
+
+## SwiftLint: `async_without_await`
+
+- **Intent**: A declaration should not be `async` if it never awaits.
+- **Never "fix"** by inserting fake suspension (e.g. `await Task.yield()`, `await Task { ... }.value`). Those mask the real issue and add meaningless suspension points.
+- **Legit use of `Task.yield()`**: OK in tests or scheduling control when you truly need a yield; not as a lint workaround.
+
+### Diagnose why the declaration is `async`
+1) **Protocol requirement** — the protocol method/property is `async`.
+2) **Override requirement** — base class API is `async`.
+3) **`@concurrent` requirement** — stays `async` even without `await`.
+4) **Accidental/legacy `async`** — no caller needs async semantics.
+
+### Preferred fixes (order)
+1) **Remove `async`** (and adjust call sites) when no async semantics are needed.
+2) If `async` is required (protocol/override/@concurrent):
+   - Re-evaluate the upstream API if you own it (can it be non-async?).
+   - If you cannot change it, keep `async` and **narrowly suppress the rule** where appropriate (common for mocks/stubs/overrides).
+
+### Suppression examples (keep scope tight)
+```swift
+// swiftlint:disable:next async_without_await
+func fetch() async { perform() }
+
+// For a block:
+// swiftlint:disable async_without_await
+func makeMock() async { perform() }
+// swiftlint:enable async_without_await
+```
+
+### Quick checklist
+- [ ] Confirm if `async` is truly required (protocol/override/@concurrent).
+- [ ] If not required, remove `async` and update callers.
+- [ ] If required, prefer localized suppression over dummy awaits.
+- [ ] Avoid adding new suspension points without intent.
+
+## Compiler Warnings: Sendable & Isolation
+
+The Swift compiler generates concurrency-related warnings based on strict concurrency checking level.
+
+### Common Warning Patterns
+
+**"Capture of non-sendable type"**
+```swift
+// Warning: Capture of 'self' with non-sendable type 'MyClass' in a `@Sendable` closure
+Task {
+    self.doWork() // 'self' is non-Sendable
+}
+```
+
+**Fixes (in order of preference):**
+1. Make the type `Sendable` if it's truly thread-safe
+2. Use `@MainActor` isolation if it's UI-related
+3. Capture only Sendable values instead of `self`
+4. Use `@unchecked Sendable` with documented safety invariant (last resort)
+
+**"Non-sendable result returned"**
+```swift
+// Warning: Non-sendable type 'MyResult' returned by implicitly async call
+let result = await actor.getData() // Returns non-Sendable type
+```
+
+**Fixes:**
+1. Make the return type Sendable
+2. Return Sendable projections (IDs, copies of data)
+3. Keep processing within the actor's isolation
+
+### Actor Isolation Warnings
+
+**"Main actor-isolated property accessed from non-isolated context"**
+```swift
+// Warning: Main actor-isolated property 'title' cannot be referenced from a non-isolated context
+func updateTitle() {
+    viewModel.title = "New" // viewModel is @MainActor
+}
+```
+
+**Fixes:**
+1. Mark the calling function `@MainActor`
+2. Use `await MainActor.run { }` for one-off access
+3. Reconsider if the property truly needs @MainActor isolation
+
+## Suppression Strategies
+
+### When to Suppress vs. Fix
+
+**Fix when:**
+- The warning identifies a real data race risk
+- The fix is straightforward (add Sendable, adjust isolation)
+- The code is new or actively maintained
+
+**Suppress when:**
+- Protocol/inheritance requires the signature
+- Third-party code forces the pattern
+- Migration is in progress (with tracked ticket)
+
+### Suppression Annotations
+
+```swift
+// Suppress Sendable warnings for legacy imports
+@preconcurrency import LegacyFramework
+
+// Suppress for a single declaration
+nonisolated(unsafe) var legacyCallback: (() -> Void)?
+
+// Type-level suppression (use sparingly)
+struct LegacyWrapper: @unchecked Sendable {
+    // Document why this is safe
+    private let lock = NSLock()
+    private var value: Int
+}
+```
+
+### Documentation Requirements
+
+When using suppression annotations, document:
+1. **Why** the suppression is needed
+2. **What** invariant makes it safe
+3. **When** it can be removed (link to migration ticket)
+
+```swift
+/// Thread-safe: Internal lock protects all mutations.
+/// TODO: Remove @unchecked when migrated to actor (JIRA-1234)
+final class ThreadSafeCache: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String: Data] = [:]
+}
+```

--- a/.agents/skills/swift-concurrency/references/memory-management.md
+++ b/.agents/skills/swift-concurrency/references/memory-management.md
@@ -1,0 +1,569 @@
+# Memory Management
+
+Use this when:
+
+- A task or async sequence is keeping objects alive longer than expected.
+- You suspect a retain cycle between a task and its owner.
+- You need to verify deallocation behavior or use `isolated deinit`.
+
+Skip this file if:
+
+- You mainly need to protect mutable state from races. Use `actors.md`.
+- You are debugging slow async code. Use `performance.md`.
+
+Jump to:
+
+- Core Concepts (Task Capture)
+- Retain Cycles
+- One-Way Retention
+- Async Sequences and Retention
+- Isolated Deinit (Swift 6.2+)
+- Detection and Testing
+- Common Patterns
+
+## Core Concepts
+
+### Tasks capture like closures
+
+Tasks capture variables and references just like regular closures. Swift doesn't automatically prevent retain cycles in concurrent code.
+
+```swift
+Task {
+    self.doWork() // ⚠️ Strong capture of self
+}
+```
+
+### Why concurrency hides memory issues
+
+- Tasks may live longer than expected
+- Async operations delay execution
+- Harder to track when memory should be released
+- Long-running tasks can hold references indefinitely
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 8.1: Overview of memory management in Swift Concurrency](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Retain Cycles
+
+### What is a retain cycle?
+
+Two or more objects hold strong references to each other, preventing deallocation.
+
+```swift
+class A {
+    var b: B?
+}
+
+class B {
+    var a: A?
+}
+
+let a = A()
+let b = B()
+a.b = b
+b.a = a // Retain cycle - neither can be deallocated
+```
+
+### Retain cycles with Tasks
+
+When task captures `self` strongly and `self` owns the task:
+
+```swift
+@MainActor
+final class ImageLoader {
+    var task: Task<Void, Never>?
+    
+    func startPolling() {
+        task = Task {
+            while true {
+                self.pollImages() // ⚠️ Strong capture
+                try? await Task.sleep(for: .seconds(1))
+            }
+        }
+    }
+}
+
+var loader: ImageLoader? = .init()
+loader?.startPolling()
+loader = nil // ⚠️ Loader never deallocated - retain cycle!
+```
+
+**Problem**: Task holds `self`, `self` holds task → neither released.
+
+## Breaking Retain Cycles
+
+### Use weak self
+
+```swift
+func startPolling() {
+    task = Task { [weak self] in
+        while let self = self {
+            self.pollImages()
+            try? await Task.sleep(for: .seconds(1))
+        }
+    }
+}
+
+var loader: ImageLoader? = .init()
+loader?.startPolling()
+loader = nil // ✅ Loader deallocated, task stops
+```
+
+### Pattern for long-running tasks
+
+```swift
+task = Task { [weak self] in
+    while let self = self {
+        await self.doWork()
+        try? await Task.sleep(for: interval)
+    }
+}
+```
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 8.2: Preventing retain cycles when using Tasks](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+Loop exits when `self` becomes `nil`.
+
+## One-Way Retention
+
+Task retains `self`, but `self` doesn't retain task. Object stays alive until task completes.
+
+```swift
+@MainActor
+final class ViewModel {
+    func fetchData() {
+        Task {
+            await performRequest()
+            updateUI() // ⚠️ Strong capture
+        }
+    }
+}
+
+var viewModel: ViewModel? = .init()
+viewModel?.fetchData()
+viewModel = nil // ViewModel stays alive until task completes
+```
+
+**Execution order**:
+1. Task starts
+2. `viewModel = nil` (but object not deallocated)
+3. Task completes
+4. ViewModel finally deallocated
+
+### When one-way retention is acceptable
+
+Short-lived tasks that complete quickly:
+
+```swift
+func saveData() {
+    Task {
+        await database.save(self.data) // OK - completes quickly
+    }
+}
+```
+
+### When to use weak self
+
+Long-running or indefinite tasks:
+
+```swift
+func startMonitoring() {
+    Task { [weak self] in
+        for await event in eventStream {
+            self?.handle(event)
+        }
+    }
+}
+```
+
+## Async Sequences and Retention
+
+### Problem: Infinite sequences
+
+```swift
+@MainActor
+final class AppLifecycleViewModel {
+    private(set) var isActive = false
+    private var task: Task<Void, Never>?
+    
+    func startObserving() {
+        task = Task {
+            for await _ in NotificationCenter.default.notifications(
+                named: .didBecomeActive
+            ) {
+                isActive = true // ⚠️ Strong capture, never ends
+            }
+        }
+    }
+}
+
+var viewModel: AppLifecycleViewModel? = .init()
+viewModel?.startObserving()
+viewModel = nil // ⚠️ Never deallocated - sequence continues
+```
+
+**Problem**: Async sequence never finishes, task holds `self` indefinitely.
+
+### Solution 1: Manual cancellation
+
+```swift
+func startObserving() {
+    task = Task {
+        for await _ in NotificationCenter.default.notifications(
+            named: .didBecomeActive
+        ) {
+            isActive = true
+        }
+    }
+}
+
+func stopObserving() {
+    task?.cancel()
+}
+
+// Usage
+viewModel?.startObserving()
+viewModel?.stopObserving() // Must call before release
+viewModel = nil
+```
+
+### Solution 2: Weak self with guard
+
+```swift
+func startObserving() {
+    task = Task { [weak self] in
+        for await _ in NotificationCenter.default.notifications(
+            named: .didBecomeActive
+        ) {
+            guard let self = self else { return }
+            self.isActive = true
+        }
+    }
+}
+```
+
+Task exits when `self` deallocates.
+
+## Isolated deinit (Swift 6.2+)
+
+Clean up actor-isolated state in deinit:
+
+```swift
+@MainActor
+final class ViewModel {
+    private var task: Task<Void, Never>?
+    
+    isolated deinit {
+        task?.cancel()
+    }
+}
+```
+
+**Limitation**: Won't break retain cycles (deinit never called if cycle exists).
+
+**Use for**: Cleanup when object is being deallocated normally.
+
+## Common Patterns
+
+### Short-lived task (strong capture OK)
+
+```swift
+func saveData() {
+    Task {
+        await database.save(self.data)
+        self.updateUI()
+    }
+}
+```
+
+**When safe**: Task completes quickly, acceptable for object to live until done.
+
+### Long-running task (weak self required)
+
+```swift
+func startPolling() {
+    task = Task { [weak self] in
+        while let self = self {
+            await self.fetchUpdates()
+            try? await Task.sleep(for: .seconds(5))
+        }
+    }
+}
+```
+
+### Async sequence monitoring (weak self + guard)
+
+```swift
+func startMonitoring() {
+    task = Task { [weak self] in
+        for await event in eventStream {
+            guard let self = self else { return }
+            self.handle(event)
+        }
+    }
+}
+```
+
+### Cancellable work with cleanup
+
+```swift
+func startWork() {
+    task = Task { [weak self] in
+        defer { self?.cleanup() }
+        
+        while let self = self {
+            await self.doWork()
+            try? await Task.sleep(for: .seconds(1))
+        }
+    }
+}
+```
+
+## Detection Strategies
+
+### Add deinit logging
+
+```swift
+deinit {
+    print("✅ \(type(of: self)) deallocated")
+}
+```
+
+If deinit never prints → likely retain cycle.
+
+### Memory graph debugger
+
+1. Run app in Xcode
+2. Debug → Debug Memory Graph
+3. Look for cycles in object graph
+
+### Instruments
+
+Use Leaks instrument to detect retain cycles at runtime.
+
+## Decision Tree
+
+```
+Task captures self?
+├─ Task completes quickly?
+│  └─ Strong capture OK
+│
+├─ Long-running or infinite?
+│  ├─ Can use weak self? → Use [weak self]
+│  ├─ Need manual control? → Store task, cancel explicitly
+│  └─ Async sequence? → [weak self] + guard
+│
+└─ Self owns task?
+   ├─ Yes → High risk of retain cycle
+   └─ No → Lower risk, but check lifetime
+```
+
+## Best Practices
+
+1. **Default to weak self** for long-running tasks
+2. **Use guard let self** in async sequences
+3. **Cancel tasks explicitly** when possible
+4. **Add deinit logging** during development
+5. **Test object deallocation** in unit tests
+6. **Use Memory Graph** to verify no cycles
+7. **Document lifetime expectations** in comments
+8. **Prefer cancellation** over weak self when possible
+9. **Avoid nested strong captures** in task closures
+10. **Use isolated deinit** for cleanup (Swift 6.2+)
+
+## Testing for Leaks
+
+### Unit test pattern
+
+```swift
+func testViewModelDeallocates() async {
+    var viewModel: ViewModel? = ViewModel()
+    weak var weakViewModel = viewModel
+    
+    viewModel?.startWork()
+    viewModel = nil
+    
+    // Give tasks time to complete
+    try? await Task.sleep(for: .milliseconds(100))
+    
+    XCTAssertNil(weakViewModel, "ViewModel should be deallocated")
+}
+```
+
+### SwiftUI view test
+
+```swift
+func testViewDeallocates() {
+    var view: MyView? = MyView()
+    weak var weakView = view
+    
+    view = nil
+    
+    XCTAssertNil(weakView)
+}
+```
+
+## Common Mistakes
+
+### ❌ Forgetting weak self in loops
+
+```swift
+Task {
+    while true {
+        self.poll() // Retain cycle
+        try? await Task.sleep(for: .seconds(1))
+    }
+}
+```
+
+### ❌ Strong capture in async sequences
+
+```swift
+Task {
+    for await item in stream {
+        self.process(item) // May never release
+    }
+}
+```
+
+### ❌ Not canceling stored tasks
+
+```swift
+class Manager {
+    var task: Task<Void, Never>?
+    
+    func start() {
+        task = Task {
+            await self.work() // Retain cycle
+        }
+    }
+    
+    // Missing: deinit { task?.cancel() }
+}
+```
+
+### ❌ Assuming deinit breaks cycles
+
+```swift
+deinit {
+    task?.cancel() // Never called if retain cycle exists
+}
+```
+
+## Examples by Use Case
+
+### Polling service
+
+```swift
+final class PollingService {
+    private var task: Task<Void, Never>?
+    
+    func start() {
+        task = Task { [weak self] in
+            while let self = self {
+                await self.poll()
+                try? await Task.sleep(for: .seconds(5))
+            }
+        }
+    }
+    
+    func stop() {
+        task?.cancel()
+    }
+}
+```
+
+### Notification observer
+
+```swift
+@MainActor
+final class NotificationObserver {
+    private var task: Task<Void, Never>?
+    
+    func startObserving() {
+        task = Task { [weak self] in
+            for await notification in NotificationCenter.default.notifications(
+                named: .someNotification
+            ) {
+                guard let self = self else { return }
+                self.handle(notification)
+            }
+        }
+    }
+    
+    isolated deinit {
+        task?.cancel()
+    }
+}
+```
+
+### Download manager
+
+```swift
+final class DownloadManager {
+    private var tasks: [URL: Task<Data, Error>] = [:]
+    
+    func download(_ url: URL) async throws -> Data {
+        let task = Task { [weak self] in
+            defer { self?.tasks.removeValue(forKey: url) }
+            return try await URLSession.shared.data(from: url).0
+        }
+        
+        tasks[url] = task
+        return try await task.value
+    }
+    
+    func cancelAll() {
+        tasks.values.forEach { $0.cancel() }
+        tasks.removeAll()
+    }
+}
+```
+
+### Timer
+
+```swift
+actor Timer {
+    private var task: Task<Void, Never>?
+    
+    func start(interval: Duration, action: @Sendable () async -> Void) {
+        task = Task {
+            while !Task.isCancelled {
+                await action()
+                try? await Task.sleep(for: interval)
+            }
+        }
+    }
+    
+    func stop() {
+        task?.cancel()
+    }
+}
+```
+
+## Common Mistakes Agents Make
+
+- **Forgetting `[weak self]` in stored tasks**: When `self` owns the task and the task captures `self`, a retain cycle prevents deallocation.
+- **Strong capture in infinite `AsyncSequence` loops**: `for await` over an infinite sequence with a strong `self` capture keeps the object alive forever.
+- **Not cancelling stored tasks on cleanup**: If the task outlives its owner, it retains captured objects indefinitely.
+- **Assuming `isolated deinit` breaks retain cycles**: `isolated deinit` runs cleanup on the correct actor, but if a cycle prevents `deinit` from being called at all, the cleanup never executes.
+- **Using `try?` in loops with `Task.sleep`**: `try?` can swallow `CancellationError`, causing the loop to continue running after cancellation. Always check `Task.isCancelled` explicitly.
+
+## Debugging Checklist
+
+When object won't deallocate:
+
+- [ ] Check for strong self captures in tasks
+- [ ] Verify tasks are canceled or complete
+- [ ] Look for infinite loops or sequences
+- [ ] Check if self owns the task
+- [ ] Use Memory Graph to find cycles
+- [ ] Add deinit logging to verify
+- [ ] Test with weak references
+- [ ] Review async sequence usage
+- [ ] Check nested task captures
+- [ ] Verify cleanup in deinit
+
+## Further Learning
+
+For migration strategies, real-world examples, and advanced memory patterns, see [Swift Concurrency Course](https://www.swiftconcurrencycourse.com).
+

--- a/.agents/skills/swift-concurrency/references/migration.md
+++ b/.agents/skills/swift-concurrency/references/migration.md
@@ -1,0 +1,1104 @@
+# Migration to Swift 6 and Strict Concurrency
+
+Use this when:
+
+- You are moving an existing codebase toward Swift 6 or stricter concurrency checking.
+- Compiler diagnostics depend on language mode, default isolation, or upcoming features.
+- You need the smallest safe migration sequence instead of a full architectural rewrite.
+
+Skip this file if:
+
+- You already know the exact diagnostic and only need a local fix. Start from `actors.md`, `sendable.md`, or `threading.md`.
+- You are looking for debounce, stream composition, or FRP operator replacements. Use `async-algorithms.md`.
+
+Jump to:
+
+- Project Settings
+- Six Migration Habits
+- Step-by-Step Migration
+- Migration Tooling
+- Rewriting Closures to Async/Await
+- Migrating from Combine/RxSwift
+- Concurrency-Safe Notifications (iOS 26+)
+- Anti-Patterns
+
+---
+
+## Why Migrate to Swift 6?
+
+Swift 6 doesn't fundamentally change how Swift Concurrency works—it **enforces existing rules more strictly**:
+
+- **Compile-time safety**: Catches data races and threading issues at compile time instead of runtime
+- **Warnings become errors**: Many Swift 5 warnings become hard errors in Swift 6 language mode
+- **Future-proofing**: New concurrency features will build on this stricter foundation
+- **Better maintainability**: Code becomes safer and easier to reason about
+
+> **Important**: You can adopt strict concurrency checking gradually while still compiling under Swift 5. You don't need to flip the Swift 6 switch immediately.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 12.2: The impact of Swift 6 on Swift Concurrency](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+---
+
+## Project Settings That Change Concurrency Behavior
+
+Before interpreting diagnostics or choosing a fix, confirm the target/module settings. These settings can materially change how code executes and what the compiler enforces.
+
+### Quick matrix
+
+| Setting / feature | Where to check | Why it matters |
+|---|---|---|
+| Swift language mode (Swift 5.x vs Swift 6) | Xcode build settings (`SWIFT_VERSION`) / SwiftPM `// swift-tools-version:` | Swift 6 turns many warnings into errors and enables stricter defaults. |
+| Strict concurrency checking | Xcode: Strict Concurrency Checking (`SWIFT_STRICT_CONCURRENCY`) / SwiftPM: strict concurrency flags | Controls how aggressively Sendable + isolation rules are enforced. |
+| Default actor isolation | Xcode: Default Actor Isolation (`SWIFT_DEFAULT_ACTOR_ISOLATION`) / SwiftPM: `.defaultIsolation(MainActor.self)` | Changes the default isolation of declarations; can reduce migration noise but changes behavior and requirements. |
+| `NonisolatedNonsendingByDefault` | Xcode upcoming feature / SwiftPM `.enableUpcomingFeature("NonisolatedNonsendingByDefault")` | Changes how nonisolated async functions execute (can inherit the caller’s actor unless explicitly marked `@concurrent`). |
+| Approachable Concurrency | Xcode build setting / SwiftPM enables the underlying upcoming features | Bundles multiple upcoming features; recommended to migrate feature-by-feature first. |
+
+## The Concurrency Rabbit Hole
+
+A common migration experience:
+
+1. Enable strict concurrency checking
+2. See 50+ errors and warnings
+3. Fix a bunch of them
+4. Rebuild and see 80+ new errors appear
+
+**Why this happens**: Fixing isolation in one place often exposes issues elsewhere. This is normal and manageable with the right strategy.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 12.1: Challenges in migrating to Swift Concurrency](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+---
+
+## Six Migration Habits for Success
+
+### 1. Don't Panic—It's All About Iterations
+
+Break migration into small, manageable chunks:
+
+```swift
+// Day 1: Enable strict concurrency, fix a few warnings
+// Build Settings → Strict Concurrency Checking = Complete
+
+// Day 2: Fix more warnings
+
+// Day 3: Revert to minimal checking if needed
+// Build Settings → Strict Concurrency Checking = Minimal
+```
+
+Allow yourself 30 minutes per day to migrate gradually. Don't expect completion in a few days for large projects.
+
+### 2. Sendable by Default for New Code
+
+When writing new types, make them `Sendable` from the start:
+
+```swift
+// ✅ Good: New code prepared for Swift 6
+struct UserProfile: Sendable {
+    let id: UUID
+    let name: String
+}
+
+// ❌ Avoid: Creating technical debt
+class UserProfile {  // Will need migration later
+    var id: UUID
+    var name: String
+}
+```
+
+It's easier to design for concurrency upfront than to retrofit it later.
+
+### 3. Use Swift 6 for New Projects and Packages
+
+For new projects, packages, or files:
+- Enable Swift 6 language mode from the start
+- Use Swift Concurrency features (async/await, actors)
+- Reduce technical debt before it accumulates
+
+You can enable Swift 6 for individual files in a Swift 5 project to prevent scope creep.
+
+### 4. Resist the Urge to Refactor
+
+**Focus solely on concurrency changes**. Don't combine migration with:
+- Architecture refactors
+- API modernization
+- Code style improvements
+
+Create separate tickets for non-concurrency refactors and address them later.
+
+### 5. Focus on Minimal Changes
+
+- Make small, focused pull requests
+- Migrate one class or module at a time
+- Get changes merged quickly to create checkpoints
+- Avoid large PRs that are hard to review
+
+### 6. Don't Just @MainActor All the Things
+
+Don't blindly add `@MainActor` to fix warnings. Consider:
+- Should this actually run on the main actor?
+- Would a custom actor be more appropriate?
+- Is `nonisolated` the right choice?
+
+**Exception**: For app projects (not frameworks), consider enabling **Default Actor Isolation** to `@MainActor`, since most app code needs main thread access.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 12.3: The six migration habits for a successful migration](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+---
+
+## Step-by-Step Migration Process
+
+### 1. Find an Isolated Piece of Code
+
+Start with:
+- Standalone packages with minimal dependencies
+- Individual Swift files within a package
+- Code that's not heavily used throughout the project
+
+**Why**: Fewer dependencies = less risk of falling into the concurrency rabbit hole.
+
+### 2. Update Related Dependencies
+
+Before enabling strict concurrency:
+
+```swift
+// Update third-party packages to latest versions
+// Example: Vapor, Alamofire, etc.
+```
+
+Apply these updates in a separate PR before proceeding with concurrency changes.
+
+### 3. Add Async Alternatives
+
+Provide async/await wrappers for existing closure-based APIs:
+
+```swift
+// Original closure-based API
+@available(*, deprecated, renamed: "fetchImage(urlRequest:)", 
+           message: "Consider using the async/await alternative.")
+func fetchImage(urlRequest: URLRequest, 
+                completion: @escaping @Sendable (Result<UIImage, Error>) -> Void) {
+    // ... existing implementation
+}
+
+// New async wrapper
+func fetchImage(urlRequest: URLRequest) async throws -> UIImage {
+    return try await withCheckedThrowingContinuation { continuation in
+        fetchImage(urlRequest: urlRequest) { result in
+            continuation.resume(with: result)
+        }
+    }
+}
+```
+
+**Benefits**:
+- Colleagues can start using async/await immediately
+- You can migrate callers before rewriting implementation
+- Tests can be updated to async/await first
+
+**Tip**: Use Xcode's **Refactor → Add Async Wrapper** to generate these automatically.
+
+### 4. Change Default Actor Isolation (Swift 6.2+)
+
+For app projects, set default isolation to `@MainActor`:
+
+**Xcode Build Settings**:
+```
+Swift Concurrency → Default Actor Isolation = MainActor
+```
+
+**Swift Package Manager**:
+```swift
+.target(
+    name: "MyTarget",
+    swiftSettings: [
+        .defaultIsolation(MainActor.self)
+    ]
+)
+```
+
+This drastically reduces warnings in app code where most types need main thread access.
+
+### 5. Enable Strict Concurrency Checking
+
+**Xcode Build Settings**: Search for "Strict Concurrency Checking"
+
+Three levels available:
+
+- **Minimal**: Only checks code that explicitly adopts concurrency (`@Sendable`, `@MainActor`)
+- **Targeted**: Checks all code that adopts concurrency, including `Sendable` conformances
+- **Complete**: Checks entire codebase (matches Swift 6 behavior)
+
+**Swift Package Manager**:
+```swift
+.target(
+    name: "MyTarget",
+    swiftSettings: [
+        .enableExperimentalFeature("StrictConcurrency=targeted")
+    ]
+)
+```
+
+**Strategy**: Start with Minimal → Targeted → Complete, fixing errors at each level.
+
+### 6. Add Sendable Conformances
+
+Even if the compiler doesn't complain, add `Sendable` to types that will cross isolation domains:
+
+```swift
+// ✅ Prepare for future use
+struct Configuration: Sendable {
+    let apiKey: String
+    let timeout: TimeInterval
+}
+```
+
+This prevents warnings when the type is used in concurrent contexts later.
+
+### 7. Enable Approachable Concurrency (Swift 6.2+)
+
+**Xcode Build Settings**: Search for "Approachable Concurrency"
+
+Enables multiple upcoming features at once:
+- `DisableOutwardActorInference`
+- `GlobalActorIsolatedTypesUsability`
+- `InferIsolatedConformances`
+- `InferSendableFromCaptures`
+- `NonisolatedNonsendingByDefault`
+
+**⚠️ Warning**: Don't just flip this switch for existing projects. Use migration tooling (see below) to migrate to each feature individually first.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 12.5: The Approachable Concurrency build setting (Updated for Swift 6.2)](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+### 8. Enable Upcoming Features
+
+**Xcode Build Settings**: Search for "Upcoming Feature"
+
+Enable features individually:
+
+**Swift Package Manager**:
+```swift
+.target(
+    name: "MyTarget",
+    swiftSettings: [
+        .enableUpcomingFeature("ExistentialAny"),
+        .enableUpcomingFeature("InferIsolatedConformances")
+    ]
+)
+```
+
+Find feature keys in Swift Evolution proposals (e.g., SE-335 for `ExistentialAny`).
+
+### 9. Change to Swift 6 Language Mode
+
+**Xcode Build Settings**:
+```
+Swift Language Version = Swift 6
+```
+
+**Swift Package Manager**:
+```swift
+// swift-tools-version: 6.0
+```
+
+If you've completed all previous steps, you should have minimal new errors.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 12.4: Steps to migrate existing code to Swift 6 and Strict Concurrency Checking](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+---
+
+## Migration Tooling for Upcoming Features
+
+Swift 6.2+ includes **semi-automatic migration** for upcoming features.
+
+### Xcode Migration
+
+1. Go to Build Settings → Find the upcoming feature (e.g., "Require Existential any")
+2. Set to **Migrate** (temporary setting)
+3. Build the project
+4. Warnings appear with **Apply** buttons
+5. Click Apply for each warning
+
+**Example warning**:
+```swift
+// ⚠️ Use of protocol 'Error' as a type must be written 'any Error'
+func fetchData() throws -> Data  // Before
+func fetchData() throws -> any Data  // After applying fix
+```
+
+### Package Migration
+
+Use the `swift package migrate` command:
+
+```bash
+# Migrate all targets
+swift package migrate --to-feature ExistentialAny
+
+# Migrate specific target
+swift package migrate --target MyTarget --to-feature ExistentialAny
+```
+
+**Output**:
+```
+> Applied 24 fix-its in 11 files (0.016s)
+> Updating manifest
+```
+
+The tool automatically:
+- Applies all fix-its
+- Updates `Package.swift` to enable the feature
+
+**Available migrations** (as of Swift 6.2):
+- `ExistentialAny` (SE-335)
+- `InferIsolatedConformances` (SE-470)
+- More features will add migration support over time
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 12.6: Migration tooling for upcoming Swift features](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+**Additional resource**: [Migration Tooling Video](https://youtu.be/FK9XFxSWZPg?si=2z_ybn1t1YCJow5k)
+
+---
+
+## Rewriting Closures to Async/Await
+
+### Using Xcode Refactoring
+
+Three refactoring options available:
+
+1. **Add Async Wrapper**: Wraps existing closure-based method (recommended first step)
+2. **Add Async Alternative**: Rewrites method as async, keeps original
+3. **Convert Function to Async**: Replaces method entirely
+
+**⚠️ Known Issue**: Refactoring can be unstable in Xcode. If you get "Connection interrupted" errors:
+- Clean build folder
+- Clear derived data
+- Restart Xcode
+- Simplify complex methods (shorthand if statements can cause failures)
+
+### Manual Rewriting Example
+
+**Before** (closure-based):
+```swift
+func fetchImage(urlRequest: URLRequest, 
+                completion: @escaping @Sendable (Result<UIImage, Error>) -> Void) {
+    URLSession.shared.dataTask(with: urlRequest) { data, _, error in
+        do {
+            if let error = error { throw error }
+            guard let data = data, let image = UIImage(data: data) else {
+                throw ImageError.conversionFailed
+            }
+            completion(.success(image))
+        } catch {
+            completion(.failure(error))
+        }
+    }.resume()
+}
+```
+
+**After** (async/await):
+```swift
+func fetchImage(urlRequest: URLRequest) async throws -> UIImage {
+    let (data, _) = try await URLSession.shared.data(for: urlRequest)
+    guard let image = UIImage(data: data) else {
+        throw ImageError.conversionFailed
+    }
+    return image
+}
+```
+
+**Benefits**:
+- Less code to maintain
+- Easier to reason about
+- No nested closures
+- Automatic error propagation
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 12.7: Techniques for rewriting closures to async/await syntax](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+---
+
+## Using @preconcurrency
+
+Suppresses `Sendable` warnings from modules you don't control.
+
+### When to Use
+
+```swift
+// ⚠️ Third-party library doesn't support Swift Concurrency yet
+@preconcurrency import SomeThirdPartyLibrary
+
+actor DataProcessor {
+    func process(_ data: LibraryType) {  // No Sendable warning
+        // ...
+    }
+}
+```
+
+### Risks
+
+- **No compile-time safety**: You're responsible for ensuring thread safety
+- **Hides real issues**: Library might not be thread-safe at all
+- **Technical debt**: Easy to forget to revisit later
+
+### Best Practices
+
+1. **Don't use by default**: Only add when compiler suggests it
+2. **Check for updates first**: Library might have a newer version with concurrency support
+3. **Document why**: Add a comment explaining why it's needed
+4. **Revisit regularly**: Set reminders to check if library has been updated
+
+```swift
+// TODO: Remove @preconcurrency when SomeLibrary adds Sendable support
+// Last checked: 2026-01-07 (version 2.3.0)
+@preconcurrency import SomeLibrary
+```
+
+The compiler will warn if `@preconcurrency` is unused:
+```
+'@preconcurrency' attribute on module 'SomeModule' is unused
+```
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 12.8: How and when to use @preconcurrency](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+---
+
+## Migrating from Combine/RxSwift
+
+### Observation Alternative
+
+Swift 6 will include **Transactional Observation** (SE-475):
+
+```swift
+// Future API (not yet implemented)
+let names = Observations { person.name }
+
+Task.detached {
+    for await name in names {
+        print("Name updated to: \(name)")
+    }
+}
+```
+
+**Current alternatives**:
+- Use `@Observable` macro for SwiftUI
+- Use `AsyncStream` for custom observation
+- Consider [AsyncExtensions](https://github.com/sideeffect-io/AsyncExtensions) package
+
+### Debouncing Example
+
+**Combine**:
+```swift
+$searchQuery
+    .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
+    .sink { [weak self] query in
+        self?.performSearch(query)
+    }
+    .store(in: &cancellables)
+```
+
+**Swift Concurrency**:
+```swift
+func search(_ query: String) {
+    currentSearchTask?.cancel()
+    
+    currentSearchTask = Task {
+        do {
+            try await Task.sleep(for: .milliseconds(500))
+            performSearch(query)
+        } catch {
+            // Search was cancelled
+        }
+    }
+}
+```
+
+**SwiftUI Integration**:
+```swift
+struct SearchView: View {
+    @State private var searchQuery = ""
+    @State private var searcher = ArticleSearcher()
+    
+    var body: some View {
+        List(searcher.results) { result in
+            Text(result.title)
+        }
+        .searchable(text: $searchQuery)
+        .onChange(of: searchQuery) { _, newValue in
+            searcher.search(newValue)
+        }
+    }
+}
+```
+
+### Mindset Shift
+
+**Don't think in Combine pipelines**. Many problems are simpler without FRP:
+
+```swift
+// ❌ Looking for AsyncSequence equivalent of complex Combine pipeline
+somePublisher
+    .debounce(for: .seconds(0.5))
+    .removeDuplicates()
+    .flatMap { ... }
+    .sink { ... }
+
+// ✅ Rethink the problem with Swift Concurrency
+Task {
+    var lastValue: String?
+    for await value in stream {
+        guard value != lastValue else { continue }
+        lastValue = value
+        try await Task.sleep(for: .seconds(0.5))
+        await process(value)
+    }
+}
+```
+
+**For complex operators**: Check [Swift Async Algorithms](https://github.com/apple/swift-async-algorithms) package.
+
+### ⚠️ Critical: Actor Isolation with Combine
+
+**Problem**: `sink` closures don't respect actor isolation at compile time.
+
+```swift
+@MainActor
+final class NotificationObserver {
+    private var cancellables: [AnyCancellable] = []
+    
+    init() {
+        NotificationCenter.default.publisher(for: .someNotification)
+            .sink { [weak self] _ in
+                self?.handleNotification()  // ⚠️ May crash if posted from background
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func handleNotification() {
+        // Expects to run on main actor
+    }
+}
+```
+
+**Why it crashes**: Notification observers run on the same thread as the poster. If posted from a background thread, the `@MainActor` method is called off the main actor.
+
+**Solutions**:
+
+1. **Migrate to Swift Concurrency** (recommended):
+```swift
+Task { [weak self] in
+    for await _ in NotificationCenter.default.notifications(named: .someNotification) {
+        await self?.handleNotification()  // ✅ Compile-time safe
+    }
+}
+```
+
+2. **Use Task wrapper** (temporary):
+```swift
+.sink { [weak self] _ in
+    Task { @MainActor in
+        self?.handleNotification()
+    }
+}
+```
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 12.9: Migrating away from Functional Reactive Programming like RxSwift or Combine](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+---
+
+## When to Use AsyncAlgorithms
+
+When migrating from Combine or RxSwift, you have multiple options for handling asynchronous patterns:
+
+### Use AsyncAlgorithms for:
+
+- **Time-based operations**: debounce, throttle, timers
+- **Combining multiple async sequences**: merge, combineLatest, zip
+- **Multi-consumer scenarios**: AsyncChannel for backpressure
+- **Complex operator chains**: FRP-like patterns in Swift Concurrency
+- **Specific operators**: removeDuplicates, chunks, adjacentPairs, compacted
+
+### Use Standard Library for:
+
+- **Bridging callbacks**: AsyncStream is sufficient
+- **Simple iteration**: for await in sequence
+- **Single-value operations**: async/await
+- **Basic transformations**: map, filter, contains
+
+### Use SwiftUI for:
+
+- **UI observation**: @Observable macro
+- **State management**: @State, @Published properties
+- **User interactions**: onChange, onReceive modifiers
+
+> **See**: [async-algorithms.md](async-algorithms.md) for detailed AsyncAlgorithms usage examples.
+
+---
+
+## Real-World Migration Examples
+
+### Example: ArticleSearcher with AsyncAlgorithms
+
+**Before: Manual Debouncing**
+
+```swift
+final class ArticleSearcher {
+    @MainActor private(set) var results: [Article] = []
+    private var currentSearchTask: Task<Void, Never>?
+
+    func search(_ query: String) {
+        currentSearchTask?.cancel()
+
+        currentSearchTask = Task {
+            do {
+                try await Task.sleep(for: .milliseconds(500))
+                await MainActor.run {
+                    self.results = []
+                }
+                self.results = await APIClient.searchArticles(query)
+            } catch {
+                // Search was cancelled
+            }
+        }
+    }
+}
+
+// SwiftUI integration
+struct SearchView: View {
+    @State private var searchQuery = ""
+    @State private var searcher = ArticleSearcher()
+
+    var body: some View {
+        List(searcher.results) { result in
+            Text(result.title)
+        }
+        .searchable(text: $searchQuery)
+        .onChange(of: searchQuery) { _, newValue in
+            searcher.search(newValue)
+        }
+    }
+}
+```
+
+**After: AsyncAlgorithms Debounce**
+
+```swift
+import AsyncAlgorithms
+
+@Observable
+final class ArticleSearcher {
+    @MainActor private(set) var results: [Article] = []
+    private var searchQueryContinuation: AsyncStream<String>.Continuation?
+
+    private lazy var searchQueryStream: AsyncStream<String> = {
+        AsyncStream { continuation in
+            searchQueryContinuation = continuation
+        }
+    }()
+
+    func search(_ query: String) {
+        searchQueryContinuation?.yield(query)
+    }
+
+    func startDebouncedSearch() {
+        Task { @MainActor in
+            for await query in searchQueryStream.debounce(for: .milliseconds(500)) {
+                self.results = []
+                self.results = await APIClient.searchArticles(query)
+            }
+        }
+    }
+}
+
+// SwiftUI integration
+struct SearchView: View {
+    @State private var searchQuery = ""
+    @State private var searcher = ArticleSearcher()
+
+    var body: some View {
+        List(searcher.results) { result in
+            Text(result.title)
+        }
+        .searchable(text: $searchQuery)
+        .onChange(of: searchQuery) { _, newValue in
+            searcher.search(newValue)
+        }
+        .onAppear {
+            searcher.startDebouncedSearch()
+        }
+    }
+}
+```
+
+**Benefits of using AsyncAlgorithms**:
+- Automatic cancellation when new values arrive
+- Backpressure handling (producer respects consumer pace)
+- Cleaner code than manual Task.sleep management
+- No need to track and cancel tasks manually
+
+### Example: Notification Stream Migration
+
+**Before: Combine Publisher**
+
+```swift
+import Combine
+
+final class NotificationObserver: ObservableObject {
+    @Published private(set) var notifications: [AppNotification] = []
+    private var cancellables = Set<AnyCancellable>()
+
+    init() {
+        NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
+            .compactMap { notification in
+                notification.object as? AppNotification
+            }
+            .receive(on: DispatchQueue.main)
+            .assign(to: &$notifications)
+    }
+}
+```
+
+**After: Standard Library Notifications**
+
+```swift
+@Observable
+final class NotificationObserver {
+    @MainActor private(set) var notifications: [AppNotification] = []
+
+    func startObserving() {
+        Task {
+            for await notification in NotificationCenter.default.notifications(named: UIApplication.didBecomeActiveNotification) {
+                if let appNotification = notification.object as? AppNotification {
+                    notifications.append(appNotification)
+                }
+            }
+        }
+    }
+}
+```
+
+**When to use each approach**:
+- Use `notifications(named:)` for standard system notifications
+- Use `AsyncChannel` for custom multi-consumer notification scenarios
+- Use `@Observable` + SwiftUI for UI state updates
+
+### Example: Multi-Source Data Loading
+
+**Before: Combine Merge**
+
+```swift
+import Combine
+
+final class MultiSourceLoader: ObservableObject {
+    @Published private(set) var items: [Item] = []
+    private var cancellables = Set<AnyCancellable>()
+
+    func loadFromAllSources() {
+        let source1 = APIClient.fetchItems(from: .source1)
+        let source2 = APIClient.fetchItems(from: .source2)
+        let source3 = APIClient.fetchItems(from: .source3)
+
+        Publishers.Merge3(source1, source2, source3)
+            .flatMap { items in
+                Just(items)
+                    .delay(for: .seconds(0.1), scheduler: DispatchQueue.main)
+            }
+            .scan([]) { accumulated, new in
+                accumulated + new
+            }
+            .receive(on: DispatchQueue.main)
+            .assign(to: &$items)
+            .store(in: &cancellables)
+    }
+}
+```
+
+**After: AsyncAlgorithms Merge + TaskGroup**
+
+```swift
+import AsyncAlgorithms
+
+@Observable
+final class MultiSourceLoader {
+    @MainActor private(set) var items: [Item] = []
+
+    func loadFromAllSources() async {
+        let sources = [
+            APIClient.fetchItems(from: .source1),
+            APIClient.fetchItems(from: .source2),
+            APIClient.fetchItems(from: .source3)
+        ]
+
+        Task { @MainActor in
+            for await stream in sources.map { $0.values }.merge() {
+                for await newItems in stream {
+                    self.items.append(contentsOf: newItems)
+                }
+            }
+        }
+    }
+
+    // Alternative: Using TaskGroup for parallel execution
+    func loadFromAllSourcesParallel() async {
+        await withTaskGroup(of: [Item].self) { group in
+            group.addTask {
+                await APIClient.fetchItems(from: .source1)
+            }
+            group.addTask {
+                await APIClient.fetchItems(from: .source2)
+            }
+            group.addTask {
+                await APIClient.fetchItems(from: .source3)
+            }
+
+            for await newItems in group {
+                await MainActor.run {
+                    self.items.append(contentsOf: newItems)
+                }
+            }
+        }
+    }
+}
+```
+
+**Key differences**:
+- Combine `merge()` combines publishers; AsyncAlgorithms `merge()` combines sequences
+- For parallel execution, use `TaskGroup` instead of `flatMap`
+- State updates can use `@MainActor` instead of `.receive(on:)`
+
+---
+
+## Anti-Patterns to Avoid
+
+### ❌ Don't Use Task.sleep for Debouncing
+
+```swift
+// ❌ Bad: Manual debouncing without backpressure
+func search(_ query: String) {
+    Task {
+        try? await Task.sleep(for: .milliseconds(500))
+        await performSearch(query)
+    }
+}
+```
+
+**Problem**: Every keystroke spawns a new task. If user types fast, multiple tasks execute simultaneously after 500ms, causing out-of-order results and wasted API calls.
+
+**Solution**: Use `debounce()` from AsyncAlgorithms for automatic backpressure and cancellation.
+
+### ❌ Don't Manually Combine Values
+
+```swift
+// ❌ Bad: Manual combination without operator
+actor FormValidator {
+    private var currentUsername: String = ""
+    private var currentEmail: String = ""
+    private var currentPassword: String = ""
+
+    func updateUsername(_ username: String) {
+        currentUsername = username
+        checkForm()
+    }
+
+    func updateEmail(_ email: String) {
+        currentEmail = email
+        checkForm()
+    }
+
+    func updatePassword(_ password: String) {
+        currentPassword = password
+        checkForm()
+    }
+
+    private func checkForm() {
+        let state = validate(
+            username: currentUsername,
+            email: currentEmail,
+            password: currentPassword
+        )
+        // Update UI or emit validation state
+    }
+}
+```
+
+**Problems**:
+- More state management
+- Boilerplate code for each field
+- Harder to add new fields
+- No stream composition benefits
+
+**Solution**: Use `combineLatest()` for cleaner, composable validation.
+
+### ❌ Don't Share Streams Without AsyncChannel
+
+```swift
+// ❌ Bad: Multiple consumers sharing same stream
+let stream = AsyncStream<Int> { continuation in
+    for i in 1...10 {
+        continuation.yield(i)
+    }
+    continuation.finish()
+}
+
+Task {
+    for await value in stream {
+        print("Consumer 1: \(value)")
+    }
+}
+
+Task {
+    for await value in stream {
+        print("Consumer 2: \(value)")
+    }
+}
+```
+
+**Problem**: Values are split between consumers unpredictably. Each value goes to only one consumer.
+
+**Solution**: Use `AsyncChannel` for true multi-consumer scenarios with backpressure.
+
+---
+
+---
+
+## Concurrency-Safe Notifications (iOS 26+)
+
+Swift 6.2 introduces **typed, thread-safe notifications**.
+
+### MainActorMessage
+
+For notifications that should be delivered on the main actor:
+
+```swift
+// Old way
+NotificationCenter.default.addObserver(
+    forName: UIApplication.didBecomeActiveNotification,
+    object: nil,
+    queue: .main
+) { [weak self] _ in
+    self?.handleDidBecomeActive()  // ⚠️ Concurrency warning
+}
+
+// New way (iOS 26+)
+token = NotificationCenter.default.addObserver(
+    of: UIApplication.self,
+    for: .didBecomeActive
+) { [weak self] message in
+    self?.handleDidBecomeActive()  // ✅ No warning, guaranteed main actor
+}
+```
+
+**Key difference**: Observer closure is guaranteed to run on `@MainActor`.
+
+### AsyncMessage
+
+For notifications delivered asynchronously on arbitrary isolation:
+
+```swift
+struct RecentBuildsChangedMessage: NotificationCenter.AsyncMessage {
+    typealias Subject = [RecentBuild]
+    let recentBuilds: Subject
+}
+
+// Enable static member lookup
+extension NotificationCenter.MessageIdentifier 
+where Self == NotificationCenter.BaseMessageIdentifier<RecentBuildsChangedMessage> {
+    static var recentBuildsChanged: NotificationCenter.BaseMessageIdentifier<RecentBuildsChangedMessage> {
+        .init()
+    }
+}
+```
+
+**Posting**:
+```swift
+let builds = [RecentBuild(appName: "Stock Analyzer")]
+let message = RecentBuildsChangedMessage(recentBuilds: builds)
+NotificationCenter.default.post(message)
+```
+
+**Observing**:
+```swift
+// Old way: Unsafe casting
+NotificationCenter.default.addObserver(forName: .recentBuildsChanged, object: nil, queue: nil) { notification in
+    guard let builds = notification.object as? [RecentBuild] else { return }
+    handleBuilds(builds)
+}
+
+// New way: Strongly typed, thread-safe
+token = NotificationCenter.default.addObserver(
+    of: [RecentBuild].self,
+    for: .recentBuildsChanged
+) { message in
+    handleBuilds(message.recentBuilds)  // ✅ Direct access, no casting
+}
+```
+
+**Benefits**:
+- Strongly typed (no `Any` casting)
+- Compile-time thread safety
+- Clear isolation guarantees
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 12.10: Migrating to concurrency-safe notifications](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+---
+
+## Common Challenges
+
+### "It's Too Much Work"
+
+Break it down:
+- Migrate one package at a time
+- Use 30-minute daily sessions
+- Create checkpoints with small PRs
+- Celebrate incremental progress
+
+### "My Team Isn't Ready"
+
+Start small:
+- Enable Swift 6 for new files only
+- Make new types `Sendable` by default
+- Share learnings in team meetings
+- Pair program on tricky migrations
+
+### "Dependencies Aren't Ready"
+
+Options:
+- Update to latest versions first
+- Use `@preconcurrency` temporarily
+- Contribute fixes to open-source dependencies
+- Wrap third-party APIs in your own concurrency-safe layer
+
+### "I Keep Going in Circles"
+
+This is the "concurrency rabbit hole":
+- Take breaks and revisit later
+- Temporarily disable strict checking to make progress elsewhere
+- Focus on one module at a time
+- Don't try to fix everything at once
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 12.11: Frequently Asked Questions (FAQ) around Swift 6 Migrations](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+---
+
+## Common Mistakes Agents Make
+
+- **Blanket `@MainActor`**: Do not slap `@MainActor` on everything to silence errors. Ask whether the code truly needs main-actor isolation.
+- **Mixing migration with unrelated refactors**: Focus solely on concurrency changes. Architectural improvements belong in separate PRs.
+- **Using `@unchecked Sendable` as a first response**: Prefer immutable value types or actors. Reserve escape hatches for documented, temporary exceptions.
+- **Giving pre-Swift 6.2 execution advice without checking the active feature set**: `nonisolated async` behavior depends on whether `NonisolatedNonsendingByDefault` is enabled.
+- **Using Approachable Concurrency without migrating feature-by-feature first**: Enable individual upcoming features before the full bundle to understand each change's impact.
+
+## Summary
+
+Migration to Swift 6 is a journey, not a sprint:
+
+1. **Start small**: Find isolated code with minimal dependencies
+2. **Be incremental**: Use the three strict concurrency levels (Minimal → Targeted → Complete)
+3. **Use tooling**: Leverage Xcode refactoring and `swift package migrate`
+4. **Create checkpoints**: Small, focused PRs that can be merged quickly
+5. **Stay positive**: The concurrency rabbit hole is real, but manageable with the right habits
+6. **Think differently**: Let go of the threading mindset; trust the compiler
+
+The result is **compile-time thread safety**, more maintainable code, and a future-proof codebase.
+
+**Additional resources**:
+- [Approachable Concurrency Video](https://youtu.be/y_Qc8cT-O_g?si=y4C1XQDGtyIOLW81)
+- [Migration Tooling Video](https://youtu.be/FK9XFxSWZPg?si=2z_ybn1t1YCJow5k)
+- [Swift Concurrency Course](https://www.swiftconcurrencycourse.com) for in-depth migration strategies
+

--- a/.agents/skills/swift-concurrency/references/performance.md
+++ b/.agents/skills/swift-concurrency/references/performance.md
@@ -1,0 +1,628 @@
+# Performance
+
+Use this when:
+
+- Async code is slower than expected or causing UI hangs.
+- You need to choose between synchronous, asynchronous, and parallel execution.
+- You are profiling concurrency overhead with Instruments.
+
+Skip this file if:
+
+- The issue is a compiler diagnostic about isolation or Sendable. Use `actors.md` or `sendable.md`.
+- You mainly need to fix a memory leak. Use `memory-management.md`.
+
+Jump to:
+
+- Core Principles
+- Common Performance Issues
+- Using Xcode Instruments
+- Suspension Points / Reducing Suspensions
+- Choosing Execution Style
+- Parallelism Costs
+- Optimization Checklist
+
+## Core Principles
+
+### Measurement is essential
+
+Can't improve what you don't measure. Establish baseline before optimizing.
+
+### Start simple, optimize later
+
+```
+Synchronous → Asynchronous → Parallel
+```
+
+Move right only when proven necessary.
+
+### Three phases of concurrency
+
+1. **No concurrency** - Synchronous method
+2. **Suspend without parallelism** - Asynchronous method
+3. **Advanced concurrency** - Parallel execution
+
+## Common Performance Issues
+
+### UI hangs
+
+Too much work on main thread causes interface freezes.
+
+### Poor parallelization
+
+Heavy work funneled into single task instead of parallel execution.
+
+### Actor contention
+
+Tasks waiting on busy actor, causing unnecessary suspensions.
+
+## Using Xcode Instruments
+
+### Swift Concurrency template
+
+Profile with CMD + I → Select "Swift Concurrency" template.
+
+**Instruments included**:
+- **Swift Tasks**: Track running, alive, total tasks
+- **Swift Actors**: Show actor execution and queue size
+
+### Key metrics
+
+```
+Tasks:
+- Total count
+- Running vs suspended
+- Task states (Creating, Running, Suspended, Ending)
+
+Actors:
+- Queue size
+- Execution time
+- Contention points
+
+Main Thread:
+- Hangs
+- Blocked time
+```
+
+### Task states
+
+- **Creating**: Task being initialized
+- **Running**: Actively executing
+- **Suspended**: Waiting (at await)
+- **Ending**: Completing
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 10.1: Using Xcode Instruments to find performance bottlenecks](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Identifying Issues
+
+### Main thread blocked
+
+```swift
+// ❌ All work on main thread
+@MainActor
+func generateWallpapers() {
+    Task {
+        for _ in 0..<100 {
+            let image = generator.generate() // Blocks main thread
+            wallpapers.append(image)
+        }
+    }
+}
+```
+
+**Instruments shows**: Long main thread hang, no parallelism.
+
+### Solution: Move to background
+
+```swift
+@MainActor
+func generateWallpapers() {
+    Task {
+        for _ in 0..<100 {
+            let image = await backgroundGenerator.generate()
+            wallpapers.append(image)
+        }
+    }
+}
+
+actor BackgroundGenerator {
+    func generate() -> Image {
+        // Heavy work in background
+    }
+}
+```
+
+### Actor contention
+
+```swift
+actor Generator {
+    func generate() -> Image {
+        // Heavy work
+    }
+}
+
+// ❌ Sequential through actor
+for _ in 0..<100 {
+    let image = await generator.generate() // Queue size = 1
+}
+```
+
+**Instruments shows**: Actor queue never exceeds 1, no parallelism.
+
+### Solution: Remove unnecessary actor
+
+```swift
+struct Generator {
+    @concurrent
+    static func generate() async -> Image {
+        // Heavy work, no shared state
+    }
+}
+
+// ✅ Parallel execution
+for i in 0..<100 {
+    Task(name: "Image \(i)") {
+        let image = await Generator.generate()
+        await addToCollection(image)
+    }
+}
+```
+
+## Suspension Points
+
+### What creates suspension
+
+Every `await` is potential suspension point:
+
+```swift
+let data = await fetchData() // May suspend
+```
+
+**Not guaranteed** - if isolation matches, may not suspend.
+
+### Suspension surface area
+
+Code between suspension points. Larger = harder to reason about:
+- Actor invariants
+- Performance
+- Thread hops
+- Reentrancy
+- State consistency
+
+### Goal
+
+- Do work before crossing isolation
+- Cross once
+- Finish job
+- Only cross again when necessary
+
+## Reducing Suspensions
+
+### 1. Use synchronous methods
+
+```swift
+// ❌ Unnecessary async
+private func scale(_ image: CGImage) async { }
+
+func process(_ image: CGImage) async {
+    let scaled = await scale(image) // Suspension point
+}
+
+// ✅ Synchronous helper
+private func scale(_ image: CGImage) { }
+
+func process(_ image: CGImage) async {
+    let scaled = scale(image) // No suspension
+}
+```
+
+**Rule**: If method doesn't need to suspend, don't mark async.
+
+### 2. Prevent actor reentrancy
+
+```swift
+// ❌ Reenters actor
+actor BankAccount {
+    func deposit(_ amount: Int) async {
+        balance += amount
+        await logTransaction() // Leaves actor
+        balance += bonus // Reenters - state may have changed
+    }
+}
+
+// ✅ Complete work before leaving
+actor BankAccount {
+    func deposit(_ amount: Int) async {
+        balance += amount
+        balance += bonus
+        await logTransaction() // Leave after state changes
+    }
+}
+```
+
+### 3. Inherit isolation
+
+```swift
+// ❌ Switches isolation
+@MainActor
+func update() async {
+    await process() // Switches away from main actor
+}
+
+// ✅ Inherits isolation (still requires await -- but no executor hop)
+@MainActor
+func update() async {
+    await process() // Stays on main actor when nonisolated(nonsending)
+}
+
+nonisolated(nonsending) func process() async { }
+```
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 10.2: Reducing suspension points by managing isolation effectively](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+### 4. Use non-suspending APIs
+
+```swift
+// ❌ May suspend
+try await Task.checkCancellation()
+
+// ✅ No suspension
+if Task.isCancelled {
+    return
+}
+```
+
+### 5. Keep delay work off the main actor
+
+If the task only needs the main actor for the final mutation, do not start the whole retry flow on `@MainActor`.
+
+```swift
+// ❌ Can wait for MainActor, then suspend immediately
+registrationRetryTask = Task { @MainActor [weak self] in
+    try? await Task.sleep(for: .milliseconds(100))
+    guard let self else { return }
+    self.registrationRetryTask = nil
+    self.updateConnectedTargetWindow()
+}
+```
+
+The delay itself is not UI work. Starting on `@MainActor` can add an avoidable executor wait before the task reaches `Task.sleep`, especially when the task is scheduled from another executor or while the main actor is busy.
+
+```swift
+// ✅ Sleep off-main, hop back only for the UI-owned work
+registrationRetryTask = Task { @concurrent [weak self] in
+    do {
+        try await Task.sleep(for: .milliseconds(100))
+    } catch is CancellationError {
+        return
+    }
+    guard let self else { return }
+
+    await MainActor.run {
+        self.registrationRetryTask = nil
+        self.updateConnectedTargetWindow()
+    }
+}
+```
+
+Use this pattern for delayed retries, backoff, and timer-like work where only the final state change is UI-owned.
+
+### 6. Embrace parallelism
+
+```swift
+// ❌ Sequential
+for url in urls {
+    let image = await download(url)
+    images.append(image)
+}
+
+// ✅ Parallel
+await withTaskGroup(of: Image.self) { group in
+    for url in urls {
+        group.addTask { await download(url) }
+    }
+    for await image in group {
+        images.append(image)
+    }
+}
+```
+
+## Analyzing Suspensions in Instruments
+
+### View task states
+
+1. Select Swift Tasks instrument
+2. Switch to "Task States" view
+3. Look for Suspended states
+4. Check suspension duration
+
+### Navigate to code
+
+1. Click task state (Running/Suspended)
+2. Open Extended Detail
+3. Click related method
+4. Use "Open in Source Viewer"
+
+### Predict suspensions
+
+```swift
+Task {
+    // State 1: Running
+    // State 2: Suspended (switch to background)
+    let data = await backgroundWork()
+    // State 3: Running (in background)
+    // State 4: Suspended (switch to main actor)
+    // State 5: Running (on main actor)
+    await MainActor.run {
+        updateUI(data)
+    }
+}
+```
+
+### Optimization example
+
+```swift
+// Before: Two suspensions
+Task {
+    let data = await generate() // Suspension 1
+    self.items.append(data) // Suspension 2 (back to main)
+}
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 10.3: Using Xcode Instruments to detect and remove suspension points](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+// After: One suspension
+Task { @concurrent in
+    let data = generate() // No suspension (synchronous)
+    await MainActor.run {
+        self.items.append(data) // Suspension 1 (to main)
+    }
+}
+```
+
+## Choosing Execution Style
+
+### Decision checklist
+
+**Use async/parallel if**:
+- [ ] Blocks main actor visibly (>16ms)
+- [ ] Scales with data (N items → N cost)
+- [ ] Involves I/O (network, disk)
+- [ ] Benefits from combining operations
+- [ ] Called frequently
+
+**2+ checks** → async/parallel justified.
+
+### Start synchronous
+
+```swift
+// Start here
+func processData(_ data: Data) -> Result {
+    // Fast, in-memory work
+}
+```
+
+**Only move to async if**:
+- Instruments show main thread hang
+- User reports sluggishness
+- Work scales with input size
+
+### When to use async
+
+```swift
+func processData(_ data: Data) async -> Result {
+    // Use when:
+    // - Touches persistent storage
+    // - Parses large datasets
+    // - Network communication
+    // - Proven slow by profiling
+}
+```
+
+### When to use parallel
+
+```swift
+await withTaskGroup(of: Result.self) { group in
+    for item in items {
+        group.addTask { await process(item) }
+    }
+}
+
+// Use when:
+// - Multiple independent operations
+// - Time-to-first-result matters
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 10.4: How to choose between serialized, asynchronous, and parallel execution](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+// - Work scales with collection size
+// - Proven beneficial by profiling
+```
+
+## Parallelism Costs
+
+### Tradeoffs
+
+**Benefits**:
+- Faster completion (if CPU-bound)
+- Better resource utilization
+- Improved responsiveness
+
+**Costs**:
+- Increased memory pressure
+- CPU scheduling overhead
+- System resource saturation
+- Battery drain
+- Thermal impact
+
+### When parallelism hurts
+
+```swift
+// ❌ Over-parallelization
+for i in 0..<1000 {
+    Task { await lightWork(i) }
+}
+// Creates 1000 tasks for trivial work
+```
+
+**Better**: Batch work or use fewer tasks.
+
+## UX-Driven Decisions
+
+### Smooth animations > raw speed
+
+```swift
+// 80ms on main thread, but animation stutters
+@MainActor
+func process() {
+    heavyWork() // Freezes UI for 1 frame
+}
+
+// 100ms total, but smooth UI
+@MainActor
+func process() async {
+    await backgroundWork() // UI stays responsive
+}
+```
+
+**Perception**: Smooth feels faster than raw speed.
+
+### Progress indication
+
+```swift
+@MainActor
+func loadItems() async {
+    isLoading = true
+    
+    for i in 0..<100 {
+        let item = await fetchItem(i)
+        items.append(item)
+        progress = Double(i) / 100 // Incremental updates
+    }
+    
+    isLoading = false
+}
+```
+
+Background work + progress = feels faster.
+
+## Optimization Checklist
+
+Before optimizing, ask:
+
+- [ ] Have I profiled with Instruments?
+- [ ] Is main thread actually blocked?
+- [ ] Can this be synchronous?
+- [ ] Am I over-parallelizing?
+- [ ] Is actor contention the issue?
+- [ ] Are suspensions necessary?
+- [ ] Does UX require background work?
+- [ ] Will this scale with data?
+
+## Common Patterns
+
+### Move heavy work to background
+
+```swift
+// Before
+@MainActor
+func generate() {
+    for _ in 0..<100 {
+        let item = heavyGeneration()
+        items.append(item)
+    }
+}
+
+// After
+@MainActor
+func generate() async {
+    for _ in 0..<100 {
+        let item = await backgroundGenerate()
+        items.append(item)
+    }
+}
+
+@concurrent
+func backgroundGenerate() async -> Item {
+    // Heavy work off main thread
+}
+```
+
+### Parallelize independent work
+
+```swift
+// Before: Sequential
+for url in urls {
+    let image = await download(url)
+    images.append(image)
+}
+
+// After: Parallel
+await withTaskGroup(of: Image.self) { group in
+    for url in urls {
+        group.addTask { await download(url) }
+    }
+    for await image in group {
+        images.append(image)
+    }
+}
+```
+
+### Reduce actor hops
+
+```swift
+// Before: Multiple hops
+actor Store {
+    func process() async {
+        let a = await fetch1() // Hop 1
+        let b = await fetch2() // Hop 2
+        let c = await fetch3() // Hop 3
+        combine(a, b, c)
+    }
+}
+
+// After: Batch fetches
+actor Store {
+    func process() async {
+        async let a = fetch1()
+        async let b = fetch2()
+        async let c = fetch3()
+        combine(await a, await b, await c) // One hop
+    }
+}
+```
+
+## Best Practices
+
+1. **Profile before optimizing** - measure baseline
+2. **Start synchronous** - add async only when needed
+3. **Use Instruments regularly** - catch issues early
+4. **Name tasks** - easier debugging in Instruments
+5. **Check suspension count** - reduce unnecessary awaits
+6. **Avoid premature parallelism** - has costs
+7. **Consider UX** - smooth > fast
+8. **Batch actor work** - reduce contention
+9. **Test on real devices** - simulators lie
+10. **Monitor in production** - real usage patterns differ
+
+## Debugging Performance
+
+### Instruments workflow
+
+1. Profile with Swift Concurrency template
+2. Identify main thread hangs
+3. Check task parallelism
+4. Analyze actor queue sizes
+5. Review suspension points
+6. Navigate to problematic code
+7. Apply optimizations
+8. Re-profile to verify
+
+### Red flags in Instruments
+
+- Main thread blocked >16ms
+- Actor queue size always 1
+- High suspension count
+- Tasks created but not running
+- Excessive task creation (1000+)
+
+## Further Learning
+
+For real-world optimization examples, profiling techniques, and advanced performance patterns, see [Swift Concurrency Course](https://www.swiftconcurrencycourse.com).
+

--- a/.agents/skills/swift-concurrency/references/sendable.md
+++ b/.agents/skills/swift-concurrency/references/sendable.md
@@ -1,0 +1,598 @@
+# Sendable
+
+Use this when:
+
+- A value or reference type must cross an isolation boundary safely.
+- You are resolving "non-Sendable type" compiler diagnostics.
+- You need to decide between value types, `@unchecked Sendable`, actors, or region-based isolation.
+
+Skip this file if:
+
+- The issue is about which actor should own the state. Use `actors.md`.
+- The issue is about how async functions execute. Use `threading.md`.
+
+Jump to:
+
+- Isolation Domains
+- Value Types (Structs, Enums)
+- Reference Types (Classes)
+- Functions and Closures (@Sendable)
+- @unchecked Sendable
+- Region-Based Isolation / `sending`
+- Global Variables
+- Decision Tree
+
+## What is Sendable?
+
+`Sendable` indicates a type is safe to share across isolation domains (actors, tasks, threads). The compiler verifies thread-safety at compile time.
+
+```swift
+public protocol Sendable {}
+```
+
+Empty protocol, but triggers compiler verification of thread-safety.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 4.1: Explaining the concept of Sendable in Swift](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Isolation Domains
+
+Three types of isolation in Swift Concurrency:
+
+### 1. Nonisolated (default)
+
+No concurrency restrictions, but can't modify isolated state:
+
+```swift
+func computeValue(a: Int, b: Int) -> Int {
+    return a + b
+}
+```
+
+### 2. Actor-isolated
+
+Dedicated isolation domain with serialized access:
+
+```swift
+actor Library {
+    var books: [String] = []
+    
+    func addBook(_ title: String) {
+        books.append(title)
+    }
+}
+
+// External access requires await
+await library.addBook("Swift Concurrency")
+```
+
+### 3. Global actor-isolated
+
+Shared isolation domain across types:
+
+```swift
+@MainActor
+func updateUI() {
+    // Runs on main thread
+}
+```
+
+## Data Races vs Race Conditions
+
+### Data Race
+
+Multiple threads access shared mutable state, at least one writes, without synchronization:
+
+```swift
+// ⚠️ Data race
+var counter = 0
+DispatchQueue.global().async { counter += 1 }
+DispatchQueue.global().async { counter += 1 }
+```
+
+**Detection**: Enable Thread Sanitizer in scheme settings.
+
+**Prevention**: Use actors or Sendable types:
+
+```swift
+actor Counter {
+    private var value = 0
+    
+    func increment() {
+        value += 1
+    }
+}
+```
+
+### Race Condition
+
+Timing-dependent behavior leading to unpredictable results:
+
+```swift
+let counter = Counter()
+
+for _ in 1...10 {
+    Task { await counter.increment() }
+}
+
+// May print inconsistent values
+print(await counter.getValue())
+```
+
+**Key difference**: Swift Concurrency prevents data races but not race conditions. You must still ensure proper sequencing.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 4.2: Understanding Data Races vs. Race Conditions: Key Differences Explained](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Value Types (Structs, Enums)
+
+### Implicit conformance
+
+Non-public structs/enums with Sendable members:
+
+```swift
+// Implicitly Sendable
+struct Person {
+    var name: String
+}
+```
+
+### Explicit conformance required
+
+Public types need explicit declaration:
+
+```swift
+public struct Person: Sendable {
+    var name: String
+}
+```
+
+**Why**: Compiler can't verify internal details of public types across modules.
+
+### Frozen types
+
+Public frozen types can be implicitly Sendable:
+
+```swift
+@frozen
+public struct Point: Sendable {
+    public var x: Double
+    public var y: Double
+}
+```
+
+### All members must be Sendable
+
+```swift
+public struct Person: Sendable {
+    var name: String
+    var hometown: Location // Must also be Sendable
+}
+
+public struct Location: Sendable {
+    var name: String
+}
+```
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 4.3: Conforming your code to the Sendable protocol](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+### Copy-on-write makes mutability safe
+
+```swift
+public struct Person: Sendable {
+    var name: String // Mutable but safe due to COW
+}
+```
+
+Each mutation creates a copy, preventing concurrent access to same instance.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 4.4: Sendable and Value Types](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Reference Types (Classes)
+
+### Requirements for Sendable classes
+
+Must be:
+1. `final` (no inheritance)
+2. Immutable stored properties only
+3. All properties Sendable
+4. No superclass or `NSObject` only
+
+```swift
+final class User: Sendable {
+    let name: String
+    let id: Int
+    
+    init(name: String, id: Int) {
+        self.name = name
+        self.id = id
+    }
+}
+```
+
+### Why non-final classes can't be Sendable
+
+Child classes could introduce unsafe mutability:
+
+```swift
+// Can't be Sendable
+class Purchaser {
+    func purchase() { }
+}
+
+// Could introduce data races
+class GamePurchaser: Purchaser {
+    var credits: Int = 0 // Mutable!
+}
+```
+
+### Actor isolation makes classes Sendable
+
+```swift
+@MainActor
+class ViewModel {
+    var data: [Item] = [] // Safe due to actor isolation
+}
+// Implicitly Sendable
+```
+
+### Composition over inheritance
+
+```swift
+final class Purchaser: Sendable {
+    func purchase() { }
+}
+
+final class GamePurchaser {
+    let purchaser: Purchaser = Purchaser()
+    // Handle credits separately
+}
+```
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 4.5: Sendable and Reference Types](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Functions and Closures (@Sendable)
+
+Mark functions/closures that cross isolation domains:
+
+```swift
+actor ContactsStore {
+    func removeAll(_ shouldRemove: @Sendable (Contact) -> Bool) async {
+        contacts.removeAll { shouldRemove($0) }
+    }
+}
+```
+
+### Captured values must be Sendable
+
+```swift
+let query = "search"
+
+// ✅ Immutable capture
+store.filter { contact in
+    contact.name.contains(query)
+}
+
+var query = "search"
+
+// ❌ Mutable capture
+store.filter { contact in
+    contact.name.contains(query) // Error
+}
+```
+
+### Capture lists for mutable values
+
+```swift
+var query = "search"
+
+// ✅ Capture immutable snapshot
+store.filter { [query] contact in
+    contact.name.contains(query)
+}
+```
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 4.6: Using @Sendable with closures](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## @unchecked Sendable
+
+**Use as last resort.** Tells compiler to skip verification—you guarantee thread-safety.
+
+### When to use
+
+Manual locking mechanisms the compiler can't verify:
+
+```swift
+final class Cache: @unchecked Sendable {
+    private let lock = NSLock()
+    private var items: [String: Data] = [:]
+    
+    func get(_ key: String) -> Data? {
+        lock.lock()
+        defer { lock.unlock() }
+        return items[key]
+    }
+    
+    func set(_ key: String, value: Data) {
+        lock.lock()
+        defer { lock.unlock() }
+        items[key] = value
+    }
+}
+```
+
+### Risks
+
+- No compile-time safety
+- Easy to introduce data races
+- Must manually ensure all access uses lock
+
+```swift
+final class Cache: @unchecked Sendable {
+    private let lock = NSLock()
+    private var items: [String: Data] = [:]
+    
+    // ⚠️ Forgot lock - data race!
+    var count: Int {
+        items.count
+    }
+}
+```
+
+**Better**: Use actor instead:
+
+```swift
+actor Cache {
+    private var items: [String: Data] = [:]
+    
+    var count: Int { items.count }
+    
+    func get(_ key: String) -> Data? {
+        items[key]
+    }
+    
+    func set(_ key: String, value: Data) {
+        items[key] = value
+    }
+}
+```
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 4.7: Using @unchecked Sendable](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Region-Based Isolation
+
+Compiler allows non-Sendable types in same scope:
+
+```swift
+class Article {
+    var title: String
+    init(title: String) { self.title = title }
+}
+
+func check() {
+    let article = Article(title: "Swift")
+    
+    Task {
+        print(article.title) // ✅ OK - same region
+    }
+}
+```
+
+**Why**: No mutation after transfer, so no data race risk.
+
+### Breaks when accessed after transfer
+
+```swift
+func check() {
+    let article = Article(title: "Swift")
+    
+    Task {
+        print(article.title)
+    }
+    
+    print(article.title) // ❌ Error - accessed after transfer
+}
+```
+
+## The sending Keyword
+
+Enforces ownership transfer for non-Sendable types:
+
+### Parameter values
+
+```swift
+actor Logger {
+    func log(article: Article) {
+        print(article.title)
+    }
+}
+
+func printTitle(article: sending Article) async {
+    let logger = Logger()
+    await logger.log(article: article)
+}
+
+// Usage
+let article = Article(title: "Swift")
+await printTitle(article: article)
+// article no longer accessible here
+```
+
+### Return values
+
+```swift
+@SomeActor
+func createArticle(title: String) -> sending Article {
+    return Article(title: title)
+}
+```
+
+Transfers ownership to caller's region.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 4.8: Understanding region-based isolation and the sending keyword](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Global Variables
+
+Must be concurrency-safe since accessible from any context.
+
+### Problem
+
+```swift
+class ImageCache {
+    static var shared = ImageCache() // ⚠️ Not concurrency-safe
+}
+```
+
+### Solution 1: Actor isolation
+
+```swift
+@MainActor
+class ImageCache {
+    static var shared = ImageCache()
+}
+```
+
+### Solution 2: Immutable + Sendable
+
+```swift
+final class ImageCache: Sendable {
+    static let shared = ImageCache()
+}
+```
+
+### Solution 3: nonisolated(unsafe)
+
+**Last resort** - you guarantee safety:
+
+```swift
+struct APIProvider: Sendable {
+    nonisolated(unsafe) static private(set) var shared: APIProvider!
+    
+    static func configure(apiURL: URL) {
+        shared = APIProvider(apiURL: apiURL)
+    }
+}
+```
+
+Use `private(set)` to limit mutation points.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 4.9: Concurrency-safe global variables](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Custom Locks + Sendable
+
+### Legacy code with locks
+
+```swift
+final class BankAccount: @unchecked Sendable {
+    private var balance: Int = 0
+    private let lock = NSLock()
+    
+    func deposit(amount: Int) {
+        lock.lock()
+        balance += amount
+        lock.unlock()
+    }
+    
+    func getBalance() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return balance
+    }
+}
+```
+
+### Migration strategy
+
+**New code**: Use actors
+
+**Existing code**: 
+1. If isolated and small scope → migrate to actor
+2. If widely used → use `@unchecked Sendable`, file migration ticket
+
+```swift
+// Better: Migrate to actor
+actor BankAccount {
+    private var balance: Int = 0
+    
+    func deposit(amount: Int) {
+        balance += amount
+    }
+    
+    func getBalance() -> Int {
+        balance
+    }
+}
+```
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 4.10: Combining Sendable with custom Locks](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Decision Tree
+
+```
+Need to share type across isolation domains?
+├─ Value type (struct/enum)?
+│  ├─ Public? → Add explicit Sendable
+│  └─ Internal? → Implicit Sendable (if members Sendable)
+│
+├─ Reference type (class)?
+│  ├─ Can be final + immutable? → Sendable
+│  ├─ Needs mutation?
+│  │  ├─ Can use actor? → Use actor (automatic Sendable)
+│  │  ├─ Main thread only? → @MainActor
+│  │  └─ Has custom lock? → @unchecked Sendable (temporary)
+│  └─ Can be struct instead? → Refactor to struct
+│
+└─ Function/closure? → @Sendable attribute
+```
+
+## Common Patterns
+
+### Restructure to avoid non-Sendable dependencies
+
+```swift
+// Instead of storing non-Sendable type
+public struct Person: Sendable {
+    var hometown: String // Just the name
+    
+    init(hometown: Location) {
+        self.hometown = hometown.name
+    }
+}
+```
+
+### Prefer actors for mutable state
+
+```swift
+// Instead of @unchecked Sendable with locks
+actor Cache {
+    private var items: [String: Data] = [:]
+    
+    func get(_ key: String) -> Data? {
+        items[key]
+    }
+}
+```
+
+### Use @MainActor for UI-bound types
+
+```swift
+@MainActor
+class ViewModel: ObservableObject {
+    @Published var items: [Item] = []
+}
+```
+
+## Best Practices
+
+1. **Prefer value types** - structs/enums are easier to make Sendable
+2. **Use actors for mutable state** - automatic thread-safety
+3. **Avoid @unchecked Sendable** - use only for proven thread-safe code
+4. **Mark public types explicitly** - don't rely on implicit conformance
+5. **Ensure all members Sendable** - one non-Sendable breaks the chain
+6. **Use @MainActor for UI types** - simple isolation for view models
+7. **Capture immutably** - use capture lists for mutable variables
+8. **Test with Thread Sanitizer** - catches runtime data races
+9. **File migration tickets** - track @unchecked Sendable usage
+
+## Further Learning
+
+For migration strategies, real-world examples, and actor patterns, see [Swift Concurrency Course](https://www.swiftconcurrencycourse.com).
+

--- a/.agents/skills/swift-concurrency/references/tasks.md
+++ b/.agents/skills/swift-concurrency/references/tasks.md
@@ -1,0 +1,636 @@
+# Tasks
+
+Use this when:
+
+- You need to start async work from synchronous code.
+- You are choosing between `Task`, `async let`, and task groups.
+- You need cancellation, priorities, or structured vs unstructured guidance.
+
+Skip this file if:
+
+- The problem is mainly actor isolation or sendability. Use `actors.md` or `sendable.md`.
+- The work is stream-shaped. Use `async-sequences.md` or `async-algorithms.md`.
+
+Jump to:
+
+- What is a Task?
+- Cancellation
+- Task Groups
+- Discarding Task Groups
+- Advanced: Task Timeout Pattern
+- SwiftUI Integration
+- Structured vs Unstructured Tasks
+- Task Priorities
+
+## What is a Task?
+
+Tasks bridge synchronous and asynchronous contexts. They start executing immediately upon creation—no `resume()` needed.
+
+```swift
+func synchronousMethod() {
+    Task {
+        await someAsyncMethod()
+    }
+}
+```
+
+## Task References
+
+Storing a reference is optional but enables cancellation and result waiting:
+
+```swift
+final class ImageLoader {
+    var loadTask: Task<UIImage, Error>?
+    
+    func load() {
+        loadTask = Task {
+            try await fetchImage()
+        }
+    }
+    
+    deinit {
+        loadTask?.cancel()
+    }
+}
+```
+
+Tasks run regardless of whether you keep a reference.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 3.1: Introduction to tasks in Swift Concurrency](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Cancellation
+
+### Checking for cancellation
+
+Tasks must manually check for cancellation:
+
+```swift
+// Throws CancellationError if canceled
+try Task.checkCancellation()
+
+// Boolean check for custom handling
+guard !Task.isCancelled else {
+    return fallbackValue
+}
+```
+
+### Where to check
+
+Add checks at natural breakpoints:
+
+```swift
+let task = Task {
+    // Before expensive work
+    try Task.checkCancellation()
+    
+    let data = try await URLSession.shared.data(from: url)
+    
+    // After network, before processing
+    try Task.checkCancellation()
+    
+    return processData(data)
+}
+```
+
+### Child task cancellation
+
+Canceling a parent automatically notifies all children:
+
+```swift
+let parent = Task {
+    async let child1 = work(1)
+    async let child2 = work(2)
+    let results = try await [child1, child2]
+}
+
+parent.cancel() // Both children notified
+```
+
+Children must still check `Task.isCancelled` to stop work.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 3.2: Task cancellation](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Error Handling
+
+Task error types are inferred from the operation:
+
+```swift
+// Can throw
+let throwingTask: Task<String, Error> = Task {
+    throw URLError(.badURL)
+}
+
+// Cannot throw
+let nonThrowingTask: Task<String, Never> = Task {
+    "Success"
+}
+```
+
+### Awaiting results
+
+```swift
+do {
+    let result = try await task.value
+} catch {
+    // Handle error
+}
+```
+
+### Handling errors internally
+
+```swift
+let safeTask: Task<String, Never> = Task {
+    do {
+        return try await riskyOperation()
+    } catch {
+        return "Fallback value"
+    }
+}
+```
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 3.3: Error handling in Tasks](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## SwiftUI Integration
+
+### The .task modifier
+
+Automatically manages task lifetime with view lifecycle:
+
+```swift
+struct ContentView: View {
+    @State private var data: Data?
+    
+    var body: some View {
+        Text(data?.description ?? "Loading...")
+            .task {
+                data = try? await fetchData()
+            }
+    }
+}
+```
+
+Task cancels automatically when view disappears.
+
+### Reacting to value changes
+
+```swift
+.task(id: searchQuery) {
+    await performSearch(searchQuery)
+}
+```
+
+When `searchQuery` changes:
+1. Previous task cancels
+2. New task starts with updated value
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 3.12: Running tasks in SwiftUI](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+### Priority configuration
+
+```swift
+// High priority (default for SwiftUI)
+.task(priority: .userInitiated) {
+    await fetchUserData()
+}
+
+// Lower priority for background work
+.task(priority: .low) {
+    await trackAnalytics()
+}
+```
+
+## Task Groups
+
+Dynamic parallel task execution with compile-time unknown task count.
+
+### Basic usage
+
+```swift
+await withTaskGroup(of: UIImage.self) { group in
+    for url in photoURLs {
+        group.addTask {
+            await downloadPhoto(url: url)
+        }
+    }
+}
+```
+
+### Collecting results
+
+```swift
+let images = await withTaskGroup(of: UIImage.self) { group in
+    for url in photoURLs {
+        group.addTask { await downloadPhoto(url: url) }
+    }
+    
+    return await group.reduce(into: []) { $0.append($1) }
+}
+```
+
+### Error handling
+
+```swift
+let images = try await withThrowingTaskGroup(of: UIImage.self) { group in
+    for url in photoURLs {
+        group.addTask { try await downloadPhoto(url: url) }
+    }
+    
+    // Iterate to propagate errors
+    var results: [UIImage] = []
+    for try await image in group {
+        results.append(image)
+    }
+    return results
+}
+```
+
+**Critical**: Errors in child tasks don't automatically fail the group. Use iteration (`for try await`, `next()`, `reduce()`) to propagate errors.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 3.5: Task Groups](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+### Early termination on error
+
+```swift
+try await withThrowingTaskGroup(of: Data.self) { group in
+    for id in ids {
+        group.addTask { try await fetch(id) }
+    }
+    
+    // First error cancels remaining tasks
+    while let data = try await group.next() {
+        process(data)
+    }
+}
+```
+
+### Cancellation
+
+```swift
+await withTaskGroup(of: Result.self) { group in
+    for item in items {
+        group.addTask { await process(item) }
+    }
+    
+    // Cancel all remaining tasks
+    group.cancelAll()
+}
+```
+
+Or prevent adding to canceled group:
+
+```swift
+let didAdd = group.addTaskUnlessCancelled {
+    await work()
+}
+```
+
+## Discarding Task Groups
+
+For fire-and-forget operations where results don't matter:
+
+```swift
+await withDiscardingTaskGroup { group in
+    group.addTask { await logEvent("user_login") }
+    group.addTask { await preloadCache() }
+    group.addTask { await syncAnalytics() }
+}
+```
+
+### Benefits
+
+- More memory efficient (doesn't store results)
+- No `next()` calls needed
+- Automatically waits for completion
+- Ideal for side effects
+
+### Error handling
+
+```swift
+try await withThrowingDiscardingTaskGroup { group in
+    group.addTask { try await uploadLog() }
+    group.addTask { try await syncSettings() }
+}
+// First error cancels group and throws
+```
+
+### Real-world pattern: Multiple notifications
+
+```swift
+extension NotificationCenter {
+    func notifications(named names: [Notification.Name]) -> AsyncStream<()> {
+        AsyncStream { continuation in
+            let task = Task {
+                await withDiscardingTaskGroup { group in
+                    for name in names {
+                        group.addTask {
+                            for await _ in self.notifications(named: name) {
+                                continuation.yield(())
+                            }
+                        }
+                    }
+                }
+                continuation.finish()
+            }
+            
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+}
+
+// Usage
+for await _ in NotificationCenter.default.notifications(
+    named: [.userDidLogin, UIApplication.didBecomeActiveNotification]
+) {
+    refreshData()
+}
+```
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 3.6: Discarding Task Groups](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Structured vs Unstructured Tasks
+
+### Structured (preferred)
+
+Bound to parent, inherit context, automatic cancellation:
+
+```swift
+// async let
+async let data1 = fetch(1)
+async let data2 = fetch(2)
+let results = await [data1, data2]
+
+// Task groups
+await withTaskGroup(of: Data.self) { group in
+    group.addTask { await fetch(1) }
+    group.addTask { await fetch(2) }
+}
+```
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 3.7: The difference between structured and unstructured tasks](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+### Unstructured (use sparingly)
+
+Independent lifecycle, manual cancellation:
+
+```swift
+// Regular task (unstructured but inherits priority)
+let task = Task {
+    await doWork()
+}
+
+// Detached task (completely independent)
+Task.detached(priority: .background) {
+    await cleanup()
+}
+```
+
+## Detached Tasks
+
+**Use as last resort.** They don't inherit:
+- Priority
+- Task-local values
+- Cancellation state
+
+```swift
+Task.detached(priority: .background) {
+    await DirectoryCleaner.cleanup()
+}
+```
+
+### When to use
+
+- Independent background work
+- No connection to parent needed
+- Acceptable to complete after parent cancels
+- No `self` references needed
+
+**Prefer**: Task groups or `async let` for most parallel work.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 3.4: Detached Tasks](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Task Priorities
+
+### Available priorities
+
+```swift
+.high           // Immediate user feedback
+.userInitiated  // User-triggered work (same as .high)
+.medium         // Default for detached tasks
+.utility        // Longer-running, non-urgent
+.low            // Similar to .background
+.background     // Lowest priority
+```
+
+### Setting priority
+
+```swift
+Task(priority: .background) {
+    await prefetchData()
+}
+```
+
+### Priority inheritance
+
+Structured tasks inherit parent priority:
+
+```swift
+Task(priority: .high) {
+    async let result = work() // Also .high
+    await result
+}
+```
+
+Detached tasks don't inherit:
+
+```swift
+Task(priority: .high) {
+    Task.detached {
+        // Runs at .medium (default)
+    }
+}
+```
+
+### Priority escalation
+
+System automatically elevates priority to prevent priority inversion:
+- Actor waiting on lower-priority task
+- High-priority task awaiting `.value` of lower-priority task
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 3.8: Managing Task priorities](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Task.sleep() vs Task.yield()
+
+### Task.sleep()
+
+Suspends for fixed duration, non-blocking:
+
+```swift
+try await Task.sleep(for: .seconds(5))
+```
+
+**Use for:**
+- Debouncing user input
+- Polling intervals
+- Rate limiting
+- Artificial delays
+
+**Respects cancellation** (throws `CancellationError`)
+
+### Task.yield()
+
+Temporarily suspends to allow other tasks to run:
+
+```swift
+await Task.yield()
+```
+
+**Use for:**
+- Testing async code
+- Allowing cooperative scheduling
+
+**Note**: If current task is highest priority, may resume immediately.
+
+### Practical: Debounced search
+
+```swift
+func search(_ query: String) async {
+    guard !query.isEmpty else {
+        searchResults = allResults
+        return
+    }
+    
+    do {
+        try await Task.sleep(for: .milliseconds(500))
+        searchResults = allResults.filter { $0.contains(query) }
+    } catch {
+        // Canceled (user kept typing)
+    }
+}
+
+// In SwiftUI
+.task(id: searchQuery) {
+    await searcher.search(searchQuery)
+}
+```
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 3.10: Task.yield() vs. Task.sleep()](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## async let vs TaskGroup
+
+| Feature | async let | TaskGroup |
+|---------|-----------|-----------|
+| Task count | Fixed at compile-time | Dynamic at runtime |
+| Syntax | Lightweight | More verbose |
+| Cancellation | Automatic on scope exit | Manual via `cancelAll()` |
+| Use when | 2-5 known parallel tasks | Loop-based parallel work |
+
+```swift
+// async let: Known task count
+async let user = fetchUser()
+async let settings = fetchSettings()
+let profile = Profile(user: await user, settings: await settings)
+
+// TaskGroup: Dynamic task count
+await withTaskGroup(of: Image.self) { group in
+    for url in urls {
+        group.addTask { await download(url) }
+    }
+}
+```
+
+## Advanced: Task Timeout Pattern
+
+Create timeout wrapper using task groups:
+
+```swift
+func withTimeout<T>(
+    _ duration: Duration,
+    operation: @Sendable @escaping () async throws -> T
+) async throws -> T {
+    try await withThrowingTaskGroup(of: T.self) { group in
+        group.addTask { try await operation() }
+        
+        group.addTask {
+            try await Task.sleep(for: duration)
+            throw TimeoutError()
+        }
+        
+        guard let result = try await group.next() else {
+            throw TimeoutError()
+        }
+        
+        group.cancelAll()
+        return result
+    }
+}
+
+// Usage
+let data = try await withTimeout(.seconds(5)) {
+    try await slowNetworkRequest()
+}
+```
+
+**`cancelAll()` is critical** — without it, the losing task keeps running until scope exit.
+
+`Task.sleep` throws `CancellationError` when the task is cancelled, making it a useful cancellation checkpoint in polling loops. `Task.yield()` only gives other tasks a chance to run and does not check cancellation — if the current task has the highest priority, it may resume immediately.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 3.14: Creating a Task timeout handler using a Task Group (advanced)](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Common Patterns
+
+### Sequential with early exit
+
+```swift
+let user = try await fetchUser()
+guard user.isActive else { return }
+
+let posts = try await fetchPosts(userId: user.id)
+```
+
+### Parallel independent work
+
+```swift
+async let user = fetchUser()
+async let settings = fetchSettings()
+async let notifications = fetchNotifications()
+
+let data = try await (user, settings, notifications)
+```
+
+### Mixed: Sequential then parallel
+
+```swift
+let user = try await fetchUser()
+
+async let posts = fetchPosts(userId: user.id)
+async let followers = fetchFollowers(userId: user.id)
+
+let profile = Profile(
+    user: user,
+    posts: try await posts,
+    followers: try await followers
+)
+```
+
+## Common Mistakes Agents Make
+
+- Replacing structured child work with many unrelated top-level tasks.
+- Using `Task.detached` just to "make it background."
+- Ignoring cancellation in long-running operations.
+- Keeping a stored task forever without a clear owner or cleanup path.
+- Priorities are hints, not guarantees. The system automatically elevates priority to prevent inversion (e.g., a high-priority task awaiting `.value` of a lower-priority task). Do not rely on priority for correctness.
+
+## Best Practices
+
+1. **Check cancellation regularly** in long-running tasks
+2. **Use structured concurrency** (avoid detached tasks)
+3. **Leverage SwiftUI's `.task` modifier** for view-bound work
+4. **Choose the right tool**: `async let` for fixed, TaskGroup for dynamic
+5. **Handle errors explicitly** in throwing task groups
+6. **Set priority only when needed** (inherit by default)
+7. **Don't mutate task groups** from outside their creation context
+
+## Further Learning
+
+For hands-on examples, advanced patterns, and migration strategies, see [Swift Concurrency Course](https://www.swiftconcurrencycourse.com).
+

--- a/.agents/skills/swift-concurrency/references/testing.md
+++ b/.agents/skills/swift-concurrency/references/testing.md
@@ -1,0 +1,592 @@
+# Testing Concurrent Code
+
+Use this when:
+
+- You are writing async tests.
+- A test is flaky because of task scheduling or actor isolation.
+- You need to replace XCTest waiting APIs or verify deallocation.
+
+Skip this file if:
+
+- You mainly need production ownership guidance. Use `actors.md`, `tasks.md`, or `memory-management.md`.
+
+Jump to:
+
+- Swift Testing (Recommended)
+- Awaiting Async Callbacks
+- Setup and Teardown
+- Handling Flaky Tests
+- Swift Concurrency Extras
+- XCTest Patterns (Legacy)
+- Memory Management Tests
+- Testing Checklist
+
+## Recommendation: Use Swift Testing
+
+**Swift Testing is strongly recommended** for new projects and tests. It provides:
+- Modern Swift syntax with macros
+- Better concurrency support
+- Cleaner test structure
+- More flexible test organization
+
+XCTest patterns are included for legacy codebases.
+
+## Swift Testing Basics
+
+### Simple async test
+
+```swift
+@Test
+@MainActor
+func emptyQuery() async {
+    let searcher = ArticleSearcher()
+    await searcher.search("")
+    #expect(searcher.results == ArticleSearcher.allArticles)
+}
+```
+
+**Key differences from XCTest**:
+- `@Test` macro instead of `XCTestCase`
+- `#expect` instead of `XCTAssert`
+- Structs preferred over classes
+- No `test` prefix required
+
+### Testing with actors
+
+```swift
+@Test
+@MainActor
+func searchReturnsResults() async {
+    let searcher = ArticleSearcher()
+    await searcher.search("swift")
+    #expect(!searcher.results.isEmpty)
+}
+```
+
+Mark test with actor if system under test requires it.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 11.2: Testing concurrent code using Swift Testing](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Awaiting Async Callbacks
+
+### Using continuations
+
+When testing unstructured tasks:
+
+```swift
+@Test
+@MainActor
+func searchTaskCompletes() async {
+    let searcher = ArticleSearcher()
+    
+    await withCheckedContinuation { continuation in
+        _ = withObservationTracking {
+            searcher.results
+        } onChange: {
+            continuation.resume()
+        }
+        
+        searcher.startSearchTask("swift")
+    }
+    
+    #expect(searcher.results.count > 0)
+}
+```
+
+**Use when**: Testing code that spawns unstructured tasks.
+
+### Using confirmations
+
+For structured async code:
+
+```swift
+@Test
+@MainActor
+func searchTriggersObservation() async {
+    let searcher = ArticleSearcher()
+    
+    await confirmation { confirm in
+        _ = withObservationTracking {
+            searcher.results
+        } onChange: {
+            confirm()
+        }
+        
+        // Must await here for confirmation to work
+        await searcher.search("swift")
+    }
+    
+    #expect(!searcher.results.isEmpty)
+}
+```
+
+**Critical**: Must `await` async work for confirmation to validate.
+
+## Setup and Teardown
+
+### Using init/deinit
+
+```swift
+@MainActor
+final class DatabaseTests {
+    let database: Database
+    
+    init() async throws {
+        database = Database()
+        await database.prepare()
+    }
+    
+    deinit {
+        // Synchronous cleanup only
+    }
+    
+    @Test
+    func insertsData() async throws {
+        try await database.insert(item)
+        #expect(await database.count() == 1)
+    }
+}
+```
+
+**Limitation**: `deinit` cannot call async methods.
+
+### Test Scoping Traits
+
+For async teardown:
+
+```swift
+@MainActor
+struct DatabaseTrait: SuiteTrait, TestTrait, TestScoping {
+    func provideScope(
+        for test: Test,
+        testCase: Test.Case?,
+        performing function: () async throws -> Void
+    ) async throws {
+        let database = Database()
+        
+        try await Environment.$database.withValue(database) {
+            await database.prepare()
+            try await function()
+            await database.cleanup() // Async teardown
+        }
+    }
+}
+
+// Environment for task-local storage
+@MainActor
+struct Environment {
+    @TaskLocal static var database = Database()
+}
+
+// Apply to suite
+@Suite(DatabaseTrait())
+@MainActor
+final class DatabaseTests {
+    @Test
+    func insertsData() async throws {
+        try await Environment.database.insert(item)
+    }
+}
+
+// Or apply to individual test
+@Test(DatabaseTrait())
+func specificTest() async throws {
+    // Test code
+}
+```
+
+**Use when**: Need async cleanup after each test.
+
+## Handling Flaky Tests
+
+### Problem: Race conditions
+
+```swift
+@Test
+@MainActor
+func isLoadingState() async throws {
+    let fetcher = ImageFetcher()
+    
+    let task = Task { try await fetcher.fetch(url) }
+    
+    // ❌ Flaky - may pass or fail
+    #expect(fetcher.isLoading == true)
+    
+    try await task.value
+    #expect(fetcher.isLoading == false)
+}
+```
+
+**Issue**: Task may complete before we check `isLoading`.
+
+### Solution: Swift Concurrency Extras
+
+```swift
+import ConcurrencyExtras
+
+@Test
+@MainActor
+func isLoadingState() async throws {
+    try await withMainSerialExecutor {
+        let fetcher = ImageFetcher { url in
+            await Task.yield() // Allow test to check state
+            return Data()
+        }
+        
+        let task = Task { try await fetcher.fetch(url) }
+        
+        await Task.yield() // Switch to task
+        
+        #expect(fetcher.isLoading == true) // ✅ Reliable
+        
+        try await task.value
+        #expect(fetcher.isLoading == false)
+    }
+}
+```
+
+**Add package**: `https://github.com/pointfreeco/swift-concurrency-extras.git`
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 11.3: Using Swift Concurrency Extras by Point-Free](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+### Serial execution required
+
+```swift
+@Suite(.serialized)
+@MainActor
+final class ImageFetcherTests {
+    // Tests run serially when using withMainSerialExecutor
+}
+```
+
+**Critical**: Main serial executor doesn't work with parallel test execution.
+
+## XCTest Patterns (Legacy)
+
+### Basic async test
+
+```swift
+final class ArticleSearcherTests: XCTestCase {
+    @MainActor
+    func testEmptyQuery() async {
+        let searcher = ArticleSearcher()
+        await searcher.search("")
+        XCTAssertEqual(searcher.results, ArticleSearcher.allArticles)
+    }
+}
+```
+
+### Using expectations
+
+```swift
+@MainActor
+func testSearchTask() async {
+    let searcher = ArticleSearcher()
+    let expectation = expectation(description: "Search complete")
+    
+    _ = withObservationTracking {
+        searcher.results
+    } onChange: {
+        expectation.fulfill()
+    }
+    
+    searcher.startSearchTask("swift")
+    
+    // Use fulfillment, not wait
+    await fulfillment(of: [expectation], timeout: 10)
+    
+    XCTAssertEqual(searcher.results.count, 1)
+}
+```
+
+**Critical**: Use `await fulfillment(of:)`, not `wait(for:)` to avoid deadlocks.
+
+### Setup and teardown
+
+```swift
+final class DatabaseTests: XCTestCase {
+    override func setUp() async throws {
+        // Async setup
+    }
+    
+    override func tearDown() async throws {
+        // Async teardown
+    }
+}
+```
+
+Mark as `async throws` to call async methods.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 11.1: Testing concurrent code using XCTest](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+### Main serial executor for all tests
+
+```swift
+final class MyTests: XCTestCase {
+    override func invokeTest() {
+        withMainSerialExecutor {
+            super.invokeTest()
+        }
+    }
+}
+```
+
+## Common Patterns
+
+### Testing @MainActor code
+
+```swift
+@Test
+@MainActor
+func viewModelUpdates() async {
+    let viewModel = ViewModel()
+    await viewModel.loadData()
+    #expect(viewModel.items.count > 0)
+}
+```
+
+### Testing actors
+
+```swift
+@Test
+func actorIsolation() async {
+    let store = DataStore()
+    await store.insert(item)
+    let count = await store.count()
+    #expect(count == 1)
+}
+```
+
+### Testing cancellation
+
+```swift
+@Test
+func cancellationStopsWork() async throws {
+    let processor = DataProcessor()
+    
+    let task = Task {
+        try await processor.processLargeDataset()
+    }
+    
+    task.cancel()
+    
+    do {
+        try await task.value
+        Issue.record("Should have thrown cancellation error")
+    } catch is CancellationError {
+        // Expected
+    }
+}
+```
+
+### Testing with delays
+
+```swift
+@Test
+func debouncedSearch() async throws {
+    try await withMainSerialExecutor {
+        let searcher = DebouncedSearcher()
+        
+        searcher.search("a")
+        await Task.yield()
+        
+        searcher.search("ab")
+        await Task.yield()
+        
+        searcher.search("abc")
+        
+        // Wait for debounce
+        try await Task.sleep(for: .milliseconds(600))
+        
+        #expect(searcher.searchCount == 1) // Only last search executed
+    }
+}
+```
+
+### Testing task groups
+
+```swift
+@Test
+func taskGroupProcessesAll() async throws {
+    let processor = BatchProcessor()
+    
+    let results = await withTaskGroup(of: Int.self) { group in
+        for i in 1...5 {
+            group.addTask { await processor.process(i) }
+        }
+        
+        var collected: [Int] = []
+        for await result in group {
+            collected.append(result)
+        }
+        return collected
+    }
+    
+    #expect(results.count == 5)
+}
+```
+
+## Testing Memory Management
+
+### Verify deallocation
+
+```swift
+@Test
+func viewModelDeallocates() async {
+    var viewModel: ViewModel? = ViewModel()
+    weak var weakViewModel = viewModel
+    
+    viewModel?.startWork()
+    viewModel = nil
+    
+    try? await Task.sleep(for: .milliseconds(100))
+    
+    #expect(weakViewModel == nil)
+}
+```
+
+### Detect retain cycles
+
+```swift
+@Test
+func noRetainCycle() async {
+    var manager: Manager? = Manager()
+    weak var weakManager = manager
+    
+    manager?.startLongRunningTask()
+    manager = nil
+    
+    #expect(weakManager == nil)
+}
+```
+
+## Best Practices
+
+1. **Use Swift Testing for new code** - modern, better concurrency support
+2. **Mark tests with correct isolation** - @MainActor when needed
+3. **Use confirmations over continuations** - when structured concurrency allows
+4. **Serialize tests with main serial executor** - avoid flaky tests
+5. **Test cancellation explicitly** - ensure proper cleanup
+6. **Verify deallocation** - catch retain cycles early
+7. **Use Task.yield() strategically** - control execution in tests
+8. **Avoid sleep in tests** - use continuations/confirmations instead
+9. **Test actor isolation** - verify thread safety
+10. **Keep tests deterministic** - avoid timing dependencies
+
+## Migration from XCTest
+
+### XCTest → Swift Testing
+
+```swift
+// XCTest
+final class MyTests: XCTestCase {
+    func testExample() async {
+        XCTAssertEqual(value, expected)
+    }
+}
+
+// Swift Testing
+@Suite
+struct MyTests {
+    @Test
+    func example() async {
+        #expect(value == expected)
+    }
+}
+```
+
+### Expectations → Confirmations
+
+```swift
+// XCTest
+let expectation = expectation(description: "Done")
+doWork { expectation.fulfill() }
+await fulfillment(of: [expectation])
+
+// Swift Testing
+await confirmation { confirm in
+    await doWork { confirm() }
+}
+```
+
+### Setup/Teardown → Traits
+
+```swift
+// XCTest
+override func setUp() async throws {
+    await prepare()
+}
+
+// Swift Testing
+struct SetupTrait: TestTrait, TestScoping {
+    func provideScope(
+        for test: Test,
+        testCase: Test.Case?,
+        performing function: () async throws -> Void
+    ) async throws {
+        await prepare()
+        try await function()
+    }
+}
+```
+
+## Troubleshooting
+
+### Test hangs
+
+**Cause**: Waiting for expectation that never fulfills.
+
+**Solution**: Add timeout, verify observation tracking.
+
+### Flaky test
+
+**Cause**: Race condition in unstructured task.
+
+**Solution**: Use main serial executor + Task.yield().
+
+### Deadlock
+
+**Cause**: Using `wait(for:)` in async context.
+
+**Solution**: Use `await fulfillment(of:)` instead.
+
+### Confirmation fails
+
+**Cause**: Not awaiting async work in confirmation block.
+
+**Solution**: Add `await` before async calls.
+
+### Actor isolation error
+
+**Cause**: Test not marked with required actor.
+
+**Solution**: Add `@MainActor` or appropriate actor to test.
+
+## Common Mistakes Agents Make
+
+- **Flaky intermediate-state assertions**: Asserting `isLoading == true` immediately after creating a `Task` is a race condition — the task may not have started yet. Use `withMainSerialExecutor` + `Task.yield()` to control scheduling before asserting intermediate state.
+- **Using `Task.sleep` as a synchronization primitive** in tests instead of deterministic scheduling.
+- **Asserting intermediate state without controlling scheduling**: Always use `withMainSerialExecutor` when you need to observe state between task creation and completion. Note: `withMainSerialExecutor` does not work with parallel test execution — mark the suite `@Suite(.serialized)`.
+- **Reaching into isolated internals** instead of testing public behavior.
+- **Keeping both Swift Testing and XCTest versions** of the same example unless they teach different migration paths.
+
+## Testing Checklist
+
+- [ ] Tests marked with correct isolation
+- [ ] Using Swift Testing (recommended)
+- [ ] Async methods properly awaited
+- [ ] Cancellation tested
+- [ ] Memory leaks checked
+- [ ] Race conditions handled
+- [ ] Timeouts appropriate
+- [ ] Flaky tests fixed with serial executor
+- [ ] Actor isolation verified
+- [ ] Cleanup in traits (not deinit)
+
+## Further Learning
+
+For advanced testing patterns, real-world examples, and migration strategies:
+- [Swift Testing Documentation](https://developer.apple.com/documentation/testing)
+- [Swift Concurrency Extras](https://github.com/pointfreeco/swift-concurrency-extras)
+- [Swift Concurrency Course](https://www.swiftconcurrencycourse.com)
+

--- a/.agents/skills/swift-concurrency/references/threading.md
+++ b/.agents/skills/swift-concurrency/references/threading.md
@@ -1,0 +1,497 @@
+# Threading
+
+Use this when:
+
+- You need to understand the relationship between tasks and threads.
+- You are debugging suspension points, actor reentrancy, or unexpected execution contexts.
+- You need Swift 6.2 behavior guidance (`nonisolated async`, `@concurrent`, `nonisolated(nonsending)`).
+
+Skip this file if:
+
+- You mainly need to protect mutable state. Use `actors.md`.
+- You need to make types safe to transfer. Use `sendable.md`.
+
+Jump to:
+
+- Core Concepts (Tasks vs Threads)
+- Cooperative Thread Pool
+- Suspension Points and Actor Reentrancy
+- Swift 6.2 Changes (SE-461, SE-466)
+- Default Isolation Domain
+- Debugging Thread Execution
+- Common Misconceptions
+- Migration Strategy
+
+## Core Concepts
+
+### What is a Thread?
+
+System-level resource that runs instructions. High overhead for creation and switching. Swift Concurrency abstracts thread management away.
+
+### Tasks vs Threads
+
+**Tasks** are units of async work, not tied to specific threads. Swift dynamically schedules tasks on available threads from a cooperative pool.
+
+**Key insight**: No direct relationship between one task and one thread.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 7.1: How Threads relate to Tasks](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+**Important (Swift 6+)**: Avoid using `Thread.current` inside async contexts. In Swift 6 language mode, `Thread.current` is unavailable from asynchronous contexts and will fail to compile. Prefer reasoning in terms of isolation domains; use Instruments and the debugger to observe execution when needed.
+
+## Cooperative Thread Pool
+
+Swift creates only as many threads as CPU cores. Tasks share these threads efficiently.
+
+### How it works
+
+1. **Limited threads**: Number matches CPU cores
+2. **Task scheduling**: Tasks scheduled onto available threads
+3. **Suspension**: At `await`, task suspends, thread freed for other work
+4. **Resumption**: Task resumes on any available thread (not necessarily the same one)
+
+```swift
+func example() async {
+    print("Started on: \(Thread.current)")
+    
+    try await Task.sleep(for: .seconds(1))
+    
+    print("Resumed on: \(Thread.current)") // Likely different thread
+}
+```
+
+### Benefits over GCD
+
+**Prevents thread explosion**:
+- No excessive thread creation
+- No high memory overhead from idle threads
+- No excessive context switching
+- No priority inversion
+
+**Better performance**:
+- Fewer threads = less context switching
+- Continuations instead of blocking
+- CPU cores stay busy efficiently
+
+## Threading Mindset → Isolation Mindset
+
+### Old way (GCD)
+
+```swift
+// Thinking about threads
+DispatchQueue.main.async {
+    // Update UI on main thread
+}
+
+DispatchQueue.global(qos: .background).async {
+    // Heavy work on background thread
+}
+```
+
+### New way (Swift Concurrency)
+
+```swift
+// Thinking about isolation domains
+@MainActor
+func updateUI() {
+    // Runs on main actor (usually main thread)
+}
+
+func heavyWork() async {
+    // Runs on any available thread in pool
+}
+```
+
+### Think in isolation domains
+
+**Don't ask**: "What thread should this run on?"
+
+**Ask**: "What isolation domain should own this work?"
+
+- `@MainActor` for UI updates
+- Custom actors for specific state
+- Nonisolated for general async work
+
+### Provide hints, not commands
+
+```swift
+Task(priority: .userInitiated) {
+    await doWork()
+}
+```
+
+You're describing the nature of work, not assigning threads. Swift optimizes execution.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 7.2: Getting rid of the "Threading Mindset"](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Suspension Points
+
+### What is a suspension point?
+
+Moment where task **may** pause to allow other work. Marked by `await`.
+
+```swift
+let data = await fetchData() // Potential suspension
+```
+
+**Critical**: `await` marks *possible* suspension, not guaranteed. If operation completes synchronously, no suspension occurs.
+
+### Why suspension points matter
+
+1. **Code may pause unexpectedly** - resumes later, possibly different thread
+2. **State can change** - mutable state may be modified during suspension
+3. **Actor reentrancy** - other tasks can access actor during suspension
+
+`Task.sleep` follows the same rule: it suspends the task rather than blocking a thread. That still does not make actor choice irrelevant. If a delayed retry starts on `@MainActor`, it may wait for main-actor availability before reaching `Task.sleep` when scheduled from another executor or while the main actor is busy. Prefer `@concurrent` when the delay itself is not UI-owned, then hop back with `MainActor.run` for the final UI mutation.
+
+### Actor reentrancy example
+
+```swift
+actor BankAccount {
+    private var balance: Int = 0
+    
+    func deposit(amount: Int) async {
+        balance += amount
+        print("Balance: \(balance)")
+        
+        await logTransaction(amount) // ⚠️ Suspension point
+        
+        balance += 10 // Bonus
+        print("After bonus: \(balance)")
+    }
+    
+    func logTransaction(_ amount: Int) async {
+        try? await Task.sleep(for: .seconds(1))
+    }
+}
+
+// Two concurrent deposits
+async let _ = account.deposit(amount: 100)
+async let _ = account.deposit(amount: 100)
+
+// Unexpected: 100 → 200 → 210 → 220
+// Expected:   100 → 110 → 210 → 220
+```
+
+**Why**: During `logTransaction`, second deposit runs, modifying balance before first completes.
+
+### Avoiding reentrancy bugs
+
+**Complete actor work before suspending**:
+
+```swift
+func deposit(amount: Int) async {
+    balance += amount
+    balance += 10 // Bonus applied first
+    print("Final balance: \(balance)")
+    
+    await logTransaction(amount) // Suspend after state changes
+}
+```
+
+**Rule**: Don't mutate actor state after suspension points.
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 7.3: Understanding Task suspension points](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+## Thread Execution Patterns
+
+### Default: Background threads
+
+Tasks run on cooperative thread pool (background threads):
+
+```swift
+Task {
+    print(Thread.current) // Background thread
+}
+```
+
+### Main thread execution
+
+Use `@MainActor` for main thread:
+
+```swift
+@MainActor
+func updateUI() {
+    Task {
+        print(Thread.current) // Main thread
+    }
+}
+```
+
+### Inheritance example
+
+```swift
+@MainActor
+func updateUI() {
+    print("Main thread: \(Thread.current)")
+    
+    await backgroundTask() // Switches to background
+    
+    print("Back on main: \(Thread.current)") // Returns to main
+}
+
+func backgroundTask() async {
+    print("Background: \(Thread.current)")
+}
+```
+
+## Swift 6.2 Changes
+
+### Nonisolated async functions (SE-461)
+
+**Old behavior**: Nonisolated async functions always switch to background.
+
+**New behavior**: Inherit caller's isolation by default.
+
+```swift
+class NotSendable {
+    func performAsync() async {
+        print(Thread.current)
+    }
+}
+
+@MainActor
+func caller() async {
+    let obj = NotSendable()
+    await obj.performAsync()
+    // Old: Background thread
+    // New: Main thread (inherits @MainActor)
+}
+```
+
+### Enabling new behavior
+
+In Xcode 16+:
+
+```swift
+// Build setting or swift-settings
+.enableUpcomingFeature("NonisolatedNonsendingByDefault")
+```
+
+### Opting out with @concurrent
+
+Force function to switch away from caller's isolation:
+
+```swift
+@concurrent
+func performAsync() async {
+    print(Thread.current) // Always background
+}
+```
+
+### nonisolated(nonsending)
+
+Prevent sending non-Sendable values across isolation:
+
+```swift
+nonisolated(nonsending) func storeTouch(...) async {
+    // Runs on caller's isolation, no value sending
+}
+```
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 7.4: Dispatching to different threads using nonisolated(nonsending) and @concurrent (Updated for Swift 6.2)](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+**Use when**: Method doesn't need to switch isolation, avoiding Sendable requirements.
+
+## Default Isolation Domain (SE-466)
+
+### Configuring default isolation
+
+**Build setting** (Xcode 16+):
+- Default Actor Isolation: `MainActor` or `None`
+
+**Swift Package**:
+
+```swift
+.target(
+    name: "MyTarget",
+    swiftSettings: [
+        .defaultIsolation(MainActor.self)
+    ]
+)
+```
+
+### Why change default?
+
+Most app code runs on main thread. Setting `@MainActor` as default:
+- Reduces false warnings
+- Avoids "concurrency rabbit hole"
+- Makes migration easier
+
+### Inference with @MainActor default
+
+```swift
+// With @MainActor as default:
+
+func f() {} // Inferred: @MainActor
+
+class C {
+    init() {} // Inferred: @MainActor
+    static var value = 10 // Inferred: @MainActor
+}
+
+@MyActor
+struct S {
+    func f() {} // Inferred: @MyActor (explicit override)
+}
+
+> **Course Deep Dive**: This topic is covered in detail in [Lesson 7.5: Controlling the default isolation domain (Updated for Swift 6.2)](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+```
+
+### Per-module setting
+
+Must opt in for each module/package. Not global across dependencies.
+
+### Backward compatibility
+
+Opt-in only. Default remains `nonisolated` if not specified.
+
+## Debugging Thread Execution
+
+### Print current thread
+
+**⚠️ Important**: `Thread.current` is unavailable in Swift 6 language mode from async contexts. The compiler error states: "Class property 'current' is unavailable from asynchronous contexts; Thread.current cannot be used from async contexts."
+
+**Workaround** (Swift 6+ mode only):
+
+```swift
+extension Thread {
+    public static var currentThread: Thread {
+        Thread.current
+    }
+}
+
+print("Thread: \(Thread.currentThread)")
+```
+
+### Debug navigator
+
+1. Set breakpoint in task
+2. Debug → Pause
+3. Check Debug Navigator for thread info
+
+### Verify main thread
+
+```swift
+assert(Thread.isMainThread)
+```
+
+## Common Misconceptions
+
+### ❌ Each Task runs on new thread
+
+**Wrong**. Tasks share limited thread pool, reuse threads.
+
+### ❌ await blocks the thread
+
+**Wrong**. `await` suspends task without blocking thread. Other tasks can use the thread.
+
+### ❌ Task execution order is guaranteed
+
+**Wrong**. Tasks execute based on system scheduling. Use `await` to enforce order.
+
+### ❌ Same task = same thread
+
+**Wrong**. Task can resume on different thread after suspension.
+
+## Why Sendable Matters
+
+Since tasks move between threads unpredictably:
+
+```swift
+func example() async {
+    print("Thread 1: \(Thread.current)")
+    
+    await someWork()
+    
+    print("Thread 2: \(Thread.current)") // Different thread
+}
+```
+
+Values crossing suspension points may cross threads. **Sendable** ensures safety.
+
+## Best Practices
+
+1. **Stop thinking about threads** - think isolation domains
+2. **Trust the system** - Swift optimizes thread usage
+3. **Use @MainActor for UI** - clear, explicit main thread execution
+4. **Minimize suspension points in actors** - avoid reentrancy bugs
+5. **Complete state changes before suspending** - prevent inconsistent state
+6. **Use priorities as hints** - not guarantees
+7. **Make types Sendable** - safe across thread boundaries
+8. **Enable Swift 6.2 features** - easier migration, better defaults
+9. **Set default isolation for apps** - reduce false warnings
+10. **Don't force thread switching** - let Swift optimize
+
+## Migration Strategy
+
+### For new projects (Xcode 16+)
+
+1. Set default isolation to `@MainActor`
+2. Enable `NonisolatedNonsendingByDefault`
+3. Use `@concurrent` for explicit background work
+
+### For existing projects
+
+1. Gradually enable Swift 6 language mode
+2. Consider default isolation change
+3. Use `@concurrent` to maintain old behavior where needed
+4. Migrate module by module
+
+## Decision Tree
+
+```
+Need to control execution?
+├─ UI updates? → @MainActor
+├─ Specific state isolation? → Custom actor
+├─ Background work? → Regular async (trust Swift)
+└─ Need to force background? → @concurrent (Swift 6.2+)
+
+Seeing Sendable warnings?
+├─ Can make type Sendable? → Add conformance
+├─ Same isolation OK? → nonisolated(nonsending)
+└─ Need different isolation? → Make Sendable or refactor
+```
+
+## GCD to Isolation Domain Migration
+
+Instead of asking "what thread should this run on?" ask "what isolation domain should own this work?"
+
+- `DispatchQueue.main.async { }` → `@MainActor func updateUI()`
+- `DispatchQueue.global().async { }` → `func work() async` (or `@concurrent` if it must leave caller isolation)
+- `DispatchQueue(label:).sync { }` → `actor` or `Mutex` for protecting state
+- Serial queue for ordering → `actor` (guarantees serial access)
+
+## Decision Rules
+
+- UI state → usually `@MainActor`
+- Mutable shared state → usually an `actor`
+- Plain async work with no isolated state → `async` API with explicit ownership
+- Work that must hop away from caller isolation under Swift 6.2-era behavior → consider `@concurrent`
+
+## Common Mistakes Agents Make
+
+- Recommending GCD queue hopping when actor isolation already expresses the ownership model.
+- Debugging correctness by thread ID instead of by isolation and ordering.
+- Treating `await` as a blocking call — it suspends the task, freeing the thread.
+- Mapping each `Task` to a conceptual thread.
+
+## Performance Insights
+
+### Why fewer threads = better performance
+
+- **Less context switching**: CPU spends more time on actual work
+- **Better cache utilization**: Threads stay on same cores longer
+- **No thread explosion**: Predictable resource usage
+- **Forward progress**: Threads never block, always productive
+
+### Cooperative pool advantages
+
+- Matches hardware (one thread per core)
+- Prevents oversubscription
+- Efficient task scheduling
+- Automatic load balancing
+
+## Further Learning
+
+For migration strategies, real-world examples, and advanced threading patterns, see [Swift Concurrency Course](https://www.swiftconcurrencycourse.com).
+

--- a/.agents/skills/swift-testing-expert/SKILL.md
+++ b/.agents/skills/swift-testing-expert/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: swift-testing-expert
+description: 'Expert guidance for Swift Testing: test structure, #expect/#require macros, traits and tags, parameterized tests, test plans, parallel execution, async waiting patterns, and XCTest migration. Use when writing new Swift tests, modernizing XCTest suites, debugging flaky tests, or improving test quality and maintainability in Apple-platform or Swift server projects.'
+---
+
+# Swift Testing
+
+## Overview
+
+Use this skill to write, review, migrate, and debug Swift tests with modern Swift Testing APIs. Prioritize readable tests, robust parallel execution, clear diagnostics, and incremental migration from XCTest where needed.
+
+## Agent behavior contract (follow these rules)
+
+1. Prefer Swift Testing for Swift unit and integration tests, but keep XCTest for UI automation (`XCUIApplication`), performance metrics (`XCTMetric`), and Objective-C-only test code.
+2. Treat `#expect` as the default assertion and use `#require` when subsequent lines depend on a prerequisite value.
+3. Default to parallel-safe guidance. If tests are not isolated, first propose fixing shared state before applying `.serialized`.
+4. Prefer traits for behavior and metadata (`.enabled`, `.disabled`, `.timeLimit`, `.bug`, tags) over naming conventions or ad-hoc comments.
+5. Recommend parameterized tests when multiple tests share logic and differ only in input values.
+6. Use `@available` on test functions for OS-gated behavior instead of runtime `#available` checks inside test bodies; never annotate suite types with `@available`.
+7. Keep migration advice incremental: convert assertions first, then organize suites, then introduce parameterization/traits.
+8. Only import `Testing` in test targets, never in app/library/binary targets.
+
+## First 60 seconds (triage template)
+
+- Clarify the goal: new tests, migration, flaky failures, performance, CI filtering, or async waiting.
+- Collect minimal facts:
+  - Xcode/Swift version and platform targets
+  - Whether tests currently use XCTest, Swift Testing, or both
+  - Whether failures are deterministic or flaky
+  - Whether tests access shared resources (database, files, network, global state)
+- Branch quickly:
+  - repetitive tests -> parameterized tests
+  - noisy or flaky failures -> known issue handling and test isolation
+  - migration questions -> XCTest mapping and coexistence strategy
+  - async callback complexity -> continuation/await patterns
+
+## Routing map (read the right reference fast)
+
+- Test building blocks and suite organization -> `references/fundamentals.md`
+- `#expect`, `#require`, and throw expectations -> `references/expectations.md`
+- Traits, tags, and Xcode test-plan filtering -> `references/traits-and-tags.md`
+- Parameterized test design and combinatorics -> `references/parameterized-testing.md`
+- Default parallel execution, `.serialized`, isolation strategy -> `references/parallelization-and-isolation.md`
+- Test speed, determinism, and flakiness prevention -> `references/performance-and-best-practices.md`
+- Async waiting and callback bridging -> `references/async-testing-and-waiting.md`
+- XCTest coexistence and migration workflow -> `references/migration-from-xctest.md`
+- Test navigator/report workflows and diagnostics -> `references/xcode-workflows.md`
+- Index and quick navigation -> `references/_index.md`
+
+## Common pitfalls -> next best move
+
+- Repetitive `testFooCaseA/testFooCaseB/...` methods -> replace with one parameterized `@Test(arguments:)`.
+- Failing optional preconditions hidden in later assertions -> `try #require(...)` then assert on unwrapped value.
+- Flaky integration tests on shared database -> isolate dependencies or in-memory repositories; use `.serialized` only as a transition step.
+- Disabled tests that silently rot -> prefer `withKnownIssue` for temporary known failures to preserve signal.
+- Unclear failure values for complex types -> conform type to `CustomTestStringConvertible` for focused test diagnostics.
+- Test-plan include/exclude by names -> use tags and tag-based filters instead.
+
+## Verification checklist
+
+- Confirm each test has a single clear behavior and expressive display name when needed.
+- Confirm prerequisites use `#require` where failure should stop the test.
+- Confirm repeated logic is parameterized instead of duplicated.
+- Confirm tests are parallel-safe or intentionally serialized with rationale.
+- Confirm async code is awaited and callback APIs are bridged safely.
+- Confirm migration keeps unsupported XCTest-only scenarios on XCTest.
+
+## References
+
+- `references/_index.md`
+- `references/fundamentals.md`
+- `references/expectations.md`
+- `references/traits-and-tags.md`
+- `references/parameterized-testing.md`
+- `references/parallelization-and-isolation.md`
+- `references/performance-and-best-practices.md`
+- `references/async-testing-and-waiting.md`
+- `references/migration-from-xctest.md`
+- `references/xcode-workflows.md`

--- a/.agents/skills/swift-testing-expert/references/_index.md
+++ b/.agents/skills/swift-testing-expert/references/_index.md
@@ -1,0 +1,12 @@
+# Swift Testing Reference Index
+
+- `fundamentals.md` - `@Test`, suites, structure, naming, and baseline patterns
+- `expectations.md` - `#expect`, `#require`, throw validation, and failure readability
+- `traits-and-tags.md` - traits, tags, bug linking, conditions, and test-plan filtering
+- `parameterized-testing.md` - single/multi-argument parameterization, `zip`, and scaling strategy
+- `parallelization-and-isolation.md` - default parallel execution, random order, `.serialized`, and isolation patterns
+- `performance-and-best-practices.md` - test speed, determinism, flaky-test prevention, and parallel-safe defaults
+- `async-testing-and-waiting.md` - async/await in tests, callback bridging, and event-stream verification
+- `migration-from-xctest.md` - pragmatic XCTest -> Swift Testing migration workflow
+- `xcode-workflows.md` - navigator/report workflows, insights, and diagnostics quality
+- `README.md` resources section - Apple documentation links for defining, organizing, and migrating tests

--- a/.agents/skills/swift-testing-expert/references/async-testing-and-waiting.md
+++ b/.agents/skills/swift-testing-expert/references/async-testing-and-waiting.md
@@ -1,0 +1,127 @@
+# Async Testing and Waiting
+
+## When to use this reference
+
+Use this file when tests involve async/await functions, completion handlers, streams/events, or timing-related flakiness.
+
+## Preferred approach
+
+- Use async test functions and `await` naturally.
+- Keep async test code close to production async patterns.
+- Prefer structured concurrency patterns over ad-hoc synchronization.
+- Prefer confirmations for async event-style tests that are not naturally awaitable.
+
+### Async function test example
+
+```swift
+import Testing
+
+struct APIClient {
+ func fetchName() async throws -> String { "Antoine" }
+}
+
+@Test func fetchNameReturnsValue() async throws {
+ let client = APIClient()
+ let value = try await client.fetchName()
+ #expect(value == "Antoine")
+}
+```
+
+## Callback bridging
+
+- For completion-handler APIs without async overloads, bridge with:
+  - `withCheckedContinuation`
+  - `withCheckedThrowingContinuation`
+- Keep continuation wrappers minimal and test-focused.
+
+### Completion-handler to async bridge
+
+```swift
+import Testing
+
+func legacyLoad(_ completion: @escaping (Result<Int, Error>) -> Void) {
+ completion(.success(42))
+}
+
+@Test func legacyAPI() async throws {
+ let value = try await withCheckedThrowingContinuation { continuation in
+ legacyLoad { result in
+ continuation.resume(with: result)
+ }
+ }
+ #expect(value == 42)
+}
+```
+
+## Confirmations for asynchronous events
+
+- Use confirmations when validating event delivery/count semantics that do not map cleanly to direct `await`.
+- Set expected counts explicitly:
+  - exact count for strict validation
+  - lower-bounded range for at-least semantics
+- Keep confirmation scope small and ensure confirmations happen before the confirmation block returns.
+
+### Confirmation example
+
+```swift
+import Testing
+
+@Test func eventIsPublishedTwice() async {
+ await confirmation("Publishes two events", expectedCount: 2) { confirm in
+ confirm()
+ confirm()
+ }
+}
+```
+
+## Event handlers and multi-fire callbacks
+
+- Avoid unsafe mutable shared counters from callback closures in strict concurrency mode.
+- Use isolation-safe patterns (actor state, AsyncSequence wrappers, or thread-safe containers).
+- Verify callback counts and ordering explicitly when behavior depends on it.
+
+### Actor-isolated counting pattern
+
+```swift
+import Testing
+
+actor EventCounter {
+ private(set) var count = 0
+ func increment() { count += 1 }
+}
+
+@Test func countEventsSafely() async {
+ let counter = EventCounter()
+ await counter.increment()
+ await counter.increment()
+ #expect(await counter.count == 2)
+}
+```
+
+## Avoid legacy waiting anti-patterns
+
+- Do not return from test before async callback work completes.
+- Avoid sleeping/time-based waits as primary synchronization.
+- Replace brittle waiting with awaitable conditions and deterministic synchronization points.
+
+```swift
+// Avoid this pattern:
+// try await Task.sleep(nanoseconds: 500_000_000)
+// #expect(flag == true)
+```
+
+## Actor isolation in tests
+
+- Isolate tests to a global actor (e.g. `@MainActor`) only when behavior truly requires it.
+- Keep non-UI tests off main actor to preserve realistic concurrency behavior.
+
+### Main-actor test only when required
+
+```swift
+import Testing
+
+@MainActor
+@Test func uiModelMutation() {
+ #expect(true)
+}
+```

--- a/.agents/skills/swift-testing-expert/references/expectations.md
+++ b/.agents/skills/swift-testing-expert/references/expectations.md
@@ -1,0 +1,145 @@
+# Expectations
+
+## When to use this reference
+
+Use this file when writing assertions, migrating from `XCTAssert*`, testing thrown errors, or documenting known failures.
+
+## `#expect` as the default
+
+- Use `#expect` for most assertions.
+- Pass natural Swift expressions (`==`, `>`, `.contains`, `.isEmpty`, etc.).
+- Rely on captured sub-expression values for rich diagnostics in Xcode.
+- Avoid old XCTest assertion families in Swift Testing tests.
+
+### Example: expressive assertions
+
+```swift
+import Testing
+
+@Test func pricingRules() {
+ let subtotal = 25
+ let discount = 5
+ let total = subtotal - discount
+
+ #expect(total == 20)
+ #expect(total > 0)
+ #expect([10, 20, 30].contains(total))
+}
+```
+
+## `#require` for prerequisites
+
+- Use `try #require(...)` when later assertions depend on this condition.
+- Treat `#require` as "guard + fail test early".
+- Use return value to unwrap optionals safely and reduce noisy optional chaining.
+- Prefer this pattern over manual optional checks when failure should halt test flow.
+
+### Example: optional precondition + unwrapped usage
+
+```swift
+import Testing
+
+@Test func parsedURLHasHTTPS() throws {
+ let value = "https://www.avanderlee.com"
+ let url = try #require(URL(string: value), "URL should parse")
+ #expect(url.scheme == "https")
+}
+```
+
+## Throwing behavior checks
+
+- For success-path calls to throwing functions, call directly and assert returned value.
+- For expected failure, use throw-aware expectations to verify:
+  - any throw
+  - specific error type
+  - specific error case/value
+- Avoid verbose hand-written `do/catch` unless custom branching is truly needed.
+
+### Example: expected throw and no-throw
+
+```swift
+import Testing
+
+enum BrewError: Error, Equatable {
+ case missingBeans
+}
+
+func brew(_ hasBeans: Bool) throws -> String {
+ guard hasBeans else { throw BrewError.missingBeans }
+ return "coffee"
+}
+
+@Test func expectedThrows() {
+ #expect(throws: BrewError.self) {
+ try brew(false)
+ }
+}
+
+@Test func expectedNoThrow() {
+ #expect(throws: Never.self) {
+ try brew(true)
+ }
+}
+```
+
+## Known issue handling
+
+- Use `withKnownIssue` for temporary expected failures you still want to compile/run.
+- Prefer `withKnownIssue` over blanket disabling when you need ongoing visibility.
+- Remove known-issue wrappers once failure condition is fixed.
+
+### Example: scope only failing section
+
+```swift
+import Testing
+
+@Test func checkoutFlow() {
+ #expect(true) // still validated
+
+ withKnownIssue("Checkout backend intermittently returns 503", isIntermittent: true) {
+ Issue.record("Known upstream issue")
+ }
+
+ #expect(2 + 2 == 4) // rest of test still executes
+}
+```
+
+## Readability upgrade
+
+- Conform complex domain types to `CustomTestStringConvertible` for concise test output.
+- Keep production `CustomStringConvertible` separate from test-specific descriptions when needed.
+
+### Example: clean diagnostic descriptions
+
+```swift
+import Testing
+
+struct Receipt: CustomTestStringConvertible {
+ let id: UUID
+ let total: Decimal
+
+ var testDescription: String {
+ "Receipt(total: \(total))"
+ }
+}
+```
+
+## XCTest mapping quick examples
+
+```swift
+// XCTAssertEqual(total, 20)
+#expect(total == 20)
+
+// try XCTUnwrap(user)
+let user = try #require(user)
+
+// XCTFail("Unreachable")
+Issue.record("Unreachable")
+```
+
+## Do / Don't
+
+- Do use `#require` when later checks depend on a value.
+- Do keep `withKnownIssue` scopes narrow.
+- Don't use XCTest assertions in Swift Testing tests.
+- Don't hide prerequisite failures inside later optional chaining.

--- a/.agents/skills/swift-testing-expert/references/fundamentals.md
+++ b/.agents/skills/swift-testing-expert/references/fundamentals.md
@@ -1,0 +1,141 @@
+# Fundamentals
+
+## When to use this reference
+
+Use this file when creating new Swift Testing suites or refactoring test structure before deeper topics like traits, parameterization, or migration.
+
+## Building blocks
+
+- Import `Testing` only in test targets.
+- Use `@Test` to declare tests explicitly (global function or type method).
+- Use suites (`struct`, `actor`, or `class`) to group related tests.
+- Prefer `struct` suites for value semantics and accidental-state-sharing prevention.
+- Use `@Suite` when adding suite-level traits or display names.
+- Use nested suites to reflect feature grouping and improve discoverability.
+
+## Core examples
+
+### Global test function
+
+```swift
+import Testing
+@testable import FoodTruck
+
+@Test("Food truck has a valid default name")
+func defaultName() {
+ let truck = FoodTruck()
+ #expect(truck.name.isEmpty == false)
+}
+```
+
+### Suite with instance tests
+
+```swift
+import Testing
+@testable import FoodTruck
+
+@Suite("Menu tests")
+struct MenuTests {
+ @Test("Returns no duplicates")
+ func uniqueItems() {
+ let items = Menu.default.items
+ #expect(Set(items).count == items.count)
+ }
+}
+```
+
+### Nested suites for feature grouping
+
+```swift
+import Testing
+@testable import FoodTruck
+
+struct CheckoutTests {
+ struct Taxes {
+ @Test func taxIsRoundedToTwoDigits() {
+ let total = Checkout.total(subtotal: 10.00, taxRate: 0.0825)
+ #expect(total == 10.83)
+ }
+ }
+
+ struct Discounts {
+ @Test func promoCodeAppliesFixedAmount() {
+ let total = Checkout.total(subtotal: 20.00, discount: .fixed(5))
+ #expect(total == 15.00)
+ }
+ }
+}
+```
+
+## Recommended defaults
+
+- Keep tests small and behavior-focused.
+- Prefer descriptive names over boilerplate `test...` prefixes.
+- Use display names where human-readable output helps triage.
+- Keep setup local, or centralize in suite init when shared across tests.
+- Avoid hidden global mutable state.
+- Use `@MainActor` only when code under test requires main-thread isolation.
+- Use `@available` on test functions when needed for platform/language gating.
+
+## Organization guidance
+
+- Group by feature behavior, not by implementation class only.
+- Promote shared traits (e.g. tags) to suite level when all tests inherit them.
+- Use tags for cross-cutting grouping across files/targets.
+- Keep unrelated tests in separate suites to preserve clear ownership.
+
+## Suite constraints to enforce
+
+- If a suite has instance test methods, it must have a callable zero-argument initializer (implicit or explicit, sync/async, throwing or non-throwing).
+- If initialization requirements cannot be met, convert tests to static/global functions or refactor suite state.
+- Suite types (and containing types) must always be available; do not apply `@available` to suite declarations.
+
+### Zero-argument initializer requirement example
+
+```swift
+import Testing
+
+@Suite
+struct SessionTests {
+ let config: URLSessionConfiguration
+
+ // Valid: callable with zero args due to default value.
+ init(config: URLSessionConfiguration = .ephemeral) {
+ self.config = config
+ }
+
+ @Test func usesEphemeralByDefault() {
+ #expect(config == .ephemeral)
+ }
+}
+```
+
+### Invalid availability placement
+
+```swift
+import Testing
+
+// Do not do this on suite types:
+// @available(iOS 18, *)
+@Suite
+struct PushTests {
+ @available(iOS 18, *)
+ @Test func supportsNewPushFormat() {
+ #expect(true)
+ }
+}
+```
+
+## Do / Don't
+
+- Do keep each test focused on one behavior.
+- Do use display names where they improve failure readability.
+- Don't rely on test execution order.
+- Don't annotate suites with `@available`; annotate test functions instead.
+
+## Review checklist
+
+- Test target imports `Testing`, app targets do not.
+- Suite choice (`struct`/`actor`/`class`) matches setup and teardown needs.
+- Instance tests have a callable zero-argument init path.
+- Availability is applied to test functions, not suite types.

--- a/.agents/skills/swift-testing-expert/references/migration-from-xctest.md
+++ b/.agents/skills/swift-testing-expert/references/migration-from-xctest.md
@@ -1,0 +1,127 @@
+# Migration from XCTest
+
+## When to use this reference
+
+Use this file for incremental migration of existing XCTest code to Swift Testing while preserving safety and CI signal.
+
+## Coexistence strategy
+
+- Swift Testing and XCTest can coexist in the same target.
+- Migrate incrementally; do not block migration on full rewrite.
+- A single source file can import both `XCTest` and `Testing` during migration.
+- Keep XCTest where Swift Testing does not apply:
+  - UI automation (`XCUIApplication`)
+  - performance APIs (`XCTMetric`)
+  - Objective-C-only tests
+
+### Mixed import file example
+
+```swift
+import XCTest
+import Testing
+```
+
+## Practical migration order
+
+1. Convert assertions to `#expect` / `#require`.
+2. Replace `test...` naming constraints with explicit `@Test`.
+3. Reorganize classes into suites where helpful.
+4. Collapse repetitive methods into parameterized tests.
+5. Add traits/tags for control and test-plan filtering.
+
+## Example conversion: class method -> Swift Testing function
+
+```swift
+// Before (XCTest)
+final class PriceTests: XCTestCase {
+ func testDiscountedTotal() {
+ XCTAssertEqual(Price.total(subtotal: 20, discount: 5), 15)
+ }
+}
+
+// After (Swift Testing)
+import Testing
+
+@Test func discountedTotal() {
+ #expect(Price.total(subtotal: 20, discount: 5) == 15)
+}
+```
+
+## Assertion mapping highlights
+
+- Most `XCTAssert*` variants -> `#expect(...)`.
+- Optional unwrap checks -> `try #require(optionalValue)`.
+- Early-stop semantics -> `#require` instead of global `continueAfterFailure = false`.
+- `XCTFail("...")` -> `Issue.record("...")`.
+
+### Table-style quick mappings
+
+```swift
+// XCTAssertTrue(isEnabled)
+#expect(isEnabled)
+
+// XCTAssertNil(error)
+#expect(error == nil)
+
+// XCTAssertThrowsError(try run())
+#expect(throws: (any Error).self) { try run() }
+
+// try XCTUnwrap(user)
+let user = try #require(user)
+```
+
+## Suite model differences
+
+- XCTest: class + `XCTestCase`.
+- Swift Testing: struct/actor/class suites, explicit attributes, value-semantics-friendly defaults.
+- Setup can move from `setUp` patterns to suite init when appropriate.
+- Teardown can move to `deinit` when using class/actor suites.
+- XCTest sync tests default to main actor behavior; Swift Testing runs tests on arbitrary tasks unless explicitly isolated (e.g. `@MainActor`).
+
+### Setup migration example
+
+```swift
+import Testing
+
+struct SessionTests {
+ let session: Session
+
+ init() {
+ self.session = Session(environment: .test)
+ }
+
+ @Test func startsDisconnected() {
+ #expect(session.isConnected == false)
+ }
+}
+```
+
+## Async migration specifics
+
+- Prefer `await` directly for async APIs.
+- Convert completion-handler APIs with `withCheckedContinuation`/`withCheckedThrowingContinuation`.
+- Replace `XCTestExpectation` patterns with confirmations when testing asynchronous event streams.
+
+### Expectation-style flow -> confirmation
+
+```swift
+import Testing
+
+@Test func receivesAtLeastOneEvent() async {
+ await confirmation("Receives event", expectedCount: 1...) { confirm in
+ confirm()
+ }
+}
+```
+
+## Migration hygiene
+
+- Prefer mechanical, reviewable commits.
+- Use editor pattern-replace to accelerate common assertion conversions.
+- Avoid mixing XCTest assertions in Swift Testing tests (and vice versa).
+
+## Common pitfalls
+
+- Migrating all files at once instead of phased migration.
+- Keeping `continueAfterFailure` patterns instead of targeted `#require`.
+- Marking every migrated test `@MainActor` unnecessarily.

--- a/.agents/skills/swift-testing-expert/references/parallelization-and-isolation.md
+++ b/.agents/skills/swift-testing-expert/references/parallelization-and-isolation.md
@@ -1,0 +1,95 @@
+# Parallelization and Isolation
+
+## When to use this reference
+
+Use this file when tests are flaky in CI, have hidden ordering dependencies, or need to scale execution speed safely.
+
+## Default execution model
+
+- Swift Testing runs test functions in parallel by default.
+- Execution order is randomized to expose hidden test dependencies.
+- Parallelization applies to synchronous and asynchronous tests.
+
+## Example: hidden dependency exposed by parallel execution
+
+```swift
+import Testing
+
+enum SharedStore {
+ static var counter = 0
+}
+
+@Test func incrementsCounter() {
+ SharedStore.counter += 1
+ #expect(SharedStore.counter >= 1)
+}
+
+@Test func expectsFreshCounter() {
+ // Flaky if tests run in parallel or random order.
+ #expect(SharedStore.counter == 0)
+}
+```
+
+## Why this matters
+
+- Faster CI feedback and shorter local iteration loops.
+- Better detection of shared-state coupling and flaky behavior.
+- More realistic stress on concurrency-sensitive code paths.
+
+## Isolation strategy first
+
+- Make tests independent by default.
+- Avoid shared mutable globals and singleton mutation across tests.
+- Isolate state per test invocation (fresh suite instance helps).
+- Prefer deterministic test data setup over implicit ordering assumptions.
+
+### Better pattern: isolate per test
+
+```swift
+import Testing
+
+struct CounterStore {
+ var counter = 0
+ mutating func increment() { counter += 1 }
+}
+
+@Test func isolatedCounter() {
+ var store = CounterStore()
+ store.increment()
+ #expect(store.counter == 1)
+}
+```
+
+## `.serialized` as a targeted tool
+
+- Apply `.serialized` to suites when tests must run one-at-a-time.
+- Use it as a transitional safety measure during migration from serial XCTest suites.
+- Refactor toward parallel-safe tests before normalizing serialization everywhere.
+- Serialized suites can still run alongside unrelated suites in parallel.
+
+### Transitional serialization example
+
+```swift
+import Testing
+
+@Suite(.serialized)
+struct LegacyDatabaseTests {
+ @Test func migrationStepA() { #expect(true) }
+ @Test func migrationStepB() { #expect(true) }
+}
+```
+
+## Shared resource scenarios
+
+- If tests hit a shared DB/file/service, choose one:
+  - isolate backing state per test
+  - use in-memory substitutes
+  - create separate serial test plan for integration path
+- Prefer architecture that supports both fast in-memory tests and selective real integration tests.
+
+## Do / Don't
+
+- Do fix shared-state coupling before adding broad serialization.
+- Do use in-memory fakes for the fast path.
+- Don't rely on execution order.
+- Don't mutate singletons across tests without reset/isolation.

--- a/.agents/skills/swift-testing-expert/references/parameterized-testing.md
+++ b/.agents/skills/swift-testing-expert/references/parameterized-testing.md
@@ -1,0 +1,284 @@
+# Parameterized Testing
+
+## When to use this reference
+
+Use this file when you have repeated tests with identical logic and only input changes.
+
+## When to parameterize
+
+- Use one parameterized test when behavior is identical and only input changes.
+- Replace copy-pasted tests and in-test `for` loops with `@Test(arguments: ...)`.
+- Keep one responsibility per parameterized test to preserve clarity.
+
+### Before -> after
+
+```swift
+// Before: multiple near-duplicate tests.
+// @Test func freeFeatureA() { ... }
+// @Test func freeFeatureB() { ... }
+
+import Testing
+
+enum Feature: CaseIterable {
+ case recording, darkMode, networkMonitor
+ var isPremium: Bool { self == .networkMonitor }
+}
+
+@Test("Free features are not premium", arguments: [Feature.recording, .darkMode])
+func freeFeatures(_ feature: Feature) {
+ #expect(feature.isPremium == false)
+}
+```
+
+## Single input collection
+
+- Pass any sendable collection (arrays, ranges, dictionaries, etc.) as arguments.
+- Each argument becomes its own independent test case with separate diagnostics.
+- Individual failing arguments can be rerun without rerunning all inputs.
+
+### Range-based arguments example
+
+```swift
+import Testing
+
+func isValidAge(_ value: Int) -> Bool { (18...120).contains(value) }
+
+@Test(arguments: 18...21)
+func validAges(_ age: Int) {
+ #expect(isValidAge(age))
+}
+```
+
+## Multiple inputs
+
+- Swift Testing supports up to two argument collections directly.
+- Two collections generate all combinations (cartesian product).
+- Control explosion by:
+  - reducing argument sets
+  - splitting tests by concern
+  - pairing related values via `zip(...)`
+
+### Cartesian product example
+
+```swift
+import Testing
+
+enum Region { case eu, us }
+enum Plan { case free, pro }
+
+func canUseVATInvoice(region: Region, plan: Plan) -> Bool {
+ region == .eu && plan == .pro
+}
+
+@Test(arguments: [Region.eu, .us], [Plan.free, .pro])
+func vatInvoiceAccess(region: Region, plan: Plan) {
+ let allowed = canUseVATInvoice(region: region, plan: plan)
+ #expect((region == .eu && plan == .pro) == allowed)
+}
+```
+
+## `zip` for paired scenarios
+
+- Use `zip` when input A must pair with a corresponding input B.
+- Prefer `zip` over full combinations when you need aligned tuples only.
+- Keep tuples readable and intentional.
+
+### `zip` example
+
+```swift
+import Testing
+
+enum Tier { case basic, premium }
+func freeTries(for tier: Tier) -> Int { tier == .basic ? 3 : 10 }
+
+@Test(arguments: zip([Tier.basic, .premium], [3, 10]))
+func freeTryLimits(_ tier: Tier, expected: Int) {
+ #expect(freeTries(for: tier) == expected)
+}
+```
+
+### `zip` pitfalls to avoid
+
+**Silent truncation**: `zip` stops at the shorter collection. If the two arrays differ in length, the extra elements are silently dropped — no compiler error, no test failure, just missing coverage.
+
+```swift
+// ❌ Silent gap: the fifth input is never tested
+@Test(arguments: zip(
+  [Status.active, .inactive, .pending, .banned, .suspended],
+  ["Active", "Inactive", "Pending", "Banned"]  // one short
+))
+func statusLabel(_ status: Status, expected: String) {
+ #expect(label(for: status) == expected)
+}
+```
+
+**Case-order fragility with `CaseIterable`**: pairing two `allCases` arrays with `zip` breaks silently if enum cases are ever reordered (e.g., by alphabetizing).
+
+```swift
+// ❌ Fragile: reordering either enum misaligns all pairs
+enum Ingredient: CaseIterable { case rice, potato, egg }
+enum Dish: CaseIterable { case onigiri, fries, omelette }
+
+@Test(arguments: zip(Ingredient.allCases, Dish.allCases))
+func cook(_ ingredient: Ingredient, into dish: Dish) {
+ #expect(cook(ingredient) == dish)
+}
+```
+
+Prefer explicit array literals or one of the alternatives below.
+
+## Paired input alternatives
+
+When inputs and expected outputs must be paired, prefer these over `zip` to avoid the silent-truncation and case-ordering problems.
+
+### Array of tuples (recommended)
+
+Pairs are co-located and impossible to misalign. Adding a new case forces a matching output to be written at the same time.
+
+```swift
+import Testing
+
+@Test(arguments: [
+ (Ingredient.rice, Dish.onigiri),
+ (.potato, .fries),
+ (.egg, .omelette)
+])
+func cook(_ ingredient: Ingredient, into dish: Dish) {
+ #expect(cook(ingredient) == dish)
+}
+```
+
+### Dictionary arguments
+
+Expresses a clear mapping; each entry is self-documenting. Requires `Hashable` keys.
+
+```swift
+import Testing
+
+@Test(arguments: [
+ Ingredient.rice: Dish.onigiri,
+ .potato: .fries,
+ .egg: .omelette
+])
+func cook(_ ingredient: Ingredient, into dish: Dish) {
+ #expect(cook(ingredient) == dish)
+}
+```
+
+### Fixed-size `zip` with `InlineArray` (Swift 6.2+)
+
+A custom `zip` overload for `InlineArray` enforces equal-length arrays at compile time via a generic length parameter. This is not part of the standard library — you must define the helper yourself.
+
+```swift
+import Testing
+
+// Custom helper: `zip` for two `InlineArray` values of the same length.
+func zip<let N: Int, A, B>(
+  _ a: InlineArray<N, A>,
+  _ b: InlineArray<N, B>
+) -> Zip2Sequence<[A], [B]> {
+  zip(Array(a), Array(b))
+}
+
+// ✅ Compile error if lengths differ — enforced at compile time
+@Test(arguments: zip(
+  InlineArray<2, Ingredient>(.rice, .potato),
+  InlineArray<2, Dish>(.onigiri, .curry)
+))
+func cook(_ ingredient: Ingredient, into dish: Dish) {
+  #expect(cook(ingredient) == dish)
+}
+```
+
+## Naming and output quality
+
+- Use meaningful parameter labels and display names.
+- Ensure argument types are readable in output; provide custom test description if noisy.
+- Keep argument lists easy to scan (multi-line formatting is recommended).
+
+## When `CaseIterable.allCases` is appropriate
+
+Using `allCases` as arguments is a valid pattern for **property-based tests** — tests that verify a universal property holds for every member of a type. The key distinction: the expected result is derived from the *property being tested*, not from a hard-coded mapping.
+
+```swift
+import Testing
+
+// ✅ Valid: verifying a mathematical property holds for all orientations.
+@Test(
+  "Rotating clockwise four times returns to the original orientation",
+  arguments: Orientation.allCases
+)
+func fullRotation(orientation: Orientation) {
+ #expect(
+  orientation
+   .rotated(.clockwise)
+   .rotated(.clockwise)
+   .rotated(.clockwise)
+   .rotated(.clockwise)
+  == orientation
+ )
+}
+```
+
+Avoid `allCases` when you need concrete, case-specific expected values — use explicit arrays or tuples instead.
+
+## Common pitfalls
+
+- **Derived expected values masking bugs**: when the expected value is derived from the same input expression as the system under test, both sides shift together and bugs pass silently. Use concrete literals in `#expect` for case-specific expectations.
+
+```swift
+// ❌ Masking: if format(day) returns "monday" instead of "Monday",
+//    this test still passes because rawValue has the same casing bug.
+@Test(arguments: Day.allCases)
+func dayLabel(day: Day) {
+ #expect(format(day) == day.rawValue)
+}
+
+// ✅ Concrete: each expectation is an independent data point.
+@Test(arguments: [
+ (Day.monday, "Monday"),
+ (.friday, "Friday")
+])
+func dayLabel(day: Day, expected: String) {
+ #expect(format(day) == expected)
+}
+```
+
+- **Control flow in test bodies**: `if`/`switch` inside a parameterized test body mirrors implementation logic. Tests that branch the same way as production code verify themselves rather than the behavior independently.
+
+```swift
+// ❌ Mirrors implementation — not independent verification.
+@Test(arguments: Day.allCases)
+func greeting(day: Day) {
+ if day == .friday {
+  #expect(greet(day) == "TGIF!")
+ } else {
+  #expect(greet(day) == "Hello, \(day)!")
+ }
+}
+
+// ✅ Separate the special case into its own test.
+@Test func fridayGreeting() {
+ #expect(greet(.friday) == "TGIF!")
+}
+
+@Test(arguments: [Day.monday, .tuesday, .wednesday, .thursday, .saturday, .sunday])
+func standardGreeting(day: Day) {
+ #expect(greet(day) == "Hello, \(day)!")
+}
+```
+
+- **Using in-test `for` loops instead of parameterized arguments** (worse diagnostics).
+- **Passing huge argument sets that explode combinations** and slow CI.
+- **Mixing multiple concerns into one parameterized function**.
+- **Extracting argument arrays into separate properties or extensions**: this hides what the test covers and forces readers to jump between definitions. Keep arguments inline unless the list is genuinely reused across multiple test functions.
+
+## Review checklist
+
+- Repetitive tests are consolidated into one parameterized test.
+- Arguments reflect domain vocabulary and produce readable failures.
+- Paired inputs are modeled as arrays of tuples or dictionaries; use `zip` with equal-length explicit arrays only when the inputs must remain as separate collections.
+- Paired inputs use tuples or dictionaries rather than `zip(allCases, allCases)`.
+- `#expect` uses concrete literal expectations, not values derived from the input itself.
+- No `if`/`switch` branching inside parameterized test bodies.
+- `CaseIterable.allCases` is only used for property-based assertions, not example-based mappings.

--- a/.agents/skills/swift-testing-expert/references/performance-and-best-practices.md
+++ b/.agents/skills/swift-testing-expert/references/performance-and-best-practices.md
@@ -1,0 +1,187 @@
+# Performance and Best Practices
+
+## When to use this reference
+
+Use this file when test runs are slow, flaky, or not scaling in CI, and when you need practical patterns for fast, deterministic Swift Testing suites.
+
+## Core principles
+
+- Prefer deterministic tests over timing-sensitive tests.
+- Prefer synchronous verification when asynchronous waiting is not required.
+- Keep tests independent so parallel execution remains safe and effective.
+- Treat `.serialized` as a temporary compromise, not a default architecture.
+
+## 1) Keep tests synchronous where possible
+
+Synchronous tests generally run faster and are easier to reason about.
+
+```swift
+import Testing
+
+struct PriceCalculator {
+ static func total(_ subtotal: Int, discount: Int) -> Int { subtotal - discount }
+}
+
+@Test func totalCalculation() {
+ #expect(PriceCalculator.total(100, discount: 20) == 80)
+}
+```
+
+Avoid introducing `async` or sleeps for purely synchronous logic.
+
+```swift
+// Avoid:
+// @Test func totalCalculation() async {
+//   try await Task.sleep(nanoseconds: 100_000_000)
+//   #expect(...)
+// }
+```
+
+## 2) Avoid unnecessary main-actor isolation
+
+`@MainActor` can reduce useful parallelization and should be used only when code truly needs main-thread isolation.
+
+```swift
+import Testing
+
+// Good: non-UI logic stays non-main-actor.
+@Test func parserIsStable() {
+ #expect("A,B,C".split(separator: ",").count == 3)
+}
+
+// Use @MainActor only for UI/main-thread sensitive code.
+@MainActor
+@Test func viewModelMutation() {
+ #expect(true)
+}
+```
+
+## 3) Remove shared mutable state
+
+Shared mutable state is a major source of flakiness and parallel failures.
+
+```swift
+import Testing
+
+enum Globals {
+ static var token: String?
+}
+
+// Flaky pattern:
+@Test func writeToken() {
+ Globals.token = "abc"
+ #expect(Globals.token == "abc")
+}
+
+@Test func expectsNoToken() {
+ #expect(Globals.token == nil)
+}
+```
+
+Better: create isolated state per test.
+
+```swift
+import Testing
+
+struct SessionState {
+ var token: String?
+}
+
+@Test func isolatedTokenState() {
+ var state = SessionState()
+ state.token = "abc"
+ #expect(state.token == "abc")
+}
+```
+
+## 4) Prefer in-memory dependencies for the fast path
+
+Use fakes/in-memory repositories for high-volume test runs; reserve real integration dependencies for dedicated plans.
+
+```swift
+import Testing
+
+protocol CacheStore {
+ func put(key: String, value: String)
+ func get(key: String) -> String?
+}
+
+final class InMemoryCacheStore: CacheStore {
+ private var values: [String: String] = [:]
+ func put(key: String, value: String) { values[key] = value }
+ func get(key: String) -> String? { values[key] }
+}
+
+@Test func cacheRoundTrip() {
+ let cache = InMemoryCacheStore()
+ cache.put(key: "user", value: "42")
+ #expect(cache.get(key: "user") == "42")
+}
+```
+
+## 5) Use parameterized tests to reduce overhead and improve diagnostics
+
+```swift
+import Testing
+
+func isValidPort(_ value: Int) -> Bool { (1...65535).contains(value) }
+
+@Test(arguments: [1, 80, 443, 65535])
+func validPorts(_ port: Int) {
+ #expect(isValidPort(port))
+}
+```
+
+This reduces duplicated setup code and gives argument-level failure visibility.
+
+## 6) Keep setup cheap and scoped
+
+- Build expensive fixtures only when needed.
+- Prefer per-suite immutable setup for shared readonly data.
+- Avoid network/file-system setup in unit tests unless behavior depends on it.
+
+```swift
+import Testing
+
+struct CurrencyTests {
+ let rates: [String: Double]
+
+ init() {
+ rates = ["USD": 1.0, "EUR": 0.92]
+ }
+
+ @Test func hasEURRate() {
+ #expect(rates["EUR"] != nil)
+ }
+}
+```
+
+## 7) Use `.serialized` narrowly
+
+```swift
+import Testing
+
+@Suite(.serialized)
+struct TemporarySerialDBTests {
+ @Test func migrationA() async throws { #expect(true) }
+ @Test func migrationB() async throws { #expect(true) }
+}
+```
+
+Add TODO context and remove once dependencies are isolated.
+
+## 8) Flakiness reduction checklist
+
+- No reliance on execution order.
+- No shared mutable globals/singletons without reset.
+- No arbitrary sleeps as synchronization.
+- No hidden external dependencies in unit tests.
+- Deterministic fixtures and stable clocks/random sources.
+- Explicit known-issue wrappers for temporary failures.
+
+## Quick do / don't
+
+- Do optimize for determinism first, then speed.
+- Do keep most tests parallel-safe and dependency-light.
+- Don't treat test slowness as only a hardware problem.
+- Don't move everything to `@MainActor` or `.serialized` to silence flakiness.

--- a/.agents/skills/swift-testing-expert/references/traits-and-tags.md
+++ b/.agents/skills/swift-testing-expert/references/traits-and-tags.md
@@ -1,0 +1,114 @@
+# Traits and Tags
+
+## When to use this reference
+
+Use this file when controlling test execution behavior, linking bug context, and organizing large test suites for targeted runs and CI filtering.
+
+## Trait categories
+
+- **Informational**: display names, bug links, tags.
+- **Conditional**: `.enabled(if:)`, `.disabled(...)`, availability attributes.
+- **Behavioral**: `.timeLimit(...)`, `.serialized`.
+
+## Basic trait examples
+
+```swift
+import Testing
+
+@Test("Uploads complete quickly", .timeLimit(.seconds(10)))
+func uploadWithinTimeLimit() async throws {
+ #expect(true)
+}
+
+@Test(.disabled("Flaky on CI while investigating issue"), .bug("https://example.com/issues/12"))
+func temporaryDisabledTest() {
+ #expect(true)
+}
+```
+
+## Conditions and disabling
+
+- Use `.enabled(if:)` or `.disabled(if:)` for runtime-evaluated environments.
+- Use `.disabled("reason")` instead of commenting tests out.
+- Include actionable reason text in disabled traits for CI/test reports.
+- Add `.bug(...)` to link issue trackers and aid future cleanup.
+
+### Runtime condition example
+
+```swift
+import Testing
+
+enum Runtime {
+ static let isCI = ProcessInfo.processInfo.environment["CI"] == "true"
+}
+
+@Test(.enabled(if: Runtime.isCI))
+func ciOnlySmokeTest() {
+ #expect(true)
+}
+```
+
+## Availability
+
+- Use `@available` on tests when entire behavior is OS-gated.
+- Prefer `@available` over inline runtime checks for clearer reporting semantics.
+
+```swift
+import Testing
+
+@available(iOS 18, *)
+@Test func modernPushPayload() {
+ #expect(true)
+}
+```
+
+## Tags
+
+- Declare custom tags and apply to tests/suites for cross-suite grouping.
+- Use tags for test-plan include/exclude, navigator filtering, and failure analytics.
+- Treat tags as cross-cutting metadata, not a replacement for suite structure.
+- Use meaningful domain labels (e.g. `networking`, `regression`, `spicy`) over vague terms.
+
+### Defining and applying tags
+
+```swift
+import Testing
+
+extension Tag {
+ @Tag static var networking: Self
+ @Tag static var regression: Self
+}
+
+@Suite(.tags(.networking))
+struct APITests {
+ @Test func fetchUser() async throws {
+ #expect(true)
+ }
+}
+
+struct CheckoutTests {
+ @Test(.tags(.regression))
+ func orderTotal() {
+ #expect(3 * 3 == 9)
+ }
+}
+```
+
+## Inheritance and scope
+
+- Traits and tags on suites cascade to contained tests.
+- Apply at suite level when broadly true; apply per test when specific.
+- Keep trait intent explicit to avoid accidental broad behavior changes.
+
+## Do / Don't
+
+- Do put shared tags at suite level for consistency.
+- Do attach bug links for temporary disables or known failures.
+- Don't use tags as a replacement for meaningful suite grouping.
+- Don't overuse `.serialized` as a blanket reliability fix.
+
+## Review checklist
+
+- Every disabled test has a reason (and ideally a bug link).
+- Tags reflect domain concerns and are reused consistently.
+- Availability and condition traits are applied to the smallest correct scope.

--- a/.agents/skills/swift-testing-expert/references/xcode-workflows.md
+++ b/.agents/skills/swift-testing-expert/references/xcode-workflows.md
@@ -1,0 +1,70 @@
+# Xcode Workflows
+
+## When to use this reference
+
+Use this file when debugging failures quickly in Xcode, configuring focused test plans, and extracting insights from large test reports.
+
+## Test Navigator usage
+
+- Run tests at function, suite, tag, and argument level.
+- In parameterized tests, rerun only failing arguments for fast iteration.
+- Use "Group by Tag" to inspect cross-suite behavior quickly.
+
+### Example flow
+
+1. Run suite.
+2. Open failing parameterized argument.
+3. Rerun only that argument to iterate quickly.
+
+## Filtering and grouping
+
+- Use tag filters in navigator for focused development loops.
+- Keep tag naming stable so teams can reuse filters and plans.
+- Prefer tag-based include/exclude over fragile test-name patterns.
+
+### Suggested tag conventions
+
+- `core` - always-on fast checks
+- `integration` - external dependency coverage
+- `regression` - bug-fix lock-in tests
+- `flaky` - temporary quarantine while fixing
+
+## Test plans
+
+- Configure include/exclude tags per target in test plans.
+- Use "any tags" vs "all tags" intentionally when combining filters.
+- Maintain separate plans for:
+  - fast core checks
+  - integration checks
+  - slower/optional scenarios
+
+### Example plan strategy
+
+- `Core` plan: include `core`, exclude `integration`.
+- `Integration` plan: include `integration`, exclude `flaky`.
+- `ReleaseGate` plan: include `core` and `regression`.
+
+## Report triage
+
+- Review distribution insights for failure clustering by tags/bugs/destinations.
+- Investigate grouped failures first (often indicates systemic regressions).
+- Ensure disabled/known-issue reasons are visible and actionable in reports.
+
+### Triage sequence
+
+1. Check if failures cluster by a shared tag.
+2. Open one representative failure.
+3. Confirm whether root cause is common (dependency/outage/config) or test-local.
+4. Fix root cause, then remove temporary known-issue annotations.
+
+## Diagnostic quality
+
+- Keep expectations expressive and narrow.
+- Improve argument/type descriptions for faster root-cause identification.
+- Ensure bug traits link to trackable issues.
+
+## Checklist
+
+- Tag naming is consistent across suites.
+- Test plans reflect team workflow (local dev, CI, release).
+- Parameterized failures are rerun at argument-level before broad reruns.

--- a/.agents/skills/swiftui-expert-skill/SKILL.md
+++ b/.agents/skills/swiftui-expert-skill/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: swiftui-expert-skill
+description: Write, review, or improve SwiftUI code following best practices for state management, view composition, performance, macOS-specific APIs, and iOS 26+ Liquid Glass adoption. Use when building new SwiftUI features, refactoring existing views, reviewing code quality, or adopting modern SwiftUI patterns.
+---
+
+# SwiftUI Expert Skill
+
+## Operating Rules
+
+- Consult `references/latest-apis.md` at the start of every task to avoid deprecated APIs
+- Prefer native SwiftUI APIs over UIKit/AppKit bridging unless bridging is necessary
+- Focus on correctness and performance; do not enforce specific architectures (MVVM, VIPER, etc.)
+- Encourage separating business logic from views for testability without mandating how
+- Follow Apple's Human Interface Guidelines and API design patterns
+- Only adopt Liquid Glass when explicitly requested by the user (see `references/liquid-glass.md`)
+- Present performance optimizations as suggestions, not requirements
+- Use `#available` gating with sensible fallbacks for version-specific APIs
+
+## Task Workflow
+
+### Review existing SwiftUI code
+- Read the code under review and identify which topics apply
+- Flag deprecated APIs (compare against `references/latest-apis.md`)
+- Run the Topic Router below for each relevant topic
+- Validate `#available` gating and fallback paths for iOS 26+ features
+
+### Improve existing SwiftUI code
+- Audit current implementation against the Topic Router topics
+- Replace deprecated APIs with modern equivalents from `references/latest-apis.md`
+- Refactor hot paths to reduce unnecessary state updates
+- Extract complex view bodies into separate subviews
+- Suggest image downsampling when `UIImage(data:)` is encountered (optional optimization, see `references/image-optimization.md`)
+
+### Implement new SwiftUI feature
+- Design data flow first: identify owned vs injected state
+- Structure views for optimal diffing (extract subviews early)
+- Apply correct animation patterns (implicit vs explicit, transitions)
+- Use `Button` for all tappable elements; add accessibility grouping and labels
+- Gate version-specific APIs with `#available` and provide fallbacks
+
+### Topic Router
+
+Consult the reference file for each topic relevant to the current task:
+
+| Topic | Reference |
+|-------|-----------|
+| State management | `references/state-management.md` |
+| View composition | `references/view-structure.md` |
+| Performance | `references/performance-patterns.md` |
+| Lists and ForEach | `references/list-patterns.md` |
+| Layout | `references/layout-best-practices.md` |
+| Sheets and navigation | `references/sheet-navigation-patterns.md` |
+| ScrollView | `references/scroll-patterns.md` |
+| Focus management | `references/focus-patterns.md` |
+| Animations (basics) | `references/animation-basics.md` |
+| Animations (transitions) | `references/animation-transitions.md` |
+| Animations (advanced) | `references/animation-advanced.md` |
+| Accessibility | `references/accessibility-patterns.md` |
+| Swift Charts | `references/charts.md` |
+| Charts accessibility | `references/charts-accessibility.md` |
+| Image optimization | `references/image-optimization.md` |
+| Liquid Glass (iOS 26+) | `references/liquid-glass.md` |
+| macOS scenes | `references/macos-scenes.md` |
+| macOS window styling | `references/macos-window-styling.md` |
+| macOS views | `references/macos-views.md` |
+| Text patterns | `references/text-patterns.md` |
+| Deprecated API lookup | `references/latest-apis.md` |
+
+## Correctness Checklist
+
+These are hard rules -- violations are always bugs:
+
+- [ ] `@State` properties are `private`
+- [ ] `@Binding` only where a child modifies parent state
+- [ ] Passed values never declared as `@State` or `@StateObject` (they ignore updates)
+- [ ] `@StateObject` for view-owned objects; `@ObservedObject` for injected
+- [ ] iOS 17+: `@State` with `@Observable`; `@Bindable` for injected observables needing bindings
+- [ ] `ForEach` uses stable identity (never `.indices` for dynamic content)
+- [ ] Constant number of views per `ForEach` element
+- [ ] `.animation(_:value:)` always includes the `value` parameter
+- [ ] `@FocusState` properties are `private`
+- [ ] No redundant `@FocusState` writes inside tap gesture handlers on `.focusable()` views
+- [ ] iOS 26+ APIs gated with `#available` and fallback provided
+- [ ] `import Charts` present in files using chart types
+
+## References
+
+- `references/latest-apis.md` -- **Read first for every task.** Deprecated-to-modern API transitions (iOS 15+ through iOS 26+)
+- `references/state-management.md` -- Property wrappers, data flow, `@Observable` migration
+- `references/view-structure.md` -- View extraction, container patterns, `@ViewBuilder`
+- `references/performance-patterns.md` -- Hot-path optimization, update control, `_logChanges()`
+- `references/list-patterns.md` -- ForEach identity, Table (iOS 16+), inline filtering pitfalls
+- `references/layout-best-practices.md` -- Layout patterns, GeometryReader alternatives
+- `references/accessibility-patterns.md` -- VoiceOver, Dynamic Type, grouping, traits
+- `references/animation-basics.md` -- Implicit/explicit animations, timing, performance
+- `references/animation-transitions.md` -- View transitions, `matchedGeometryEffect`, `Animatable`
+- `references/animation-advanced.md` -- Phase/keyframe animations (iOS 17+), `@Animatable` macro (iOS 26+)
+- `references/charts.md` -- Swift Charts marks, axes, selection, styling, Chart3D (iOS 26+)
+- `references/charts-accessibility.md` -- Charts VoiceOver, Audio Graph, fallback strategies
+- `references/sheet-navigation-patterns.md` -- Sheets, NavigationSplitView, Inspector
+- `references/scroll-patterns.md` -- ScrollViewReader, programmatic scrolling
+- `references/focus-patterns.md` -- Focus state, focusable views, focused values, default focus, common pitfalls
+- `references/image-optimization.md` -- AsyncImage, downsampling, caching
+- `references/liquid-glass.md` -- iOS 26+ Liquid Glass effects and fallback patterns
+- `references/macos-scenes.md` -- Settings, MenuBarExtra, WindowGroup, multi-window
+- `references/macos-window-styling.md` -- Toolbar styles, window sizing, Commands
+- `references/macos-views.md` -- HSplitView, Table, PasteButton, AppKit interop
+- `references/text-patterns.md` -- Text initializer selection, verbatim vs localized

--- a/.agents/skills/swiftui-expert-skill/references/accessibility-patterns.md
+++ b/.agents/skills/swiftui-expert-skill/references/accessibility-patterns.md
@@ -1,0 +1,215 @@
+# SwiftUI Accessibility Patterns Reference
+
+## Table of Contents
+
+- [Core Principle](#core-principle)
+- [Dynamic Type and @ScaledMetric](#dynamic-type-and-scaledmetric)
+- [Accessibility Traits](#accessibility-traits)
+- [Decorative Images](#decorative-images)
+- [Element Grouping](#element-grouping)
+- [Custom Controls](#custom-controls)
+- [Summary Checklist](#summary-checklist)
+
+## Core Principle
+
+Prefer `Button` over `onTapGesture` for tappable elements. `Button` provides VoiceOver support, focus handling, and proper traits for free.
+
+## Dynamic Type and @ScaledMetric
+
+System text styles scale with Dynamic Type automatically. Prefer built-in styles like `.largeTitle`, `.title`, `.title2`, `.title3`, `.headline`, `.subheadline`, `.body`, `.callout`, `.footnote`, `.caption`, and `.caption2` when they fit your UI:
+
+```swift
+VStack(alignment: .leading) {
+    Text("Inbox")
+        .font(.title2)
+    Text("3 unread messages")
+        .font(.body)
+    Text("Updated just now")
+        .font(.caption)
+}
+```
+
+For custom fonts, use a Dynamic Type-aware font initializer so the text still follows the user's preferred content size:
+
+```swift
+VStack(alignment: .leading) {
+    Text("Article")
+        .font(.custom("SourceSerif4-Semibold", size: 28, relativeTo: .title2))
+    Text("Body copy")
+        .font(.custom("SourceSerif4-Regular", size: 17))
+}
+```
+
+`Font.custom(_:size:relativeTo:)` lets you match a specific text style. `Font.custom(_:size:)` scales relative to the body style. Avoid fixed-size custom fonts for primary content that should respond to Dynamic Type.
+
+For non-text numeric values like padding, spacing, and image sizes, use `@ScaledMetric`:
+
+```swift
+struct ProfileHeader: View {
+    @ScaledMetric private var avatarSize = 60.0
+    @ScaledMetric private var spacing = 12.0
+
+    var body: some View {
+        HStack(spacing: spacing) {
+            Image("avatar")
+                .resizable()
+                .frame(width: avatarSize, height: avatarSize)
+            Text("Username")
+        }
+    }
+}
+```
+
+Specify a `relativeTo` text style when the value should track a specific Dynamic Type style, including for images or icons that should stay proportional to nearby text:
+
+```swift
+struct StatusRow: View {
+    @ScaledMetric(relativeTo: .body) private var iconSize = 18.0
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: iconSize))
+            Text("Synced")
+                .font(.custom("AvenirNext-Regular", size: 17, relativeTo: .body))
+        }
+    }
+}
+```
+
+## Accessibility Traits
+
+Use `accessibilityAddTraits` and `accessibilityRemoveTraits` for state-driven traits:
+
+```swift
+Text(item.title)
+    .accessibilityAddTraits(item.isSelected ? [.isSelected, .isButton] : .isButton)
+```
+
+Use `.disabled(true)` to make VoiceOver announce "Dimmed" for non-interactive elements.
+
+## Decorative Images
+
+Use `Image(decorative:bundle:)` when an asset image is purely visual and should not appear in the accessibility tree.
+
+```swift
+Image(decorative: "confetti")
+```
+
+This is appropriate for backgrounds, flourishes, and icons that do not add meaning beyond nearby text.
+
+If the image conveys information, keep it accessible and provide a clear label:
+
+```swift
+Image("receipt")
+    .accessibilityLabel("Receipt")
+```
+
+For non-asset images, such as SF Symbols, hide decorative content with `accessibilityHidden(true)` instead:
+
+```swift
+Image(systemName: "sparkles")
+    .accessibilityHidden(true)
+```
+
+## Element Grouping
+
+### .combine -- Auto-join child labels
+
+```swift
+HStack {
+    Image(systemName: "star.fill")
+    Text("Favorites")
+    Text("(\(count))")
+}
+.accessibilityElement(children: .combine)
+```
+
+VoiceOver reads all child labels as one element, separated by commas.
+
+### .ignore -- Manual label for container
+
+```swift
+HStack {
+    Text(item.name)
+    Spacer()
+    Text(item.price)
+}
+.accessibilityElement(children: .ignore)
+.accessibilityLabel("\(item.name), \(item.price)")
+```
+
+### .contain -- Semantic grouping
+
+```swift
+HStack {
+    ForEach(tabs) { tab in
+        TabButton(tab: tab)
+    }
+}
+.accessibilityElement(children: .contain)
+.accessibilityLabel("Tab bar")
+```
+
+VoiceOver announces the container name when focus enters/exits.
+
+## Custom Controls
+
+### Adjustable controls (increment/decrement)
+
+```swift
+PageControl(selectedIndex: $selectedIndex, pageCount: pageCount)
+    .accessibilityElement()
+    .accessibilityValue("Page \(selectedIndex + 1) of \(pageCount)")
+    .accessibilityAdjustableAction { direction in
+        switch direction {
+        case .increment:
+            guard selectedIndex < pageCount - 1 else { break }
+            selectedIndex += 1
+        case .decrement:
+            guard selectedIndex > 0 else { break }
+            selectedIndex -= 1
+        @unknown default:
+            break
+        }
+    }
+```
+
+### Representing custom views as native controls
+
+When a custom view should behave like a native control for accessibility:
+
+```swift
+HStack {
+    Text(label)
+    Toggle("", isOn: $isOn)
+}
+.accessibilityRepresentation {
+    Toggle(label, isOn: $isOn)
+}
+```
+
+### Label-content pairing
+
+```swift
+@Namespace private var ns
+
+HStack {
+    Text("Volume")
+        .accessibilityLabeledPair(role: .label, id: "volume", in: ns)
+    Slider(value: $volume)
+        .accessibilityLabeledPair(role: .content, id: "volume", in: ns)
+}
+```
+
+## Summary Checklist
+
+- [ ] Use `Button` instead of `onTapGesture` for tappable elements
+- [ ] Use built-in text styles or Dynamic Type-aware custom fonts for text
+- [ ] Use `@ScaledMetric` for custom values that should scale with Dynamic Type
+- [ ] Mark purely decorative images as decorative or hidden from accessibility
+- [ ] Group related elements with `accessibilityElement(children:)`
+- [ ] Provide `accessibilityLabel` when default labels are unclear
+- [ ] Use `accessibilityRepresentation` for custom controls
+- [ ] Use `accessibilityAdjustableAction` for increment/decrement controls
+- [ ] Ensure navigation flow is logical when using VoiceOver grouping

--- a/.agents/skills/swiftui-expert-skill/references/animation-advanced.md
+++ b/.agents/skills/swiftui-expert-skill/references/animation-advanced.md
@@ -1,0 +1,403 @@
+# SwiftUI Advanced Animations
+
+Transactions, phase animations (iOS 17+), keyframe animations (iOS 17+), completion handlers (iOS 17+), and `@Animatable` macro (iOS 26+).
+
+## Table of Contents
+- [Transactions](#transactions)
+- [Phase Animations (iOS 17+)](#phase-animations-ios-17)
+- [Keyframe Animations (iOS 17+)](#keyframe-animations-ios-17)
+- [Animation Completion Handlers (iOS 17+)](#animation-completion-handlers-ios-17)
+- [@Animatable Macro (iOS 26+)](#animatable-macro-ios-26)
+
+---
+
+## Transactions
+
+The underlying mechanism for all animations in SwiftUI.
+
+### Basic Usage
+
+```swift
+// withAnimation is shorthand for withTransaction
+withAnimation(.default) { flag.toggle() }
+
+// Equivalent explicit transaction
+var transaction = Transaction(animation: .default)
+withTransaction(transaction) { flag.toggle() }
+```
+
+### The .transaction Modifier
+
+```swift
+Rectangle()
+    .frame(width: flag ? 100 : 50, height: 50)
+    .transaction { t in
+        t.animation = .default
+    }
+```
+
+**Note:** This behaves like the deprecated `.animation(_:)` without value parameter - it animates on every state change.
+
+### Animation Precedence
+
+**Implicit animations override explicit animations** (later in view tree wins).
+
+```swift
+Button("Tap") {
+    withAnimation(.linear) { flag.toggle() }
+}
+.animation(.bouncy, value: flag)  // .bouncy wins!
+```
+
+### Disabling Animations
+
+```swift
+// Prevent implicit animations from overriding
+.transaction { t in
+    t.disablesAnimations = true
+}
+
+// Remove animation entirely
+.transaction { $0.animation = nil }
+```
+
+### Custom Transaction Keys (iOS 17+)
+
+Pass metadata through transactions.
+
+```swift
+struct ChangeSourceKey: TransactionKey {
+    static let defaultValue: String = "unknown"
+}
+
+extension Transaction {
+    var changeSource: String {
+        get { self[ChangeSourceKey.self] }
+        set { self[ChangeSourceKey.self] = newValue }
+    }
+}
+
+// Set source
+var transaction = Transaction(animation: .default)
+transaction.changeSource = "server"
+withTransaction(transaction) { flag.toggle() }
+
+// Read in view tree
+.transaction { t in
+    if t.changeSource == "server" {
+        t.animation = .smooth
+    } else {
+        t.animation = .bouncy
+    }
+}
+```
+
+---
+
+## Phase Animations (iOS 17+)
+
+Cycle through discrete phases automatically. Each phase change is a separate animation.
+
+### Basic Usage
+
+```swift
+// GOOD - triggered phase animation
+Button("Shake") { trigger += 1 }
+    .phaseAnimator(
+        [0.0, -10.0, 10.0, -5.0, 5.0, 0.0],
+        trigger: trigger
+    ) { content, offset in
+        content.offset(x: offset)
+    }
+
+// Infinite loop (no trigger)
+Circle()
+    .phaseAnimator([1.0, 1.2, 1.0]) { content, scale in
+        content.scaleEffect(scale)
+    }
+```
+
+### Enum Phases (Recommended for Clarity)
+
+```swift
+// GOOD - enum phases are self-documenting
+enum BouncePhase: CaseIterable {
+    case initial, up, down, settle
+
+    var scale: CGFloat {
+        switch self {
+        case .initial: 1.0
+        case .up: 1.2
+        case .down: 0.9
+        case .settle: 1.0
+        }
+    }
+}
+
+Circle()
+    .phaseAnimator(BouncePhase.allCases, trigger: trigger) { content, phase in
+        content.scaleEffect(phase.scale)
+    }
+```
+
+### Custom Timing Per Phase
+
+```swift
+.phaseAnimator([0, -20, 20], trigger: trigger) { content, offset in
+    content.offset(x: offset)
+} animation: { phase in
+    switch phase {
+    case -20: .bouncy
+    case 20: .linear
+    default: .smooth
+    }
+}
+```
+
+### Good vs Bad
+
+```swift
+// GOOD - use phaseAnimator for multi-step sequences
+.phaseAnimator([0, -10, 10, 0], trigger: trigger) { content, offset in
+    content.offset(x: offset)
+}
+
+// BAD - manual DispatchQueue sequencing
+Button("Animate") {
+    withAnimation(.easeOut(duration: 0.1)) { offset = -10 }
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        withAnimation { offset = 10 }
+    }
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+        withAnimation { offset = 0 }
+    }
+}
+```
+
+---
+
+## Keyframe Animations (iOS 17+)
+
+Precise timing control with exact values at specific times.
+
+### Basic Usage
+
+```swift
+Button("Bounce") { trigger += 1 }
+    .keyframeAnimator(
+        initialValue: AnimationValues(),
+        trigger: trigger
+    ) { content, value in
+        content
+            .scaleEffect(value.scale)
+            .offset(y: value.verticalOffset)
+    } keyframes: { _ in
+        KeyframeTrack(\.scale) {
+            SpringKeyframe(1.2, duration: 0.15)
+            SpringKeyframe(0.9, duration: 0.1)
+            SpringKeyframe(1.0, duration: 0.15)
+        }
+        KeyframeTrack(\.verticalOffset) {
+            LinearKeyframe(-20, duration: 0.15)
+            LinearKeyframe(0, duration: 0.25)
+        }
+    }
+
+struct AnimationValues {
+    var scale: CGFloat = 1.0
+    var verticalOffset: CGFloat = 0
+}
+```
+
+### Keyframe Types
+
+| Type | Behavior |
+|------|----------|
+| `CubicKeyframe` | Smooth interpolation |
+| `LinearKeyframe` | Straight-line interpolation |
+| `SpringKeyframe` | Spring physics |
+| `MoveKeyframe` | Instant jump (no interpolation) |
+
+### Multiple Synchronized Tracks
+
+Tracks run **in parallel**, each animating one property.
+
+```swift
+// GOOD - bell shake with synchronized rotation and scale
+struct BellAnimation {
+    var rotation: Double = 0
+    var scale: CGFloat = 1.0
+}
+
+Image(systemName: "bell.fill")
+    .keyframeAnimator(
+        initialValue: BellAnimation(),
+        trigger: trigger
+    ) { content, value in
+        content
+            .rotationEffect(.degrees(value.rotation))
+            .scaleEffect(value.scale)
+    } keyframes: { _ in
+        KeyframeTrack(\.rotation) {
+            CubicKeyframe(15, duration: 0.1)
+            CubicKeyframe(-15, duration: 0.1)
+            CubicKeyframe(10, duration: 0.1)
+            CubicKeyframe(-10, duration: 0.1)
+            CubicKeyframe(0, duration: 0.1)
+        }
+        KeyframeTrack(\.scale) {
+            CubicKeyframe(1.1, duration: 0.25)
+            CubicKeyframe(1.0, duration: 0.25)
+        }
+    }
+
+// BAD - manual timer-based animation
+Image(systemName: "bell.fill")
+    .onTapGesture {
+        withAnimation(.easeOut(duration: 0.1)) { rotation = 15 }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            withAnimation { rotation = -15 }
+        }
+        // ... more manual timing - error prone
+    }
+```
+
+### KeyframeTimeline (iOS 17+)
+
+Query animation values directly for testing or non-SwiftUI use.
+
+```swift
+let timeline = KeyframeTimeline(initialValue: AnimationValues()) {
+    KeyframeTrack(\.scale) {
+        CubicKeyframe(1.2, duration: 0.25)
+        CubicKeyframe(1.0, duration: 0.25)
+    }
+}
+
+let midpoint = timeline.value(time: 0.25)
+print(midpoint.scale)  // Value at 0.25 seconds
+```
+
+---
+
+## Animation Completion Handlers (iOS 17+)
+
+Execute code when animations finish.
+
+### With withAnimation
+
+```swift
+// GOOD - completion with withAnimation
+Button("Animate") {
+    withAnimation(.spring) {
+        isExpanded.toggle()
+    } completion: {
+        showNextStep = true
+    }
+}
+```
+
+### With Transaction (For Reexecution)
+
+```swift
+// GOOD - completion fires on every trigger change
+Circle()
+    .scaleEffect(bounceCount % 2 == 0 ? 1.0 : 1.2)
+    .transaction(value: bounceCount) { transaction in
+        transaction.animation = .spring
+        transaction.addAnimationCompletion {
+            message = "Bounce \(bounceCount) complete"
+        }
+    }
+
+// BAD - completion only fires ONCE (no value parameter)
+Circle()
+    .scaleEffect(bounceCount % 2 == 0 ? 1.0 : 1.2)
+    .animation(.spring, value: bounceCount)
+    .transaction { transaction in  // No value!
+        transaction.addAnimationCompletion {
+            completionCount += 1  // Only fires once, ever
+        }
+    }
+```
+
+---
+
+## @Animatable Macro (iOS 26+)
+
+The `@Animatable` macro auto-synthesizes `animatableData` from all animatable stored properties, eliminating verbose manual conformance. Use `@AnimatableIgnored` to exclude properties that should not animate.
+
+### Before (Manual)
+
+```swift
+struct Wedge: Shape {
+    var startAngle: Angle
+    var endAngle: Angle
+    var drawClockwise: Bool
+
+    var animatableData: AnimatablePair<Double, Double> {
+        get { AnimatablePair(startAngle.radians, endAngle.radians) }
+        set {
+            startAngle = .radians(newValue.first)
+            endAngle = .radians(newValue.second)
+        }
+    }
+
+    func path(in rect: CGRect) -> Path { /* ... */ }
+}
+```
+
+### After (@Animatable)
+
+```swift
+@Animatable
+struct Wedge: Shape {
+    var startAngle: Angle
+    var endAngle: Angle
+    @AnimatableIgnored var drawClockwise: Bool
+
+    func path(in rect: CGRect) -> Path { /* ... */ }
+}
+```
+
+### When to Use
+- **Prefer `@Animatable`** for any custom `Shape`, `AnimatableModifier`, or type conforming to `Animatable` with multiple properties
+- **Use `@AnimatableIgnored`** for properties that control behavior but should not interpolate (e.g., directions, flags, identifiers)
+- The macro works with any type conforming to `Animatable`, not just `Shape`
+
+> Source: "What's new in SwiftUI" (WWDC25, session 256)
+
+---
+
+## Quick Reference
+
+### Transactions (All iOS versions)
+- `withTransaction` is the explicit form of `withAnimation`
+- Implicit animations override explicit (later in view tree wins)
+- Use `disablesAnimations` to prevent override
+- Use `.transaction { $0.animation = nil }` to remove animation
+
+### Custom Transaction Keys (iOS 17+)
+- Pass metadata through animation system via `TransactionKey`
+
+### Phase Animations (iOS 17+)
+- Use for multi-step sequences returning to start
+- Prefer enum phases for clarity
+- Each phase change is a separate animation
+- Use `trigger` parameter for one-shot animations
+
+### Keyframe Animations (iOS 17+)
+- Use for precise timing control
+- Tracks run in parallel
+- Use `KeyframeTimeline` for testing/advanced use
+- Prefer over manual DispatchQueue timing
+
+### Completion Handlers (iOS 17+)
+- Use `withAnimation(.animation) { } completion: { }` for one-shot completion handlers
+- Use `.transaction(value:)` for handlers that should refire on every value change
+- Without `value:` parameter, completion only fires once
+
+### @Animatable Macro (iOS 26+)
+- Use `@Animatable` to auto-synthesize `animatableData` from stored properties
+- Use `@AnimatableIgnored` to exclude non-animatable properties
+- Replaces verbose manual `animatableData` getters/setters

--- a/.agents/skills/swiftui-expert-skill/references/animation-basics.md
+++ b/.agents/skills/swiftui-expert-skill/references/animation-basics.md
@@ -1,0 +1,284 @@
+# SwiftUI Animation Basics
+
+Core animation concepts, implicit vs explicit animations, timing curves, and performance patterns.
+
+## Table of Contents
+- [Core Concepts](#core-concepts)
+- [Implicit Animations](#implicit-animations)
+- [Explicit Animations](#explicit-animations)
+- [Animation Placement](#animation-placement)
+- [Selective Animation](#selective-animation)
+- [Timing Curves](#timing-curves)
+- [Animation Performance](#animation-performance)
+- [Disabling Animations](#disabling-animations)
+- [Debugging](#debugging)
+
+---
+
+## Core Concepts
+
+State changes trigger view updates. SwiftUI provides mechanisms to animate these changes.
+
+**Animation Process:**
+1. State change triggers view tree re-evaluation
+2. SwiftUI compares new tree to current render tree
+3. Animatable properties are identified and interpolated (~60 fps)
+
+**Key Characteristics:**
+- Animations are additive and cancelable
+- Always start from current render tree state
+- Blend smoothly when interrupted
+
+---
+
+## Implicit Animations
+
+Use `.animation(_:value:)` to animate when a specific value changes.
+
+```swift
+// GOOD - uses value parameter
+Rectangle()
+    .frame(width: isExpanded ? 200 : 100, height: 50)
+    .animation(.spring, value: isExpanded)
+    .onTapGesture { isExpanded.toggle() }
+
+// BAD - deprecated, animates all changes unexpectedly
+Rectangle()
+    .frame(width: isExpanded ? 200 : 100, height: 50)
+    .animation(.spring)  // Deprecated!
+```
+
+---
+
+## Explicit Animations
+
+Use `withAnimation` for event-driven state changes.
+
+```swift
+// GOOD - explicit animation
+Button("Toggle") {
+    withAnimation(.spring) {
+        isExpanded.toggle()
+    }
+}
+
+// BAD - no animation context
+Button("Toggle") {
+    isExpanded.toggle()  // Abrupt change
+}
+```
+
+**When to use which:**
+- **Implicit**: Animations tied to specific value changes, precise view tree scope
+- **Explicit**: Event-driven animations (button taps, gestures)
+
+---
+
+## Animation Placement
+
+Place animation modifiers after the properties they should animate.
+
+```swift
+// GOOD - animation after properties
+Rectangle()
+    .frame(width: isExpanded ? 200 : 100, height: 50)
+    .foregroundStyle(isExpanded ? .blue : .red)
+    .animation(.default, value: isExpanded)  // Animates both
+
+// BAD - animation before properties
+Rectangle()
+    .animation(.default, value: isExpanded)  // Too early!
+    .frame(width: isExpanded ? 200 : 100, height: 50)
+```
+
+---
+
+## Selective Animation
+
+Animate only specific properties using multiple animation modifiers or scoped animations.
+
+```swift
+// GOOD - selective animation
+Rectangle()
+    .frame(width: isExpanded ? 200 : 100, height: 50)
+    .animation(.spring, value: isExpanded)  // Animate size
+    .foregroundStyle(isExpanded ? .blue : .red)
+    .animation(nil, value: isExpanded)  // Don't animate color
+
+// iOS 17+ scoped animation
+Rectangle()
+    .foregroundStyle(isExpanded ? .blue : .red)  // Not animated
+    .animation(.spring) {
+        $0.frame(width: isExpanded ? 200 : 100, height: 50)  // Animated
+    }
+```
+
+---
+
+## Timing Curves
+
+### Built-in Curves
+
+| Curve | Use Case |
+|-------|----------|
+| `.spring` | Interactive elements, most UI |
+| `.easeInOut` | Appearance changes |
+| `.bouncy` | Playful feedback (iOS 17+) |
+| `.linear` | Progress indicators only |
+
+### Modifiers
+
+```swift
+.animation(.default.speed(2.0), value: flag)  // 2x faster
+.animation(.default.delay(0.5), value: flag)  // Delayed start
+.animation(.default.repeatCount(3, autoreverses: true), value: flag)
+```
+
+### Good vs Bad Timing
+
+```swift
+// GOOD - appropriate timing for interaction type
+Button("Tap") {
+    withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+        isActive.toggle()
+    }
+}
+.scaleEffect(isActive ? 0.95 : 1.0)
+
+// BAD - too slow for button feedback
+Button("Tap") {
+    withAnimation(.easeInOut(duration: 1.0)) {  // Way too slow!
+        isActive.toggle()
+    }
+}
+
+// BAD - linear feels robotic
+Rectangle()
+    .animation(.linear(duration: 0.5), value: isActive)  // Mechanical
+```
+
+---
+
+## Animation Performance
+
+### Prefer Transforms Over Layout
+
+```swift
+// GOOD - GPU accelerated transforms
+Rectangle()
+    .frame(width: 100, height: 100)
+    .scaleEffect(isActive ? 1.5 : 1.0)  // Fast
+    .offset(x: isActive ? 50 : 0)        // Fast
+    .rotationEffect(.degrees(isActive ? 45 : 0))  // Fast
+    .animation(.spring, value: isActive)
+
+// BAD - layout changes are expensive
+Rectangle()
+    .frame(width: isActive ? 150 : 100, height: isActive ? 150 : 100)  // Expensive
+    .padding(isActive ? 50 : 0)  // Expensive
+```
+
+### Narrow Animation Scope
+
+```swift
+// GOOD - animation scoped to specific subview
+VStack {
+    HeaderView()  // Not affected
+    ExpandableContent(isExpanded: isExpanded)
+        .animation(.spring, value: isExpanded)  // Only this
+    FooterView()  // Not affected
+}
+
+// BAD - animation at root
+VStack {
+    HeaderView()
+    ExpandableContent(isExpanded: isExpanded)
+    FooterView()
+}
+.animation(.spring, value: isExpanded)  // Animates everything
+```
+
+### Avoid Animation in Hot Paths
+
+```swift
+// GOOD - gate by threshold
+.onPreferenceChange(ScrollOffsetKey.self) { offset in
+    let shouldShow = offset.y < -50
+    if shouldShow != showTitle {  // Only when crossing threshold
+        withAnimation(.easeOut(duration: 0.2)) {
+            showTitle = shouldShow
+        }
+    }
+}
+
+// BAD - animating every scroll change
+.onPreferenceChange(ScrollOffsetKey.self) { offset in
+    withAnimation {  // Fires constantly!
+        self.offset = offset.y
+    }
+}
+```
+
+---
+
+## Disabling Animations
+
+```swift
+// GOOD - disable with transaction
+Text("Count: \(count)")
+    .transaction { $0.animation = nil }
+
+// GOOD - disable from parent context
+DataView()
+    .transaction { $0.disablesAnimations = true }
+
+// BAD - hacky zero duration
+Text("Count: \(count)")
+    .animation(.linear(duration: 0), value: count)  // Hacky
+```
+
+---
+
+## Debugging
+
+```swift
+// Slow down for inspection
+#if DEBUG
+.animation(.linear(duration: 3.0).speed(0.2), value: isExpanded)
+#else
+.animation(.spring, value: isExpanded)
+#endif
+
+// Debug modifier to log values
+struct AnimationDebugModifier: ViewModifier, Animatable {
+    var value: Double
+    var animatableData: Double {
+        get { value }
+        set {
+            value = newValue
+            print("Animation: \(newValue)")
+        }
+    }
+    func body(content: Content) -> some View {
+        content.opacity(value)
+    }
+}
+```
+
+---
+
+## Quick Reference
+
+### Do
+- Use `.animation(_:value:)` with value parameter
+- Use `withAnimation` for event-driven animations
+- Prefer transforms over layout changes
+- Scope animations narrowly
+- Choose appropriate timing curves
+
+### Don't
+- Use deprecated `.animation(_:)` without value
+- Animate layout properties in hot paths
+- Apply broad animations at root level
+- Use linear timing for UI (feels robotic)
+- Animate on every frame in scroll handlers

--- a/.agents/skills/swiftui-expert-skill/references/animation-transitions.md
+++ b/.agents/skills/swiftui-expert-skill/references/animation-transitions.md
@@ -1,0 +1,326 @@
+# SwiftUI Transitions
+
+Transitions for view insertion/removal, custom transitions, and the Animatable protocol.
+
+## Table of Contents
+- [Property Animations vs Transitions](#property-animations-vs-transitions)
+- [Basic Transitions](#basic-transitions)
+- [Asymmetric Transitions](#asymmetric-transitions)
+- [Custom Transitions](#custom-transitions)
+- [Identity and Transitions](#identity-and-transitions)
+- [The Animatable Protocol](#the-animatable-protocol)
+
+---
+
+## Property Animations vs Transitions
+
+**Property animations**: Interpolate values on views that exist before AND after state change.
+
+**Transitions**: Animate views being inserted or removed from the render tree.
+
+```swift
+// Property animation - same view, different properties
+Rectangle()
+    .frame(width: isExpanded ? 200 : 100, height: 50)
+    .animation(.spring, value: isExpanded)
+
+// Transition - view inserted/removed
+if showDetail {
+    DetailView()
+        .transition(.scale)
+}
+```
+
+---
+
+## Basic Transitions
+
+### Critical: Transitions Require Animation Context
+
+```swift
+// GOOD - animation outside conditional
+VStack {
+    Button("Toggle") { showDetail.toggle() }
+    if showDetail {
+        DetailView()
+            .transition(.slide)
+    }
+}
+.animation(.spring, value: showDetail)
+
+// GOOD - explicit animation
+Button("Toggle") {
+    withAnimation(.spring) {
+        showDetail.toggle()
+    }
+}
+if showDetail {
+    DetailView()
+        .transition(.scale.combined(with: .opacity))
+}
+
+// BAD - animation inside conditional (removed with view!)
+if showDetail {
+    DetailView()
+        .transition(.slide)
+        .animation(.spring, value: showDetail)  // Won't work on removal!
+}
+
+// BAD - no animation context
+Button("Toggle") {
+    showDetail.toggle()  // No animation
+}
+if showDetail {
+    DetailView()
+        .transition(.slide)  // Ignored - just appears/disappears
+}
+```
+
+### Built-in Transitions
+
+| Transition | Effect |
+|------------|--------|
+| `.opacity` | Fade in/out (default) |
+| `.scale` | Scale up/down |
+| `.slide` | Slide from leading edge |
+| `.move(edge:)` | Move from specific edge |
+| `.offset(x:y:)` | Move by offset amount |
+
+### Combining Transitions
+
+```swift
+// Parallel - both simultaneously
+.transition(.slide.combined(with: .opacity))
+
+// Chained
+.transition(.scale.combined(with: .opacity).combined(with: .offset(y: 20)))
+```
+
+---
+
+## Asymmetric Transitions
+
+Different animations for insertion vs removal.
+
+```swift
+// GOOD - different animations for insert/remove
+if showCard {
+    CardView()
+        .transition(
+            .asymmetric(
+                insertion: .scale.combined(with: .opacity),
+                removal: .move(edge: .bottom).combined(with: .opacity)
+            )
+        )
+}
+
+// BAD - same transition when different behaviors needed
+if showCard {
+    CardView()
+        .transition(.slide)  // Same both ways - may feel awkward
+}
+```
+
+---
+
+## Custom Transitions
+
+### Pre-iOS 17
+
+```swift
+struct BlurModifier: ViewModifier {
+    var radius: CGFloat
+    func body(content: Content) -> some View {
+        content.blur(radius: radius)
+    }
+}
+
+extension AnyTransition {
+    static func blur(radius: CGFloat) -> AnyTransition {
+        .modifier(
+            active: BlurModifier(radius: radius),
+            identity: BlurModifier(radius: 0)
+        )
+    }
+}
+
+// Usage
+.transition(.blur(radius: 10))
+```
+
+### iOS 17+ (Transition Protocol)
+
+```swift
+struct BlurTransition: Transition {
+    var radius: CGFloat
+
+    func body(content: Content, phase: TransitionPhase) -> some View {
+        content
+            .blur(radius: phase.isIdentity ? 0 : radius)
+            .opacity(phase.isIdentity ? 1 : 0)
+    }
+}
+
+// Usage
+.transition(BlurTransition(radius: 10))
+```
+
+### Good vs Bad Custom Transitions
+
+```swift
+// GOOD - reusable transition
+if showContent {
+    ContentView()
+        .transition(BlurTransition(radius: 10))
+}
+
+// BAD - inline logic (won't animate on removal!)
+if showContent {
+    ContentView()
+        .blur(radius: showContent ? 0 : 10)  // Not a transition
+        .opacity(showContent ? 1 : 0)
+}
+```
+
+---
+
+## Identity and Transitions
+
+View identity changes trigger transitions, not property animations.
+
+```swift
+// Triggers transition - different branches have different identities
+if isExpanded {
+    Rectangle().frame(width: 200, height: 50)
+} else {
+    Rectangle().frame(width: 100, height: 50)
+}
+
+// Triggers transition - .id() changes identity
+Rectangle()
+    .id(flag)  // Different identity when flag changes
+    .transition(.scale)
+
+// Property animation - same view, same identity
+Rectangle()
+    .frame(width: isExpanded ? 200 : 100, height: 50)
+    .animation(.spring, value: isExpanded)
+```
+
+---
+
+## The Animatable Protocol
+
+Enables custom property interpolation during animations.
+
+### Protocol Definition
+
+```swift
+protocol Animatable {
+    associatedtype AnimatableData: VectorArithmetic
+    var animatableData: AnimatableData { get set }
+}
+```
+
+### Basic Implementation
+
+```swift
+// GOOD - explicit animatableData
+struct ShakeModifier: ViewModifier, Animatable {
+    var shakeCount: Double
+
+    var animatableData: Double {
+        get { shakeCount }
+        set { shakeCount = newValue }
+    }
+
+    func body(content: Content) -> some View {
+        content.offset(x: sin(shakeCount * .pi * 2) * 10)
+    }
+}
+
+extension View {
+    func shake(count: Int) -> some View {
+        modifier(ShakeModifier(shakeCount: Double(count)))
+    }
+}
+
+// Usage
+Button("Shake") { shakeCount += 3 }
+    .shake(count: shakeCount)
+    .animation(.default, value: shakeCount)
+
+// BAD - missing animatableData (silent failure!)
+struct BadShakeModifier: ViewModifier {
+    var shakeCount: Double
+    // Missing animatableData! Uses EmptyAnimatableData
+
+    func body(content: Content) -> some View {
+        content.offset(x: sin(shakeCount * .pi * 2) * 10)
+    }
+}
+// Animation jumps to final value instead of interpolating
+```
+
+### Multiple Properties with AnimatablePair
+
+```swift
+// GOOD - AnimatablePair for two properties
+struct ComplexModifier: ViewModifier, Animatable {
+    var scale: CGFloat
+    var rotation: Double
+
+    var animatableData: AnimatablePair<CGFloat, Double> {
+        get { AnimatablePair(scale, rotation) }
+        set {
+            scale = newValue.first
+            rotation = newValue.second
+        }
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .scaleEffect(scale)
+            .rotationEffect(.degrees(rotation))
+    }
+}
+
+// GOOD - nested AnimatablePair for 3+ properties
+struct ThreePropertyModifier: ViewModifier, Animatable {
+    var x: CGFloat
+    var y: CGFloat
+    var rotation: Double
+
+    var animatableData: AnimatablePair<AnimatablePair<CGFloat, CGFloat>, Double> {
+        get { AnimatablePair(AnimatablePair(x, y), rotation) }
+        set {
+            x = newValue.first.first
+            y = newValue.first.second
+            rotation = newValue.second
+        }
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .offset(x: x, y: y)
+            .rotationEffect(.degrees(rotation))
+    }
+}
+```
+
+---
+
+## Quick Reference
+
+### Do
+- Place transitions outside conditional structures
+- Use `withAnimation` or `.animation` outside the `if`
+- Implement `animatableData` explicitly for custom Animatable
+- Use `AnimatablePair` for multiple animated properties
+- Use asymmetric transitions when insert/remove need different effects
+
+### Don't
+- Put animation modifiers inside conditionals for transitions
+- Forget `animatableData` implementation (silent failure)
+- Use inline blur/opacity instead of proper transitions
+- Expect property animation when view identity changes

--- a/.agents/skills/swiftui-expert-skill/references/charts-accessibility.md
+++ b/.agents/skills/swiftui-expert-skill/references/charts-accessibility.md
@@ -1,0 +1,135 @@
+# Swift Charts Accessibility, Fallback, and Resources
+
+## Table of Contents
+
+- [Accessibility](#accessibility)
+  - [Meaningful Labels](#meaningful-labels)
+  - [Custom Audio Graphs](#custom-audio-graphs)
+- [Composite Example](#composite-example)
+- [Fallback Strategies](#fallback-strategies)
+  - [Version Breakdown](#version-breakdown)
+- [WWDC Sessions](#wwdc-sessions)
+- [Summary Checklist](#summary-checklist)
+
+---
+
+## Accessibility
+
+Swift Charts provides built-in accessibility support. VoiceOver users get three rotor actions automatically:
+
+- **Describe Chart** — overview of axes and data series
+- **Audio Graph** — sonification where pitch represents data values
+- **Chart Detail** — interactive mode for exploring individual data points
+
+### Meaningful Labels
+
+**Always** use clear, descriptive strings in `.value(_, _)` calls. These labels are read by VoiceOver and used in the Audio Graph.
+
+```swift
+// Good — descriptive labels
+LineMark(
+    x: .value("Date", entry.date),
+    y: .value("Daily Steps", entry.count)
+)
+
+// Bad — generic labels
+LineMark(
+    x: .value("X", entry.date),
+    y: .value("Y", entry.count)
+)
+```
+
+### Custom Audio Graphs
+
+For advanced accessibility, conform your chart view to `AXChartDescriptorRepresentable` and implement `makeChartDescriptor()`. Attach it with `.accessibilityChartDescriptor(self)`.
+
+```swift
+struct StepsChart: View, AXChartDescriptorRepresentable {
+    let steps: [DailySteps]
+
+    var body: some View {
+        Chart(steps) { day in
+            LineMark(x: .value("Date", day.date), y: .value("Steps", day.count))
+        }
+        .accessibilityChartDescriptor(self)
+    }
+
+    func makeChartDescriptor() -> AXChartDescriptor {
+        guard let first = steps.first, let last = steps.last else {
+            return AXChartDescriptor(title: "Daily Step Count", summary: nil,
+                xAxis: AXNumericDataAxisDescriptor(title: "Date", range: 0...1, gridlinePositions: []) { "\($0)" },
+                yAxis: AXNumericDataAxisDescriptor(title: "Steps", range: 0...1, gridlinePositions: []) { "\($0)" },
+                additionalAxes: [], series: [])
+        }
+        let xAxis = AXDateDataAxisDescriptor(
+            title: "Date", range: first.date...last.date, gridlinePositions: [])
+        let yAxis = AXNumericDataAxisDescriptor(
+            title: "Steps", range: 0...Double(steps.map(\.count).max() ?? 0),
+            gridlinePositions: []) { "\(Int($0)) steps" }
+        let series = AXDataSeriesDescriptor(
+            name: "Daily Steps", isContinuous: true,
+            dataPoints: steps.map { .init(x: $0.date, y: Double($0.count)) })
+        return AXChartDescriptor(title: "Daily Step Count", summary: nil,
+            xAxis: xAxis, yAxis: yAxis, additionalAxes: [], series: [series])
+    }
+}
+```
+
+## Composite Example
+
+A scrollable bar chart with range selection combining multiple iOS 17+ APIs:
+
+```swift
+@State private var selectedRange: ClosedRange<Int>?
+
+Chart(weeklyRevenue) { week in
+    BarMark(x: .value("Week", week.index), y: .value("Revenue", week.revenue))
+        .foregroundStyle(by: .value("Region", week.region))
+}
+.chartScrollableAxes(.horizontal)
+.chartXVisibleDomain(length: 8)
+.chartXSelection(range: $selectedRange)
+.chartXAxis {
+    AxisMarks(values: .stride(by: 1)) {
+        AxisGridLine()
+        AxisValueLabel { Text("W\($0.as(Int.self) ?? 0)") }
+    }
+}
+```
+
+## Fallback Strategies
+
+Gate advanced APIs with `#available` and provide a fallback chart without the gated features. Because chart modifiers like `.chartXSelection` change the return type, you must duplicate the entire `Chart` — you cannot conditionally apply the modifier:
+
+### Version Breakdown
+
+- iOS 16+: `Chart`, custom axes, scales, `BarMark`, `LineMark`, `AreaMark`, `PointMark`, `RectangleMark`, `RuleMark`, `ChartProxy`, `chartOverlay`, `chartBackground`
+- iOS 17+: `SectorMark`, `chartXSelection`, `chartYSelection`, `chartAngleSelection`, `chartScrollableAxes`, visible-domain scrolling APIs, `chartGesture`
+- iOS 18+: `AreaPlot`, `BarPlot`, `LinePlot`, `PointPlot`, `RectanglePlot`, `RulePlot`, `SectorPlot`, function plotting
+- iOS 26+: `Chart3D`, `SurfacePlot`, Z-axis marks, 3D camera and pose APIs
+
+## WWDC Sessions
+
+- [Hello Swift Charts](https://developer.apple.com/videos/play/wwdc2022/10136/) (WWDC 2022) — introduction to the framework
+- [Swift Charts: Raise the bar](https://developer.apple.com/videos/play/wwdc2022/10137/) (WWDC 2022) — marks, composition, customization
+- [Design an effective chart](https://developer.apple.com/videos/play/wwdc2022/110340/) (WWDC 2022) — chart design principles
+- [Design app experiences with charts](https://developer.apple.com/videos/play/wwdc2022/110342/) (WWDC 2022) — integrating charts into app UX
+- [Explore pie charts and interactivity in Swift Charts](https://developer.apple.com/videos/play/wwdc2023/10037/) (WWDC 2023) — SectorMark, selection, scrolling
+- [Swift Charts: Vectorized and function plots](https://developer.apple.com/videos/play/wwdc2024/10155/) (WWDC 2024) — LinePlot, AreaPlot, function plotting
+- [Bring Swift Charts to the third dimension](https://developer.apple.com/videos/play/wwdc2025/313/) (WWDC 2025) — Chart3D, SurfacePlot, 3D marks
+
+## Summary Checklist
+
+- [ ] `import Charts` is present in files using chart types
+- [ ] Deployment target matches the APIs used (`Chart` on iOS 16+, selection and `SectorMark` on iOS 17+, plot types on iOS 18+, `Chart3D` on iOS 26+)
+- [ ] Chart data models use `Identifiable` (or `Chart(data, id:)` is provided)
+- [ ] All chart families are represented with the correct mark type
+- [ ] Axes use `AxisMarks` when default ticks are too dense or unclear
+- [ ] `chartXScale` or `chartYScale` is set when fixed domains matter
+- [ ] Chart-wide modifiers are applied to `Chart`, not individual marks
+- [ ] `foregroundStyle(by:)` used for categorical series (not manual per-mark colors)
+- [ ] Single-value selection uses `chartXSelection(value:)` or `chartYSelection(value:)`
+- [ ] Range selection uses `chartXSelection(range:)` or `chartYSelection(range:)`
+- [ ] `SectorMark` selection uses `chartAngleSelection(value:)`
+- [ ] iOS 17+, iOS 18+, and iOS 26+ APIs are guarded with `#available`
+- [ ] `.value()` labels are descriptive for VoiceOver and Audio Graph accessibility

--- a/.agents/skills/swiftui-expert-skill/references/charts.md
+++ b/.agents/skills/swiftui-expert-skill/references/charts.md
@@ -1,0 +1,602 @@
+# SwiftUI Charts Reference
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Availability](#availability)
+- [Core APIs](#core-apis)
+- [Chart Types](#chart-types)
+- [Axis Tweaks](#axis-tweaks)
+- [Selection APIs](#selection-apis)
+- [Annotations](#annotations)
+- [ChartProxy and Custom Touch Handling](#chartproxy-and-custom-touch-handling)
+- [Modifier Scope](#modifier-scope)
+- [Styling and Visual Channels](#styling-and-visual-channels)
+- [Composing Multiple Marks](#composing-multiple-marks)
+- [Animating Chart Data](#animating-chart-data)
+- [Best Practices](#best-practices)
+
+## Overview
+
+Swift Charts is Apple's native charting framework for SwiftUI. Use `Chart` with one or more marks to build bar, line, area, point, rule, rectangle, and sector charts. This reference covers the standard 2D chart APIs, axis customization, built-in selection APIs, annotations, and custom touch handling.
+
+## Availability
+
+Base `Chart`, custom axes, scales, and most marks require iOS 16 or later.
+
+- `BarMark`, `LineMark`, `AreaMark`, `PointMark`, `RectangleMark`, and `RuleMark` are available on iOS 16+
+- `SectorMark`, built-in selection, and scrollable chart axes require iOS 17+
+- Data-driven plot types such as `BarPlot` and `LinePlot` require iOS 18+
+- Chart3D and Z-axis APIs exist on iOS 26+; this reference is primarily about 2D `Chart`, with a dedicated Chart3D section below
+
+```swift
+if #available(iOS 17, *) {
+    // Selection, SectorMark, scrollable axes
+} else {
+    // Base Chart, axes, scales, and core marks
+}
+```
+
+## Core APIs
+
+### Import the Framework
+
+Always check that the file imports `Charts` before using `Chart`, `Chart3D`, `BarMark`, `SectorMark`, or `ChartProxy`.
+
+```swift
+import SwiftUI
+import Charts
+```
+
+If chart types are unresolved, the first thing to verify is that `Charts` is imported in that file.
+
+### Chart Container
+
+`Chart` is the root view. Add one or more marks inside it.
+
+```swift
+Chart(sales) { item in
+    BarMark(
+        x: .value("Month", item.month),
+        y: .value("Revenue", item.revenue)
+    )
+}
+```
+
+### Data Models Should Be Identifiable
+
+Prefer `Identifiable` models for chart data so identity stays stable as data changes.
+
+```swift
+struct SalesPoint: Identifiable {
+    let id: UUID
+    let month: String
+    let revenue: Double
+}
+```
+
+If your model cannot conform to `Identifiable`, provide an explicit id key path:
+
+```swift
+Chart(sales, id: \.month) { item in
+    BarMark(
+        x: .value("Month", item.month),
+        y: .value("Revenue", item.revenue)
+    )
+}
+```
+
+### Plottable Values
+
+Use `.value(_, _)` to describe what each axis value means. Those labels are reused by axes, legends, and accessibility.
+
+```swift
+LineMark(
+    x: .value("Day", entry.date),
+    y: .value("Steps", entry.count)
+)
+```
+
+## Chart Types
+
+### BarMark
+
+```swift
+BarMark(
+    x: .value("Product", product.name),
+    y: .value("Units", product.units)
+)
+```
+
+Stacking via `MarkStackingMethod`: `.standard`, `.normalized`, `.center`, `.unstacked`.
+
+### LineMark
+
+```swift
+LineMark(
+    x: .value("Day", day.date),
+    y: .value("Steps", day.count)
+)
+.interpolationMethod(.monotone)
+```
+
+Interpolation methods: `.linear`, `.monotone`, `.cardinal`, `.catmullRom`, `.stepStart`, `.stepCenter`, `.stepEnd`. Cardinal and Catmull-Rom accept optional tension/alpha parameters.
+
+### AreaMark
+
+```swift
+AreaMark(
+    x: .value("Hour", sample.hour),
+    y: .value("Temperature", sample.value),
+    stacking: .unstacked
+)
+```
+
+Ranged areas use `yStart`/`yEnd` for bands like min/max or confidence intervals:
+
+```swift
+AreaMark(
+    x: .value("Day", sample.day),
+    yStart: .value("Low", sample.low),
+    yEnd: .value("High", sample.high)
+)
+```
+
+### PointMark
+
+```swift
+PointMark(
+    x: .value("Time", measurement.time),
+    y: .value("Value", measurement.value)
+)
+```
+
+### RectangleMark
+
+```swift
+RectangleMark(
+    xStart: .value("Start Day", cell.startDay),
+    xEnd: .value("End Day", cell.endDay),
+    yStart: .value("Low", cell.low),
+    yEnd: .value("High", cell.high)
+)
+```
+
+### RuleMark
+
+```swift
+RuleMark(y: .value("Goal", 10_000))
+    .foregroundStyle(.red)
+```
+
+### SectorMark
+
+Use `SectorMark` for pie and donut-style charts. `SectorMark` requires iOS 17 or later.
+
+```swift
+Chart(expenses) { expense in
+    SectorMark(
+        angle: .value("Amount", expense.amount),
+        innerRadius: .ratio(0.6),
+        angularInset: 2
+    )
+    .foregroundStyle(by: .value("Category", expense.category))
+}
+```
+
+Use `innerRadius` to turn a pie chart into a donut chart, and `angularInset` to separate slices visually.
+
+### Plot Types (iOS 18+)
+
+iOS 18 adds data-driven plot wrappers: `AreaPlot`, `BarPlot`, `LinePlot`, `PointPlot`, `RectanglePlot`, `RulePlot`, and `SectorPlot`.
+
+`LinePlot` and `AreaPlot` also accept function closures for plotting mathematical functions without discrete data:
+
+```swift
+if #available(iOS 18, *) {
+    Chart {
+        LinePlot(x: "x", y: "sin(x)") { x in
+            sin(x)
+        }
+    }
+    .chartXScale(domain: -Double.pi ... Double.pi)
+    .chartYScale(domain: -1.5 ... 1.5)
+}
+```
+
+Use plot types when you want a data-first API surface or need function plotting. The underlying chart families stay the same.
+
+### Chart3D (iOS 26+)
+
+`Chart3D` is a separate API for 3D chart content. It supports 3D `PointMark`, `RectangleMark`, `RuleMark`, and `SurfacePlot`.
+
+```swift
+if #available(iOS 26, *) {
+    Chart3D(points) { point in
+        PointMark(
+            x: .value("X", point.x),
+            y: .value("Y", point.y),
+            z: .value("Z", point.z)
+        )
+    }
+    .chart3DPose(.front)
+    .chart3DCameraProjection(.perspective)
+}
+```
+
+`SurfacePlot` visualizes mathematical surfaces by evaluating a two-variable function:
+
+```swift
+if #available(iOS 26, *) {
+    Chart3D {
+        SurfacePlot(x: "x", y: "height", z: "z") { x, z in
+            sin(x) * cos(z)
+        }
+    }
+    .chartXScale(domain: -Double.pi ... Double.pi)
+    .chartZScale(domain: -Double.pi ... Double.pi)
+}
+```
+
+Camera and pose configuration:
+
+- **Projection**: `.chart3DCameraProjection(.orthographic)` (default, precise measurements) or `.perspective` (depth effect)
+- **Pose presets**: `.chart3DPose(.default)`, `.front`, `.back`, `.left`, `.right`
+- **Custom pose**: `.chart3DPose(azimuth: .degrees(45), inclination: .degrees(30))`
+- On visionOS, Chart3D supports natural 3D interaction gestures for rotation and exploration
+
+**Always** gate `Chart3D` with `#available(iOS 26, *)` — it is not available on earlier OS versions.
+
+## Axis Tweaks
+
+### Axis Visibility and Labels
+
+Use `chartXAxis`, `chartYAxis`, `chartXAxisLabel`, and `chartYAxisLabel` on the `Chart` container.
+Axis visibility supports `.automatic`, `.visible`, and `.hidden`.
+
+```swift
+Chart(data) { item in
+    BarMark(
+        x: .value("Month", item.month),
+        y: .value("Revenue", item.revenue)
+    )
+}
+.chartXAxis(.visible)
+.chartYAxis(.hidden)
+.chartXAxisLabel("Month")
+.chartYAxisLabel("Revenue")
+```
+
+### Custom Axis Marks
+
+Use `AxisMarks` to control tick placement, labels, and grid lines.
+
+```swift
+Chart(steps) { day in
+    LineMark(
+        x: .value("Day", day.date),
+        y: .value("Steps", day.count)
+    )
+}
+.chartXAxis {
+    AxisMarks(
+        preset: .aligned,
+        position: .bottom,
+        values: .stride(by: .day)
+    ) {
+        AxisGridLine()
+        AxisTick(length: .label)
+        AxisValueLabel(format: .dateTime.weekday(.abbreviated))
+    }
+}
+```
+
+Useful `AxisMarks` inputs:
+
+- `preset`: `.automatic`, `.extended`, `.aligned`, `.inset`
+- `position`: `.automatic`, `.leading`, `.trailing`, `.top`, `.bottom`
+- `values`: `.automatic`, `.automatic(desiredCount:)`, `.stride(by:)`, `.stride(by:count:)`, or an explicit array
+
+### Axis Components
+
+Within `AxisMarks`, combine the built-in axis components as needed:
+
+```swift
+AxisGridLine()
+AxisTick()
+AxisValueLabel()
+```
+
+`AxisValueLabel` can be tuned for dense axes:
+
+```swift
+AxisValueLabel(
+    collisionResolution: .greedy(minimumSpacing: 8),
+    orientation: .vertical
+)
+```
+
+Label orientations: `.automatic`, `.horizontal`, `.vertical`, `.verticalReversed`.
+
+Collision strategies: `.automatic`, `.greedy`, `.greedy(priority:minimumSpacing:)`, `.truncate`, `.disabled`.
+
+### Axis Domains and Plot Area Tweaks
+
+Use scales when you need explicit axis domains or plot area control.
+
+```swift
+Chart(data) { item in
+    LineMark(
+        x: .value("Index", item.index),
+        y: .value("Score", item.score)
+    )
+}
+.chartXScale(domain: 0...30)
+.chartYScale(domain: 0...100)
+.chartPlotStyle { plotArea in
+    plotArea
+        .background(.gray.opacity(0.08))
+}
+```
+
+You can set one axis domain without forcing the other:
+
+```swift
+.chartXScale(domain: startDate...endDate)
+```
+
+### Scrollable Axes (iOS 17+)
+
+For larger datasets, make the plot area scroll and control the visible domain.
+
+```swift
+@State private var scrollX = 7
+
+Chart(data) { item in
+    BarMark(
+        x: .value("Day", item.day),
+        y: .value("Value", item.value)
+    )
+}
+.chartScrollableAxes(.horizontal)
+.chartXVisibleDomain(length: 7)
+.chartScrollPosition(x: $scrollX)
+```
+
+## Selection APIs
+
+### Single-Value Selection
+
+Use `chartXSelection(value:)` or `chartYSelection(value:)` for one selected value.
+
+```swift
+@State private var selectedDate: Date?
+
+Chart(steps) { day in
+    LineMark(x: .value("Day", day.date), y: .value("Steps", day.count))
+
+    if let selectedDate {
+        RuleMark(x: .value("Selected Day", selectedDate))
+            .foregroundStyle(.secondary)
+    }
+}
+.chartXSelection(value: $selectedDate)
+```
+
+### Range Selection
+
+Use `chartXSelection(range:)` or `chartYSelection(range:)` for a dragged range. Bind to a `ClosedRange` whose bound type matches the plotted axis value.
+
+```swift
+@State private var selectedWeeks: ClosedRange<Int>?
+
+Chart(weeks) { week in
+    BarMark(x: .value("Week", week.index), y: .value("Revenue", week.revenue))
+}
+.chartXSelection(range: $selectedWeeks)
+```
+
+### Choosing Single vs Range
+
+- Use `value:` bindings when only one point or axis value should be selected.
+- Use `range:` bindings when users should brush a span (for zoom windows, comparisons, or grouped summaries).
+
+### Angle Selection
+
+Use `chartAngleSelection(value:)` with `SectorMark` charts. No built-in range overload for angle selection.
+
+```swift
+@State private var selectedAmount: Double?
+
+Chart(expenses) { expense in
+    SectorMark(angle: .value("Amount", expense.amount))
+        .foregroundStyle(by: .value("Category", expense.category))
+}
+.chartAngleSelection(value: $selectedAmount)
+```
+
+**Important**: Selection bindings return the plottable axis value, not the full data element. Map back to your model if you need the selected record.
+
+## Annotations
+
+Use `annotation(position:)` on a mark when you need labels, callouts, or highlighted values attached to the plotted content.
+
+```swift
+BarMark(
+    x: .value("Month", item.month),
+    y: .value("Revenue", item.revenue)
+)
+.annotation(position: .top) {
+    Text(item.revenue.formatted())
+}
+```
+
+This is useful for selected values, thresholds, summaries, and direct labeling. Common positions include `.overlay`, `.top`, `.bottom`, `.leading`, and `.trailing`.
+
+## ChartProxy and Custom Touch Handling
+
+Use `chartOverlay`/`chartBackground` (iOS 16+) or `chartGesture` (iOS 17+) with `ChartProxy` when built-in selection modifiers are not enough.
+
+```swift
+.chartOverlay { proxy in
+    GeometryReader { geometry in
+        Rectangle().fill(.clear).contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        guard let plotFrame = proxy.plotFrame else { return } // iOS 16: use proxy.plotAreaFrame
+                        let frame = geometry[plotFrame]
+                        let x = value.location.x - frame.origin.x
+                        guard x >= 0, x <= frame.size.width else { return }
+                        selectedDate = proxy.value(atX: x, as: Date.self)
+                    }
+                    .onEnded { _ in selectedDate = nil }
+            )
+    }
+}
+```
+
+Use `proxy.plotFrame` (iOS 17+) or `proxy.plotAreaFrame` (iOS 16) to get the plot area anchor.
+
+`ChartProxy` gives you lower-level access to:
+
+- `value(atX:as:)`, `value(atY:as:)`, and `value(at:as:)` for converting gesture coordinates into chart values
+- `position(forX:)`, `position(forY:)`, and `position(for:)` for placing custom overlays or indicators
+- `selectXValue(at:)`, `selectYValue(at:)`, `selectXRange(from:to:)`, and `selectYRange(from:to:)` for driving built-in selection from custom gestures
+- `plotFrame` (iOS 17+) or `plotAreaFrame` (iOS 16) with `plotSize` for converting between gesture coordinates and the plot area
+
+`select*` ChartProxy selection methods and `chartGesture` are available on iOS 17+.
+
+## Modifier Scope
+
+Apply chart-wide modifiers to the `Chart` container and mark-specific modifiers to the individual mark.
+
+```swift
+Chart(data) { item in
+    LineMark(
+        x: .value("Day", item.date),
+        y: .value("Value", item.value)
+    )
+    .interpolationMethod(.monotone)   // Mark-level modifier
+}
+.chartXAxis { AxisMarks() }            // Chart-level modifier
+.chartYScale(domain: 0...100)          // Chart-level modifier
+.chartPlotStyle { $0.background(.thinMaterial) }
+```
+
+## Styling and Visual Channels
+
+### Categorical Coloring
+
+Use `foregroundStyle(by: .value(...))` to color marks by a data property. Swift Charts generates a legend automatically.
+
+```swift
+Chart(sales) { item in
+    BarMark(
+        x: .value("Month", item.month),
+        y: .value("Revenue", item.revenue)
+    )
+    .foregroundStyle(by: .value("Region", item.region))
+}
+```
+
+**Avoid** applying `.foregroundStyle(.red)` per mark for categorical data — this suppresses the automatic legend and breaks accessibility.
+
+### Custom Color Scales
+
+Use `chartForegroundStyleScale` to control the mapping from data values to colors.
+
+```swift
+.chartForegroundStyleScale([
+    "North": .blue,
+    "South": .orange,
+    "East": .green
+])
+```
+
+For dynamic data where not all series appear at every point, use the mapping overload:
+
+```swift
+.chartForegroundStyleScale(domain: regions, mapping: { region in
+    colorForRegion(region)
+})
+```
+
+### Symbol and Size Channels
+
+Use `symbol(by:)` and `symbolSize(by:)` to encode additional data dimensions on `PointMark` and `LineMark`.
+
+```swift
+Chart(measurements) { item in
+    PointMark(
+        x: .value("Time", item.time),
+        y: .value("Value", item.value)
+    )
+    .foregroundStyle(by: .value("Category", item.category))
+    .symbol(by: .value("Category", item.category))
+    .symbolSize(by: .value("Weight", item.weight))
+}
+```
+
+### Legend Control
+
+```swift
+.chartLegend(.visible)
+.chartLegend(.hidden)
+.chartLegend(position: .bottom, alignment: .center)
+```
+
+## Composing Multiple Marks
+
+Combine different mark types inside the same `Chart` closure:
+
+```swift
+// Line with points
+LineMark(x: .value("Day", day.date), y: .value("Steps", day.count))
+    .interpolationMethod(.monotone)
+PointMark(x: .value("Day", day.date), y: .value("Steps", day.count))
+
+// Bars with threshold line
+BarMark(x: .value("Month", item.month), y: .value("Revenue", item.revenue))
+RuleMark(y: .value("Target", 10_000))
+    .foregroundStyle(.red)
+    .lineStyle(StrokeStyle(dash: [5, 3]))
+```
+
+## Animating Chart Data
+
+Chart marks animate automatically when data identity is stable and changes are wrapped in an animation.
+
+```swift
+withAnimation(.easeInOut) {
+    chartData = updatedData
+}
+```
+
+**Always** use `Identifiable` models (or explicit `id:`) so Swift Charts can match old and new data points and animate transitions between them.
+
+## Best Practices
+
+### Do
+
+- Use semantic `.value(_, _)` labels so axes and accessibility read clearly
+- Prefer `Identifiable` models (or explicit `id:`) for stable chart data identity
+- Use `foregroundStyle(by:)` for categorical series to get automatic legends and accessibility
+- Use `RuleMark` for goals, thresholds, and selected-value indicators
+- Use explicit `AxisMarks(values:)` when automatic tick generation gets crowded
+- Use `chartXScale` and `chartYScale` when you need stable visual comparisons
+- Use `chartXSelection(range:)` or `chartYSelection(range:)` for brushed selection
+- Gate iOS 17+ APIs such as `SectorMark` and selection with `#available`
+
+### Don't
+
+- Put chart-wide modifiers such as `chartXAxis` or `chartXSelection` on individual marks
+- Apply manual `.foregroundStyle(.color)` per mark for categorical data — use `foregroundStyle(by:)` instead
+- Rely on unstable identities when chart data can be inserted, removed, or reordered
+- Use string values for naturally numeric or date-based axes unless you want categorical behavior
+- Stack unrelated series by default just because `BarMark` and `AreaMark` allow it
+- Force every tick label to display when collision handling or stride values would be clearer
+- Assume selection returns a model object; it only returns the plottable axis value
+- Forget that range selection is available only for X and Y axes, not angle selection
+
+For chart accessibility (VoiceOver, Audio Graph, `AXChartDescriptorRepresentable`), fallback strategies, WWDC sessions, and a full summary checklist, see `charts-accessibility.md`.

--- a/.agents/skills/swiftui-expert-skill/references/focus-patterns.md
+++ b/.agents/skills/swiftui-expert-skill/references/focus-patterns.md
@@ -1,0 +1,299 @@
+# SwiftUI Focus Patterns Reference
+
+## Table of Contents
+
+- [@FocusState](#focusstate)
+- [Making Views Focusable](#making-views-focusable)
+- [Focused Values for Commands and Menus](#focused-values-for-commands-and-menus)
+- [Default Focus](#default-focus)
+- [Focus Scope and Sections](#focus-scope-and-sections)
+- [Focus Effects](#focus-effects)
+- [Search Focus](#search-focus)
+- [Common Pitfalls](#common-pitfalls)
+
+## @FocusState
+
+Always mark `@FocusState` as `private`. Use `Bool` for a single field, an optional `Hashable` enum for multiple fields.
+
+### Single field
+
+```swift
+@FocusState private var isFocused: Bool
+
+TextField("Email", text: $email)
+    .focused($isFocused)
+```
+
+### Multiple fields
+
+```swift
+enum Field: Hashable { case name, email, password }
+@FocusState private var focusedField: Field?
+
+TextField("Name", text: $name)
+    .focused($focusedField, equals: .name)
+TextField("Email", text: $email)
+    .focused($focusedField, equals: .email)
+```
+
+Set `focusedField = .email` to move focus programmatically; set `nil` to dismiss the keyboard.
+
+### `focused(_:)` vs `focused(_:equals:)` with nested views
+
+`.focused($bool)` reports `true` when the modified view *or any focusable descendant* has focus. `.focused($enum, equals:)` reports its value only when that specific view receives focus.
+
+```swift
+enum Focus: Hashable { case container, field }
+@FocusState private var focus: Focus?
+
+VStack {
+    TextField("Name", text: $name)
+        .focused($focus, equals: .field)
+}
+.focusable()
+.focused($focus, equals: .container)
+```
+
+With `focused(_:equals:)` and a single `@FocusState`, SwiftUI distinguishes the container *receiving* focus from the container merely *containing* focus.
+
+### `isFocused` environment value
+
+Read-only environment value that returns `true` when the nearest focusable ancestor has focus. Useful for styling non-focusable child views.
+
+```swift
+struct HighlightWrapper: View {
+    @Environment(\.isFocused) private var isFocused
+
+    var body: some View {
+        content
+            .background(isFocused ? Color.accentColor.opacity(0.1) : .clear)
+    }
+}
+```
+
+## Making Views Focusable
+
+### `.focusable(_:)`
+
+Makes a non-text-input view participate in the focus system. Focused views can respond to keyboard events via `onKeyPress` and menu commands like Edit > Delete via `onDeleteCommand`.
+
+```swift
+struct SelectableCard: View {
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        CardContent()
+            .focusable()
+            .focused($isFocused)
+            .border(isFocused ? Color.accentColor : .clear)
+            .onDeleteCommand { deleteCard() }
+    }
+}
+```
+
+### `.focusable(_:interactions:)` (iOS 17+)
+
+Controls which focus-driven interactions the view supports via `FocusInteractions`:
+
+- `.activate` -- Button-like: only focusable when system-wide keyboard navigation is on (macOS/iOS)
+- `.edit` -- Captures keyboard/Digital Crown input
+- `.automatic` -- Platform default (both activate and edit)
+
+```swift
+MyTapGestureView(...)
+    .focusable(interactions: .activate)
+```
+
+Use `.activate` for custom button-like views that should match system keyboard-navigation behavior.
+
+## Focused Values for Commands and Menus
+
+Focused values let parent views (App, Scene, Commands) read state from whichever view currently has focus. Use for enabling/disabling menu commands based on the focused document or selection.
+
+### Declare with `@Entry`
+
+```swift
+extension FocusedValues {
+    @Entry var selectedDocument: Binding<Document>?
+}
+```
+
+Focused values are typically optional (default is `nil` when no view publishes them), but you can also use non-optional entries when you have a sensible default value.
+
+### Publish from views
+
+```swift
+// View-scoped: available when this view (or descendant) has focus
+.focusedValue(\.selectedDocument, $document)
+
+// Scene-scoped: available when this scene has focus
+.focusedSceneValue(\.selectedDocument, $document)
+```
+
+### Consume in commands
+
+`@FocusedValue` reads the value; `@FocusedBinding` unwraps a `Binding` automatically.
+
+```swift
+@main
+struct MyApp: App {
+    @FocusedBinding(\.selectedDocument) var document
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+        .commands {
+            CommandGroup(after: .pasteboard) {
+                Button("Duplicate") { document?.duplicate() }
+                    .disabled(document == nil)
+            }
+        }
+    }
+}
+```
+
+### `@FocusedObject` (iOS 16+)
+
+For `ObservableObject` types. The view invalidates when the focused object changes.
+
+```swift
+// Publish
+.focusedObject(myObservableModel)
+
+// Consume
+@FocusedObject var model: MyModel?
+```
+
+Scene-scoped variant: `.focusedSceneObject(_:)`.
+
+## Default Focus
+
+### `.defaultFocus(_:_:priority:)` (iOS 17+, macOS 13+, tvOS 16+)
+
+Prefer `.defaultFocus` over setting `@FocusState` in `onAppear` for initial focus placement.
+
+```swift
+@FocusState private var focusedField: Field?
+
+VStack {
+    TextField("Name", text: $name)
+        .focused($focusedField, equals: .name)
+    TextField("Email", text: $email)
+        .focused($focusedField, equals: .email)
+}
+.defaultFocus($focusedField, .email)
+```
+
+**Priority**: `.automatic` (default) applies on window appearance and programmatic focus changes. `.userInitiated` also applies during user-driven focus navigation.
+
+### `prefersDefaultFocus(_:in:)` (macOS/tvOS/watchOS)
+
+Used with `.focusScope(_:)` to mark a preferred default target within a scoped region.
+
+### `resetFocus` environment action (macOS/tvOS/watchOS)
+
+Re-evaluates default focus within a namespace.
+
+```swift
+@Namespace var scopeID
+@Environment(\.resetFocus) private var resetFocus
+
+Button("Reset") { resetFocus(in: scopeID) }
+```
+
+## Focus Scope and Sections
+
+### `.focusScope(_:)` (macOS/tvOS/watchOS)
+
+Limits default focus preferences to a namespace. Use with `prefersDefaultFocus` and `resetFocus`.
+
+### `.focusSection()` (macOS 13+, tvOS 15+)
+
+Guides directional and sequential focus movement through a group of focusable descendants. Useful when focusable views are spatially separated and directional navigation would otherwise skip them.
+
+```swift
+HStack {
+    VStack { Button("1") {}; Button("2") {}; Spacer() }
+    Spacer()
+    VStack { Spacer(); Button("A") {}; Button("B") {} }
+        .focusSection()
+}
+```
+
+Without `.focusSection()`, swiping right from buttons 1/2 finds nothing. With it, the VStack receives directional focus and delivers it to its first focusable child.
+
+## Focus Effects
+
+### `.focusEffectDisabled(_:)`
+
+Suppresses the system focus ring (macOS) or hover effect. Use when providing custom focus visuals.
+
+```swift
+MyCustomCard()
+    .focusable()
+    .focusEffectDisabled()
+    .overlay { customFocusRing }
+```
+
+`isFocusEffectEnabled` environment value reads the current state.
+
+## Search Focus
+
+### `.searchFocused(_:)` / `.searchFocused(_:equals:)`
+
+Bind focus state to the search field associated with the nearest `.searchable` modifier. Works like `.focused` but targets the search bar.
+
+```swift
+@FocusState private var isSearchFocused: Bool
+
+NavigationStack {
+    ContentView()
+        .searchable(text: $query)
+        .searchFocused($isSearchFocused)
+}
+
+// Programmatically focus the search bar
+Button("Search") { isSearchFocused = true }
+```
+
+## Common Pitfalls
+
+### Redundant `@FocusState` writes revoke focus
+
+`.focusable()` + `.focused()` handles focus-on-click natively. Adding a tap gesture that *also* writes to `@FocusState` triggers a redundant state write, causing a second body evaluation that revokes focus. The result: focus briefly appears then disappears, and key commands like `onDeleteCommand` stop working.
+
+```swift
+// WRONG -- tap gesture redundantly sets focus, causing double evaluation
+CardView()
+    .focusable()
+    .focused($isFocused)
+    .onTapGesture { isFocused = true }  // Remove this line
+
+// CORRECT -- let .focusable() + .focused() handle it
+CardView()
+    .focusable()
+    .focused($isFocused)
+```
+
+### Ambiguous focus bindings
+
+Binding the same enum case to multiple views is ambiguous. SwiftUI picks the first candidate and emits a runtime warning.
+
+```swift
+// WRONG -- .name bound to two views
+TextField("Name", text: $name)
+    .focused($focusedField, equals: .name)
+TextField("Full Name", text: $fullName)
+    .focused($focusedField, equals: .name)  // ambiguous
+```
+
+Always use distinct enum cases for each focusable view.
+
+### `.onAppear` focus timing
+
+Setting `@FocusState` in `.onAppear` may fail if the view tree hasn't settled. Prefer `.defaultFocus` (iOS 17+) for reliable initial focus. If you must use `.onAppear`, wrap in `DispatchQueue.main.async` as a last resort.
+
+### Missing `.focusable()` for non-text views
+
+`TextField` and `SecureField` are implicitly focusable. Custom views (stacks, shapes, images) are not. Forgetting `.focusable()` means `.focused()` bindings have no effect and key event handlers never fire.

--- a/.agents/skills/swiftui-expert-skill/references/image-optimization.md
+++ b/.agents/skills/swiftui-expert-skill/references/image-optimization.md
@@ -1,0 +1,203 @@
+# SwiftUI Image Optimization Reference
+
+## Table of Contents
+
+- [AsyncImage Best Practices](#asyncimage-best-practices)
+- [Image Decoding and Downsampling (Optional Optimization)](#image-decoding-and-downsampling-optional-optimization)
+- [UIImage Loading and Memory](#uiimage-loading-and-memory)
+- [SF Symbols](#sf-symbols)
+- [Summary Checklist](#summary-checklist)
+
+## AsyncImage Best Practices
+
+### Basic AsyncImage with Phase Handling
+
+```swift
+// Good - handles loading and error states
+AsyncImage(url: imageURL) { phase in
+    switch phase {
+    case .empty:
+        ProgressView()
+    case .success(let image):
+        image
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+    case .failure:
+        Image(systemName: "photo")
+            .foregroundStyle(.secondary)
+    @unknown default:
+        EmptyView()
+    }
+}
+.frame(width: 200, height: 200)
+```
+
+For custom placeholders, replace `ProgressView()` in the `.empty` case with your placeholder view. Add `.transition(.opacity)` to the success case and `.animation(.easeInOut, value: imageURL)` to the container for fade-in transitions.
+
+## Image Decoding and Downsampling (Optional Optimization)
+
+**When you encounter `UIImage(data:)` usage, consider suggesting image downsampling as a potential performance improvement**, especially for large images in lists or grids.
+
+### Current Pattern That Could Be Optimized
+
+```swift
+// Current pattern - decodes full image on main thread
+// Unsafe - force unwrap can crash if imageData is invalid
+Image(uiImage: UIImage(data: imageData)!)
+    .resizable()
+    .aspectRatio(contentMode: .fit)
+    .frame(width: 200, height: 200)
+```
+
+### Suggested Optimization Pattern
+
+```swift
+// Suggested optimization - decode and downsample off main thread
+struct OptimizedImageView: View {
+    let imageData: Data
+    let targetSize: CGSize
+    @State private var processedImage: UIImage?
+    
+    var body: some View {
+        Group {
+            if let processedImage {
+                Image(uiImage: processedImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+            } else {
+                ProgressView()
+            }
+        }
+        .task {
+            processedImage = await decodeAndDownsample(imageData, targetSize: targetSize)
+        }
+    }
+    
+    private func decodeAndDownsample(_ data: Data, targetSize: CGSize) async -> UIImage? {
+        await Task.detached {
+            guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
+                return nil
+            }
+            
+            let options: [CFString: Any] = [
+                kCGImageSourceThumbnailMaxPixelSize: max(targetSize.width, targetSize.height),
+                kCGImageSourceCreateThumbnailFromImageAlways: true,
+                kCGImageSourceCreateThumbnailWithTransform: true
+            ]
+            
+            guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
+                return nil
+            }
+            
+            return UIImage(cgImage: cgImage)
+        }.value
+    }
+}
+
+// Usage
+OptimizedImageView(
+    imageData: imageData,
+    targetSize: CGSize(width: 200, height: 200)
+)
+```
+
+### Reusable Downsampling Actor
+
+For production use, wrap the logic in an `actor` with scale-aware sizing and cache-disabled source options:
+
+```swift
+actor ImageProcessor {
+    func downsample(data: Data, targetSize: CGSize) -> UIImage? {
+        let scale = await UIScreen.main.scale
+        let maxPixel = max(targetSize.width, targetSize.height) * scale
+        let sourceOptions: [CFString: Any] = [kCGImageSourceShouldCache: false]
+        guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions as CFDictionary) else { return nil }
+        let downsampleOptions: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixel,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceShouldCacheImmediately: true
+        ]
+        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, downsampleOptions as CFDictionary) else { return nil }
+        return UIImage(cgImage: cgImage)
+    }
+}
+```
+
+Key details: `kCGImageSourceShouldCache: false` on the source prevents the full-resolution image from being cached in memory. Multiplying `targetSize` by `UIScreen.main.scale` ensures the thumbnail is sharp on Retina displays. `kCGImageSourceShouldCacheImmediately: true` on the thumbnail forces decoding at creation time rather than at first render.
+
+### When to Suggest This Optimization
+
+Mention this optimization when you see `UIImage(data:)` usage, particularly in:
+- Scrollable content (List, ScrollView with LazyVStack/LazyHStack)
+- Grid layouts with many images
+- Image galleries or carousels
+- Any scenario where large images are displayed at smaller sizes
+
+**Don't automatically apply it**—present it as an optional improvement for performance-sensitive scenarios.
+
+## UIImage Loading and Memory
+
+### UIImage(named:) Caches in System Cache
+
+`UIImage(named:)` adds images to the system cache, which can cause memory spikes when loading many images (e.g., in a slider or gallery). For single-use or frequently-rotated images, use `UIImage(contentsOfFile:)` to bypass the cache:
+
+```swift
+// Caches in system cache -- memory builds up
+let image = UIImage(named: "Wallpapers/image_001.jpg")
+
+// No system caching -- memory stays flat
+guard let path = Bundle.main.path(forResource: "Wallpapers/image_001.jpg", ofType: nil) else { return nil }
+let image = UIImage(contentsOfFile: path)
+```
+
+### NSCache for Controlled Image Caching
+
+When image processing (resizing, filtering) is needed, use `NSCache` with a `countLimit` to bound memory instead of relying on system caching:
+
+```swift
+struct ImageCache {
+    private let cache = NSCache<NSString, UIImage>()
+
+    init(countLimit: Int = 50) {
+        cache.countLimit = countLimit
+    }
+
+    subscript(key: String) -> UIImage? {
+        get { cache.object(forKey: key as NSString) }
+        nonmutating set {
+            if let newValue {
+                cache.setObject(newValue, forKey: key as NSString)
+            } else {
+                cache.removeObject(forKey: key as NSString)
+            }
+        }
+    }
+}
+```
+
+## SF Symbols
+
+```swift
+Image(systemName: "star.fill")
+    .foregroundStyle(.yellow)
+    .symbolRenderingMode(.multicolor)     // or .hierarchical, .palette, .monochrome
+
+// Animated symbols (iOS 17+)
+Image(systemName: "antenna.radiowaves.left.and.right")
+    .symbolEffect(.variableColor)
+```
+
+Variants are available via naming convention: `star.circle.fill`, `star.square.fill`, `folder.badge.plus`.
+
+## Summary Checklist
+
+- [ ] Use `AsyncImage` with proper phase handling
+- [ ] Handle empty, success, and failure states
+- [ ] Consider downsampling for `UIImage(data:)` in performance-sensitive scenarios
+- [ ] Decode and downsample images off the main thread
+- [ ] Use appropriate target sizes for downsampling
+- [ ] Consider image caching for frequently accessed images
+- [ ] Use SF Symbols with appropriate rendering modes
+
+**Performance Note**: Image downsampling is an optional optimization. Only suggest it when you encounter `UIImage(data:)` usage in performance-sensitive contexts like scrollable lists or grids.

--- a/.agents/skills/swiftui-expert-skill/references/latest-apis.md
+++ b/.agents/skills/swiftui-expert-skill/references/latest-apis.md
@@ -1,0 +1,488 @@
+# Latest SwiftUI APIs Reference
+
+> Based on a comparison of Apple's documentation using the Sosumi MCP, we found the latest recommended APIs to use.
+
+## Table of Contents
+- [Always Use (iOS 15+)](#always-use-ios-15)
+- [When Targeting iOS 16+](#when-targeting-ios-16)
+- [When Targeting iOS 17+](#when-targeting-ios-17)
+- [When Targeting iOS 18+](#when-targeting-ios-18)
+- [When Targeting iOS 26+](#when-targeting-ios-26)
+
+---
+
+## Always Use (iOS 15+)
+
+These APIs have been deprecated long enough that there is no reason to use the old variants.
+
+### Compact Replacements
+
+These replacements have minimal API shape changes. Most are near-direct swaps; a few require an additional parameter or structural adjustment:
+
+- **`navigationTitle(_:)`** instead of `navigationBarTitle(_:)`
+- **`toolbar { ToolbarItem(...) }`** instead of `navigationBarItems(...)` (structural change)
+- **`toolbarVisibility(.hidden, for: .navigationBar)`** instead of `navigationBarHidden(_:)`
+- **`statusBarHidden(_:)`** instead of `statusBar(hidden:)`
+- **`ignoresSafeArea(_:edges:)`** instead of `edgesIgnoringSafeArea(_:)`
+- **`preferredColorScheme(_:)`** instead of `colorScheme(_:)`
+- **`foregroundStyle(_:)`** instead of `foregroundColor(_:)` (e.g., `.foregroundStyle(.primary)`)
+- **`clipShape(.rect(cornerRadius:))`** instead of `cornerRadius()`
+- **`textInputAutocapitalization(_:)`** instead of `autocapitalization(_:)` (note: `.never` replaces `.none`)
+- **`animation(_:value:)`** instead of `animation(_:)` (adds required `value:` parameter; back-deploys to iOS 13+)
+
+### Presentation
+
+- **Always use `.confirmationDialog(_:isPresented:actions:message:)`** instead of `actionSheet(...)`.
+- **Always use `.alert(_:isPresented:actions:message:)`** instead of `alert(isPresented:content:)`.
+
+Both take a title `String`, `isPresented: Binding<Bool>`, an `actions` builder with `Button` items (supporting `role: .destructive` / `.cancel`), and an optional `message` builder:
+
+```swift
+.alert("Delete Item?", isPresented: $showAlert) {
+    Button("Delete", role: .destructive) { deleteItem() }
+    Button("Cancel", role: .cancel) { }
+} message: {
+    Text("This action cannot be undone.")
+}
+```
+
+### Text Input
+
+**Always use `onSubmit(of:_:)` and `focused(_:equals:)` instead of `TextField` `onEditingChanged`/`onCommit` callbacks.**
+
+```swift
+@FocusState private var isFocused: Bool
+
+TextField("Search", text: $query)
+    .focused($isFocused)
+    .onSubmit { performSearch() }
+```
+
+### Accessibility
+
+**Always use dedicated accessibility modifiers instead of the generic `accessibility(...)` variants.** Use `.accessibilityLabel()`, `.accessibilityValue()`, `.accessibilityHint()`, `.accessibilityAddTraits()`, `.accessibilityHidden()` instead of `.accessibility(label:)`, `.accessibility(value:)`, etc.
+
+### Custom Environment / Container Values
+
+**Always use the `@Entry` macro instead of manual `EnvironmentKey` conformance.** The `@Entry` macro was introduced in Xcode 16 and back-deploys to all OS versions.
+
+```swift
+// Modern — one line replaces ~10 lines of EnvironmentKey boilerplate
+extension EnvironmentValues {
+    @Entry var myCustomValue: String = "Default value"
+}
+```
+
+### Styling
+
+**Always use `Button` instead of `onTapGesture()` unless you need tap location or count.**
+
+```swift
+Button("Tap me") { performAction() }
+
+// Use onTapGesture only when you need location or count
+Image("photo")
+    .onTapGesture(count: 2) { handleDoubleTap() }
+```
+
+---
+
+## When Targeting iOS 16+
+
+### Navigation
+
+**Use `NavigationStack` (or `NavigationSplitView`) instead of `NavigationView`.** Value-based `NavigationLink(value:)` with `.navigationDestination(for:)` replaces destination-based links.
+
+```swift
+NavigationStack {
+    List(items) { item in
+        NavigationLink(value: item) { Text(item.name) }
+    }
+    .navigationDestination(for: Item.self) { DetailView(item: $0) }
+}
+```
+
+### Simple Renames
+
+- **`tint(_:)`** instead of `accentColor(_:)`
+- **`autocorrectionDisabled(_:)`** instead of `disableAutocorrection(_:)`
+
+### Clipboard
+
+**Prefer `PasteButton` for user-initiated paste UI** to avoid paste prompts. It handles permissions automatically. Use `UIPasteboard` only when you need programmatic or non-`Transferable` clipboard access (triggers the paste permission prompt).
+
+```swift
+PasteButton(payloadType: String.self) { strings in
+    pastedText = strings.first ?? ""
+}
+```
+
+---
+
+## When Targeting iOS 17+
+
+### State Management
+
+- **Prefer `@Observable` over `ObservableObject` for new code.** Use `@State` instead of `@StateObject`; use `@Bindable` instead of `@ObservedObject`. See `state-management.md` for full `@Observable` migration patterns.
+
+### Events
+
+**Use `onChange(of:initial:_:)` or `onChange(of:) { }` instead of `onChange(of:perform:)`.**
+
+The deprecated variant passes only the new value. The modern variants provide either both old and new values, or a no-parameter closure.
+
+- **No-parameter** (most common): `.onChange(of: value) { doSomething() }`
+- **Old and new values**: `.onChange(of: value) { old, new in ... }`
+- **With initial trigger**: `.onChange(of: value, initial: true) { ... }`
+- **Deprecated**: `.onChange(of: value) { newValue in ... }` — single-parameter closure
+
+### Sensory Feedback
+
+**Prefer `sensoryFeedback(_:trigger:)` and related overloads instead of `UIImpactFeedbackGenerator`, `UISelectionFeedbackGenerator`, and `UINotificationFeedbackGenerator` in SwiftUI views.**
+
+Attach haptics declaratively to the view that owns the state change, rather than imperatively firing UIKit generators inside button actions.
+
+```swift
+@State private var isFavorite = false
+
+Button("Favorite", systemImage: isFavorite ? "heart.fill" : "heart") {
+    isFavorite.toggle()
+}
+.sensoryFeedback(.selection, trigger: isFavorite)
+```
+
+Use the conditional overload when feedback should fire only for specific transitions:
+
+```swift
+.sensoryFeedback(.selection, trigger: phase) { old, new in
+    old == .inactive || new == .expanded
+}
+```
+
+### Gestures
+
+- **`MagnifyGesture`** instead of `MagnificationGesture` (access magnitude via `value.magnification`)
+- **`RotateGesture`** instead of `RotationGesture` (access angle via `value.rotation`)
+
+### Layout
+
+**Consider `containerRelativeFrame()` or `visualEffect()` as alternatives to `GeometryReader` for sizing and position-based effects.** `GeometryReader` is not deprecated and remains necessary for many measurement-based layouts.
+
+```swift
+Image("hero")
+    .resizable()
+    .containerRelativeFrame(.horizontal) { length, axis in length * 0.8 }
+```
+
+- **`visualEffect { content, geometry in ... }`** — position-based effects (parallax, offsets) without a `GeometryReader` wrapper.
+- **`onGeometryChange(for:of:action:)`** — react to geometry changes of a specific view; useful for driving state/effects. `GeometryReader` is still better when layout itself depends on geometry. Note the two-closure shape:
+  ```swift
+  .onGeometryChange(for: CGFloat.self) { proxy in proxy.size.height } action: { newHeight in height = newHeight }
+  ```
+- **`.coordinateSpace(.named("scroll"))`** instead of `.coordinateSpace(name: "scroll")`.
+
+---
+
+## When Targeting iOS 18+
+
+### Tabs
+
+**Use the `Tab` API instead of `tabItem(_:)`.**
+
+```swift
+TabView {
+    Tab("Home", systemImage: "house") { HomeView() }
+    Tab("Search", systemImage: "magnifyingglass") { SearchView() }
+    Tab("Profile", systemImage: "person") { ProfileView() }
+}
+```
+
+When using `Tab(role:)`, all tabs must use the `Tab` syntax. Mixing `Tab(role:)` with `.tabItem()` causes compilation errors.
+
+### Previews
+
+**Use `@Previewable` for dynamic properties in previews.**
+
+```swift
+// Modern (iOS 18+)
+#Preview {
+    @Previewable @State var isOn = false
+    Toggle("Setting", isOn: $isOn)
+}
+```
+
+---
+
+## When Targeting iOS 26+
+
+For Liquid Glass APIs (`glassEffect`, `GlassEffectContainer`, glass button styles), see [liquid-glass.md](liquid-glass.md).
+
+### Scroll Edge Effects
+
+**Use `scrollEdgeEffectStyle(_:for:)` to configure scroll edge behavior.**
+
+```swift
+ScrollView {
+    // content
+}
+.scrollEdgeEffectStyle(.soft, for: .top)
+```
+
+### Background Extension
+
+**Use `backgroundExtensionEffect()` for edge-extending blurred backgrounds.**
+
+Views behind a Liquid Glass sidebar can appear clipped. This modifier mirrors and blurs content outside the safe area so artwork remains visible.
+
+```swift
+Image("hero")
+    .backgroundExtensionEffect()
+```
+
+> Source: "Build a SwiftUI app with the new design" (WWDC25, session 323)
+
+### Tab Bar
+
+**Use `tabBarMinimizeBehavior(_:)` to control tab bar minimization on scroll.**
+
+```swift
+TabView {
+    // tabs
+}
+.tabBarMinimizeBehavior(.onScrollDown)
+```
+
+**Use `tabViewBottomAccessory` for persistent controls above the tab bar.** Read `tabViewBottomAccessoryPlacement` from the environment to adapt content when the accessory collapses into the tab bar area.
+
+```swift
+TabView {
+    // tabs
+}
+.tabViewBottomAccessory {
+    NowPlayingBar()
+}
+```
+
+**Use `Tab(role: .search)` for a dedicated search tab.** The tab separates from the rest and morphs into a search field when selected.
+
+```swift
+TabView {
+    Tab("Home", systemImage: "house") { HomeView() }
+    Tab("Profile", systemImage: "person") { ProfileView() }
+    Tab(role: .search) { SearchResultsView() }
+}
+```
+
+> Source: "What's new in SwiftUI" (WWDC25, session 256) and "Build a SwiftUI app with the new design" (WWDC25, session 323)
+
+### Toolbars
+
+**Use `ToolbarSpacer` to control grouping of toolbar items.** Fixed spacers visually separate related groups; flexible spacers push items apart.
+
+```swift
+.toolbar {
+    ToolbarItem(placement: .topBarTrailing) {
+        Button("Up", systemImage: "chevron.up") { }
+    }
+    ToolbarItem(placement: .topBarTrailing) {
+        Button("Down", systemImage: "chevron.down") { }
+    }
+    ToolbarSpacer(.fixed)
+    ToolbarItem(placement: .topBarTrailing) {
+        Button("Settings", systemImage: "gear") { }
+    }
+}
+```
+
+**Use `sharedBackgroundVisibility(.hidden)` to remove the glass group background from an individual toolbar item.**
+
+```swift
+ToolbarItem(placement: .topBarTrailing) {
+    Image(systemName: "person.circle.fill")
+        .sharedBackgroundVisibility(.hidden)
+}
+```
+
+**Use `badge(_:)` on toolbar item content to display an indicator.**
+
+```swift
+ToolbarItem(placement: .topBarTrailing) {
+    Button("Notifications", systemImage: "bell") { }
+        .badge(unreadCount)
+}
+```
+
+> Source: "Build a SwiftUI app with the new design" (WWDC25, session 323)
+
+### Search
+
+**Use `searchToolbarBehavior(.minimizable)` to opt into a minimized search button.** The system may automatically minimize search into a toolbar button depending on available space. Use this modifier to explicitly opt in.
+
+```swift
+NavigationStack {
+    ContentView()
+        .searchable(text: $query)
+        .searchToolbarBehavior(.minimizable)
+}
+```
+
+> Source: "Build a SwiftUI app with the new design" (WWDC25, session 323)
+
+### Animations
+
+**Use `@Animatable` macro instead of manual `animatableData` declarations.** The macro auto-synthesizes `animatableData` from all animatable properties. Use `@AnimatableIgnored` to exclude specific properties.
+
+```swift
+@Animatable
+struct Wedge: Shape {
+    var startAngle: Angle
+    var endAngle: Angle
+    @AnimatableIgnored var drawClockwise: Bool
+
+    func path(in rect: CGRect) -> Path { /* ... */ }
+}
+```
+
+> Source: "What's new in SwiftUI" (WWDC25, session 256)
+
+### Presentations
+
+**Use `navigationZoomTransition` to morph sheets out of their source view.** Toolbar items and buttons can serve as the transition source.
+
+```swift
+.toolbar {
+    ToolbarItem {
+        Button("Add", systemImage: "plus") { showSheet = true }
+            .navigationTransitionSource(id: "addSheet", namespace: namespace)
+    }
+}
+.sheet(isPresented: $showSheet) {
+    AddItemView()
+        .navigationTransitionDestination(id: "addSheet", namespace: namespace)
+}
+```
+
+> Source: "Build a SwiftUI app with the new design" (WWDC25, session 323)
+
+### Controls
+
+**Use `controlSize(.extraLarge)` for extra-large prominent action buttons.**
+
+```swift
+Button("Get Started") { }
+    .buttonStyle(.borderedProminent)
+    .controlSize(.extraLarge)
+```
+
+**Use `concentric` corner style for buttons that match their container's corners.**
+
+```swift
+Button("Confirm") { }
+    .clipShape(.rect(cornerRadius: 12, style: .concentric))
+```
+
+**Sliders now support tick marks and a neutral value.**
+
+```swift
+Slider(value: $speed, in: 0.5...2.0, step: 0.25) {
+    Text("Speed")
+} ticks: {
+    SliderTick(value: 0.6)
+    SliderTick(value: 0.9)
+}
+.sliderNeutralValue(1.0)
+```
+
+> Source: "Build a SwiftUI app with the new design" (WWDC25, session 323)
+
+### Rich Text
+
+**Use `TextEditor` with an `AttributedString` binding for rich text editing.** Supports bold, italic, underline, strikethrough, custom fonts, foreground/background colors, paragraph styles, and Genmoji.
+
+```swift
+@State private var text: AttributedString = "Hello, world!"
+
+var body: some View {
+    TextEditor(text: $text)
+}
+```
+
+> Source: "Cook up a rich text experience in SwiftUI with AttributedString" (WWDC25, session 280)
+
+### Web Content
+
+**Use `WebView` to display web content.** For richer interaction, create a `WebPage` observable model.
+
+```swift
+// Simple URL display
+WebView(url: URL(string: "https://example.com")!)
+
+// With observable model
+@State private var page = WebPage()
+
+WebView(page)
+    .onAppear { page.load(URLRequest(url: myURL)) }
+    .navigationTitle(page.title ?? "")
+```
+
+> Source: "Meet WebKit for SwiftUI" (WWDC25, session 231)
+
+### Drag and Drop
+
+**Use `dragContainer` for multi-item drag operations.** Combine with `DragConfiguration` for custom drag behavior and `onDragSessionUpdated` to observe events.
+
+```swift
+PhotoGrid(photos: photos)
+    .dragContainer(for: Photo.self) { selection in
+        return selection.map { $0.transferable }
+    }
+    .onDragSessionUpdated { session in
+        if session.phase == .endedWithDelete {
+            deleteSelectedPhotos()
+        }
+    }
+```
+
+> Source: "What's new in SwiftUI" (WWDC25, session 256)
+
+### Scene Bridging
+
+**UIKit and AppKit lifecycle apps can now request SwiftUI scenes.** This enables using SwiftUI-only scene types like `MenuBarExtra` and `ImmersiveSpace` from imperative lifecycle apps via `UIApplication.shared.activateSceneSession(for:errorHandler:)`.
+
+> Source: "What's new in SwiftUI" (WWDC25, session 256)
+
+---
+
+## Quick Lookup Table
+
+| Deprecated | Recommended | Since |
+|-----------|-------------|-------|
+| `navigationBarTitle(_:)` | `navigationTitle(_:)` | iOS 15+ |
+| `navigationBarItems(...)` | `toolbar { ToolbarItem(...) }` | iOS 15+ |
+| `navigationBarHidden(_:)` | `toolbarVisibility(.hidden, for: .navigationBar)` | iOS 15+ |
+| `statusBar(hidden:)` | `statusBarHidden(_:)` | iOS 15+ |
+| `edgesIgnoringSafeArea(_:)` | `ignoresSafeArea(_:edges:)` | iOS 15+ |
+| `colorScheme(_:)` | `preferredColorScheme(_:)` | iOS 15+ |
+| `foregroundColor(_:)` | `foregroundStyle(_:)` | iOS 15+ |
+| `cornerRadius(_:)` | `clipShape(.rect(cornerRadius:))` | iOS 15+ |
+| `actionSheet(...)` | `confirmationDialog(...)` | iOS 15+ |
+| `alert(isPresented:content:)` | `alert(_:isPresented:actions:message:)` | iOS 15+ |
+| `autocapitalization(_:)` | `textInputAutocapitalization(_:)` | iOS 15+ |
+| `accessibility(label:)` etc. | `accessibilityLabel()` etc. | iOS 15+ |
+| `TextField` `onCommit`/`onEditingChanged` | `onSubmit` + `focused` | iOS 15+ |
+| `animation(_:)` (no value) | `animation(_:value:)` | Back-deploys (iOS 13+) |
+| Manual `EnvironmentKey` | `@Entry` macro | Back-deploys (Xcode 16+) |
+| `NavigationView` | `NavigationStack` / `NavigationSplitView` | iOS 16+ |
+| `accentColor(_:)` | `tint(_:)` | iOS 16+ |
+| `disableAutocorrection(_:)` | `autocorrectionDisabled(_:)` | iOS 16+ |
+| `UIPasteboard.general` | `PasteButton` | iOS 16+ |
+| `onChange(of:perform:)` | `onChange(of:) { }` or `onChange(of:) { old, new in }` | iOS 17+ |
+| `UIImpactFeedbackGenerator` / `UISelectionFeedbackGenerator` / `UINotificationFeedbackGenerator` | `sensoryFeedback(_:trigger:)` | iOS 17+ |
+| `MagnificationGesture` | `MagnifyGesture` | iOS 17+ |
+| `RotationGesture` | `RotateGesture` | iOS 17+ |
+| `coordinateSpace(name:)` | `coordinateSpace(.named(...))` | iOS 17+ |
+| `ObservableObject` | `@Observable` | iOS 17+ |
+| `tabItem(_:)` | `Tab` API | iOS 18+ |
+| Manual `animatableData` | `@Animatable` macro | iOS 26+ |
+| `presentationBackground(_:)` on sheets | Default Liquid Glass sheet material | iOS 26+ |
+| Custom toolbar background hacks | `scrollEdgeEffectStyle(_:for:)` | iOS 26+ |

--- a/.agents/skills/swiftui-expert-skill/references/layout-best-practices.md
+++ b/.agents/skills/swiftui-expert-skill/references/layout-best-practices.md
@@ -1,0 +1,266 @@
+# SwiftUI Layout Best Practices Reference
+
+## Table of Contents
+
+- [Relative Layout Over Constants](#relative-layout-over-constants)
+- [Context-Agnostic Views](#context-agnostic-views)
+- [Own Your Container](#own-your-container)
+- [Layout Performance](#layout-performance)
+- [View Logic and Testability](#view-logic-and-testability)
+- [Full-Width Views](#full-width-views)
+- [Action Handlers](#action-handlers)
+- [Summary Checklist](#summary-checklist)
+
+## Relative Layout Over Constants
+
+**Use dynamic layout calculations instead of hard-coded values.**
+
+```swift
+// Good - relative to actual layout
+GeometryReader { geometry in
+    VStack {
+        HeaderView()
+            .frame(height: geometry.size.height * 0.2)
+        ContentView()
+    }
+}
+
+// Avoid - magic numbers that don't adapt
+VStack {
+    HeaderView()
+        .frame(height: 150)  // Doesn't adapt to different screens
+    ContentView()
+}
+```
+
+**Why**: Hard-coded values don't account for different screen sizes, orientations, or dynamic content (like status bars during phone calls).
+
+## Context-Agnostic Views
+
+**Views should work in any context.** Never assume presentation style or screen size.
+
+```swift
+// Good - adapts to given space
+struct ProfileCard: View {
+    let user: User
+    
+    var body: some View {
+        VStack {
+            Image(user.avatar)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+            Text(user.name)
+            Spacer()
+        }
+        .padding()
+    }
+}
+
+// Avoid - assumes full screen
+struct ProfileCard: View {
+    let user: User
+    
+    var body: some View {
+        VStack {
+            Image(user.avatar)
+                .frame(width: UIScreen.main.bounds.width)  // Wrong!
+            Text(user.name)
+        }
+    }
+}
+```
+
+**Why**: Views should work as full screens, modals, sheets, popovers, or embedded content.
+
+## Own Your Container
+
+**Custom views should own static containers but not lazy/repeatable ones.**
+
+```swift
+// Good - owns static container
+struct HeaderView: View {
+    var body: some View {
+        HStack {
+            Image(systemName: "star")
+            Text("Title")
+            Spacer()
+        }
+    }
+}
+
+// Avoid - missing container
+struct HeaderView: View {
+    var body: some View {
+        Image(systemName: "star")
+        Text("Title")
+        // Caller must wrap in HStack
+    }
+}
+
+// Good - caller owns lazy container
+struct FeedView: View {
+    let items: [Item]
+    
+    var body: some View {
+        LazyVStack {
+            ForEach(items) { item in
+                ItemRow(item: item)
+            }
+        }
+    }
+}
+```
+
+## Layout Performance
+
+### Avoid Layout Thrash
+
+**Minimize deep view hierarchies and excessive layout dependencies.**
+
+```swift
+// Bad - deep nesting, excessive layout passes
+VStack {
+    HStack {
+        VStack {
+            HStack {
+                VStack {
+                    Text("Deep")
+                }
+            }
+        }
+    }
+}
+
+// Good - flatter hierarchy
+VStack {
+    Text("Shallow")
+    Text("Structure")
+}
+```
+
+**Avoid excessive `GeometryReader` and preference chains:**
+
+```swift
+// Bad - multiple geometry readers cause layout thrash
+GeometryReader { outerGeometry in
+    VStack {
+        GeometryReader { innerGeometry in
+            // Layout recalculates multiple times
+        }
+    }
+}
+
+// Good - single geometry reader or use alternatives (iOS 17+)
+containerRelativeFrame(.horizontal) { width, _ in
+    width * 0.8
+}
+```
+
+**Gate frequent geometry updates:**
+
+```swift
+// Bad - updates on every pixel change
+.onPreferenceChange(ViewSizeKey.self) { size in
+    currentSize = size
+}
+
+// Good - gate by threshold
+.onPreferenceChange(ViewSizeKey.self) { size in
+    let difference = abs(size.width - currentSize.width)
+    if difference > 10 {  // Only update if significant change
+        currentSize = size
+    }
+}
+```
+
+## View Logic and Testability
+
+### Keep Business Logic in Services and Models
+
+**Business logic belongs in services and models, not in views.** Views should stay simple and declarative — orchestrating UI state, not implementing business rules. This makes logic independently testable without requiring view instantiation.
+
+> **iOS 17+**: Use `@Observable` with `@State`.
+
+```swift
+@Observable
+final class AuthService {
+    var email = ""
+    var password = ""
+    var isValid: Bool {
+        !email.isEmpty && password.count >= 8
+    }
+
+    func login() async throws {
+        // Business logic here — testable without the view
+    }
+}
+
+struct LoginView: View {
+    @State private var authService = AuthService()
+
+    var body: some View {
+        Form {
+            TextField("Email", text: $authService.email)
+            SecureField("Password", text: $authService.password)
+            Button("Login") {
+                Task {
+                    try? await authService.login()
+                }
+            }
+            .disabled(!authService.isValid)
+        }
+    }
+}
+```
+
+For iOS 16 and earlier, use `ObservableObject` with `@StateObject` -- see `state-management.md` for the legacy pattern.
+
+Avoid embedding business logic directly in view closures (e.g., validation checks inside a `Button` action). This makes logic untestable without view instantiation.
+
+**Note**: This is about making business logic testable, not about enforcing a specific architecture. The key is that logic lives outside views where it can be tested independently.
+
+## Full-Width Views
+
+**When a single view needs to fill the available width, use `.frame(maxWidth: .infinity, alignment:)` instead of wrapping it in a stack with a `Spacer`.**
+
+```swift
+// Good - frame modifier
+Text("Hello")
+    .frame(maxWidth: .infinity, alignment: .leading)
+
+// Avoid - unnecessary stack and spacer
+HStack {
+    Text("Hello")
+    Spacer()
+}
+```
+
+**Why**: `.frame(maxWidth:alignment:)` is a single modifier that clearly communicates intent. Wrapping in an `HStack` with a `Spacer` adds an extra container to the view hierarchy for no benefit.
+
+## Action Handlers
+
+**Separate layout from logic.** View body should reference action methods, not contain inline logic.
+
+```swift
+// Good - action references method
+Button("Publish Project", action: publishService.handlePublish)
+
+// Avoid - multi-line logic in closure
+Button("Publish Project") {
+    isLoading = true
+    apiService.publish(project) { result in /* ... */ }
+}
+```
+
+## Summary Checklist
+
+- [ ] Use relative layout over hard-coded constants
+- [ ] Views work in any context (don't assume screen size)
+- [ ] Custom views own static containers
+- [ ] Avoid deep view hierarchies (layout thrash)
+- [ ] Gate frequent geometry updates by thresholds
+- [ ] Business logic kept in services and models (not in views)
+- [ ] Action handlers reference methods, not inline logic
+- [ ] Use `.frame(maxWidth: .infinity, alignment:)` for full-width views (not `HStack` + `Spacer`)
+- [ ] Avoid excessive `GeometryReader` usage
+- [ ] Use `containerRelativeFrame()` when appropriate

--- a/.agents/skills/swiftui-expert-skill/references/liquid-glass.md
+++ b/.agents/skills/swiftui-expert-skill/references/liquid-glass.md
@@ -1,0 +1,416 @@
+# SwiftUI Liquid Glass Reference (iOS 26+)
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Availability](#availability)
+- [Core APIs](#core-apis)
+- [GlassEffectContainer](#glasseffectcontainer)
+- [Glass Button Styles](#glass-button-styles)
+- [Morphing Transitions](#morphing-transitions)
+- [Modifier Order](#modifier-order)
+- [Complete Examples](#complete-examples)
+- [Fallback Strategies](#fallback-strategies)
+- [Design System Notes](#design-system-notes)
+- [Best Practices](#best-practices)
+- [Checklist](#checklist)
+
+## Overview
+
+Liquid Glass is Apple's new design language introduced in iOS 26. It provides translucent, dynamic surfaces that respond to content and user interaction. This reference covers the native SwiftUI APIs for implementing Liquid Glass effects.
+
+**Only adopt Liquid Glass when explicitly requested by the user.** Do not proactively convert existing UI to glass effects.
+
+## Availability
+
+All Liquid Glass APIs require iOS 26 or later. Always provide fallbacks:
+
+```swift
+if #available(iOS 26, *) {
+    // Liquid Glass implementation
+} else {
+    // Fallback using materials
+}
+```
+
+## Core APIs
+
+### glassEffect Modifier
+
+The primary modifier for applying glass effects to views:
+
+```swift
+.glassEffect(_ style: GlassEffectStyle = .regular, in shape: some Shape = .rect)
+```
+
+#### Basic Usage
+
+```swift
+Text("Hello")
+    .padding()
+    .glassEffect()  // Default regular style, rect shape
+```
+
+#### With Shape
+
+```swift
+Text("Rounded Glass")
+    .padding()
+    .glassEffect(in: .rect(cornerRadius: 16))
+
+Image(systemName: "star")
+    .padding()
+    .glassEffect(in: .circle)
+
+Text("Capsule")
+    .padding(.horizontal, 20)
+    .padding(.vertical, 10)
+    .glassEffect(in: .capsule)
+```
+
+### GlassEffectStyle
+
+#### Prominence Levels
+
+```swift
+.glassEffect(.regular)     // Standard glass appearance
+.glassEffect(.prominent)   // More visible, higher contrast
+```
+
+#### Tinting
+
+Add color tint to the glass:
+
+```swift
+.glassEffect(.regular.tint(.blue))
+.glassEffect(.prominent.tint(.red.opacity(0.3)))
+```
+
+#### Interactivity
+
+Make glass respond to touch/pointer hover:
+
+```swift
+// Interactive glass - responds to user interaction
+.glassEffect(.regular.interactive())
+
+// Combined with tint
+.glassEffect(.regular.tint(.blue).interactive())
+```
+
+**Important**: Only use `.interactive()` on elements that actually respond to user input (buttons, tappable views, focusable elements).
+
+## GlassEffectContainer
+
+Wraps multiple glass elements for proper visual grouping and spacing.
+
+**Glass cannot sample other glass.** The glass material reflects and refracts light by sampling content from an area larger than itself. Nearby glass elements in different containers will produce inconsistent visual results because they cannot sample each other. `GlassEffectContainer` gives grouped elements a shared sampling region, ensuring a consistent appearance.
+
+```swift
+GlassEffectContainer {
+    HStack {
+        Button("One") { }
+            .glassEffect()
+        Button("Two") { }
+            .glassEffect()
+    }
+}
+```
+
+### With Spacing
+
+Control the visual spacing between glass elements:
+
+```swift
+GlassEffectContainer(spacing: 24) {
+    HStack(spacing: 24) {
+        GlassChip(icon: "pencil")
+        GlassChip(icon: "eraser")
+        GlassChip(icon: "trash")
+    }
+}
+```
+
+**Note**: The container's `spacing` parameter should match the actual spacing in your layout for proper glass effect rendering.
+
+> Source: "Build a SwiftUI app with the new design" (WWDC25, session 323)
+
+## Glass Button Styles
+
+Built-in button styles for glass appearance:
+
+```swift
+// Standard glass button
+Button("Action") { }
+    .buttonStyle(.glass)
+
+// Prominent glass button (higher visibility)
+Button("Primary Action") { }
+    .buttonStyle(.glassProminent)
+```
+
+### Custom Glass Buttons
+
+For more control, apply glass effect manually:
+
+```swift
+Button(action: { }) {
+    Label("Settings", systemImage: "gear")
+        .padding()
+}
+.glassEffect(.regular.interactive(), in: .capsule)
+```
+
+## Morphing Transitions
+
+Create smooth transitions between glass elements using `glassEffectID` and `@Namespace`:
+
+```swift
+struct MorphingExample: View {
+    @Namespace private var animation
+    @State private var isExpanded = false
+
+    var body: some View {
+        GlassEffectContainer {
+            if isExpanded {
+                ExpandedCard()
+                    .glassEffect()
+                    .glassEffectID("card", in: animation)
+            } else {
+                CompactCard()
+                    .glassEffect()
+                    .glassEffectID("card", in: animation)
+            }
+        }
+        .animation(.smooth, value: isExpanded)
+    }
+}
+```
+
+### Requirements for Morphing
+
+1. Both views must have the same `glassEffectID`
+2. Use the same `@Namespace`
+3. Wrap in `GlassEffectContainer`
+4. Apply animation to the container or parent
+
+## Modifier Order
+
+**Critical**: Apply `glassEffect` after layout and visual modifiers:
+
+```swift
+// CORRECT order
+Text("Label")
+    .font(.headline)           // 1. Typography
+    .foregroundStyle(.primary) // 2. Color
+    .padding()                 // 3. Layout
+    .glassEffect()             // 4. Glass effect LAST
+
+// WRONG order - glass applied too early
+Text("Label")
+    .glassEffect()             // Wrong position
+    .padding()
+    .font(.headline)
+```
+
+## Complete Examples
+
+### Toolbar with Glass Buttons
+
+```swift
+struct GlassToolbar: View {
+    var body: some View {
+        if #available(iOS 26, *) {
+            GlassEffectContainer(spacing: 16) {
+                HStack(spacing: 16) {
+                    ToolbarButton(icon: "pencil", action: { })
+                    ToolbarButton(icon: "eraser", action: { })
+                    ToolbarButton(icon: "scissors", action: { })
+                    Spacer()
+                    ToolbarButton(icon: "square.and.arrow.up", action: { })
+                }
+                .padding(.horizontal)
+            }
+        } else {
+            // Fallback toolbar
+            HStack(spacing: 16) {
+                // ... fallback implementation
+            }
+        }
+    }
+}
+
+struct ToolbarButton: View {
+    let icon: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .font(.title2)
+                .frame(width: 44, height: 44)
+        }
+        .glassEffect(.regular.interactive(), in: .circle)
+    }
+}
+```
+
+### Card with Glass Effect
+
+```swift
+struct GlassCard: View {
+    let title: String
+    let subtitle: String
+
+    var body: some View {
+        if #available(iOS 26, *) {
+            cardContent
+                .glassEffect(.regular, in: .rect(cornerRadius: 20))
+        } else {
+            cardContent
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 20))
+        }
+    }
+
+    private var cardContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.headline)
+            Text(subtitle)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+```
+
+### Segmented Control
+
+```swift
+struct GlassSegmentedControl: View {
+    @Binding var selection: Int
+    let options: [String]
+    @Namespace private var animation
+
+    var body: some View {
+        if #available(iOS 26, *) {
+            GlassEffectContainer(spacing: 4) {
+                HStack(spacing: 4) {
+                    ForEach(options.indices, id: \.self) { index in
+                        Button(options[index]) {
+                            withAnimation(.smooth) {
+                                selection = index
+                            }
+                        }
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 8)
+                        .glassEffect(
+                            selection == index ? .prominent.interactive() : .regular.interactive(),
+                            in: .capsule
+                        )
+                        .glassEffectID(selection == index ? "selected" : "option\(index)", in: animation)
+                    }
+                }
+                .padding(4)
+            }
+        } else {
+            Picker("Options", selection: $selection) {
+                ForEach(options.indices, id: \.self) { index in
+                    Text(options[index]).tag(index)
+                }
+            }
+            .pickerStyle(.segmented)
+        }
+    }
+}
+```
+
+## Fallback Strategies
+
+### Using Materials
+
+```swift
+if #available(iOS 26, *) {
+    content.glassEffect()
+} else {
+    content.background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16))
+}
+```
+
+### Available Materials for Fallback
+
+- `.ultraThinMaterial` - Closest to glass appearance
+- `.thinMaterial` - Slightly more opaque
+- `.regularMaterial` - Standard blur
+- `.thickMaterial` - More opaque
+- `.ultraThickMaterial` - Most opaque
+
+### Conditional Modifier Extension
+
+```swift
+extension View {
+    @ViewBuilder
+    func glassEffectWithFallback(
+        _ style: GlassEffectStyle = .regular,
+        in shape: some Shape = .rect,
+        fallbackMaterial: Material = .ultraThinMaterial
+    ) -> some View {
+        if #available(iOS 26, *) {
+            self.glassEffect(style, in: shape)
+        } else {
+            self.background(fallbackMaterial, in: shape)
+        }
+    }
+}
+```
+
+## Design System Notes
+
+### Toolbar Icons
+
+In the new design, toolbar icons use **monochrome rendering** by default. The monochrome palette reduces visual noise and maintains legibility. Use `tint(_:)` only to convey meaning (e.g., a call to action), not for visual effect.
+
+### Sheet Presentations
+
+Partial-height sheets use a Liquid Glass background by default. If you previously used `presentationBackground(_:)` with a custom background, consider removing it to let the new material shine. Sheets can morph out of the glass controls that present them using `navigationZoomTransition`.
+
+### Scroll Edge Effects
+
+An automatic scroll edge effect blurs and fades content under system toolbars to keep controls legible. Remove any custom background-darkening effects behind bar items, as they will interfere.
+
+> Source: "Build a SwiftUI app with the new design" (WWDC25, session 323)
+
+## Best Practices
+
+### Do
+
+- Use `GlassEffectContainer` for grouped glass elements (glass cannot sample other glass)
+- Apply glass after layout modifiers
+- Use `.interactive()` only on tappable elements
+- Match container spacing with layout spacing
+- Provide material-based fallbacks for older iOS
+- Keep glass shapes consistent within a feature
+- Remove custom `presentationBackground(_:)` on sheets to use the default glass material
+
+### Don't
+
+- Apply glass to every element (use sparingly)
+- Use `.interactive()` on static content
+- Mix different corner radii arbitrarily
+- Forget iOS version checks
+- Apply glass before padding/frame modifiers
+- Nest `GlassEffectContainer` unnecessarily
+- Add custom darkening backgrounds behind toolbars (conflicts with scroll edge effect)
+
+## Checklist
+
+- [ ] `#available(iOS 26, *)` with fallback
+- [ ] `GlassEffectContainer` wraps grouped elements
+- [ ] `.glassEffect()` applied after layout modifiers
+- [ ] `.interactive()` only on user-interactable elements
+- [ ] `glassEffectID` with `@Namespace` for morphing
+- [ ] Consistent shapes and spacing across feature
+- [ ] Container spacing matches layout spacing
+- [ ] Appropriate prominence levels used

--- a/.agents/skills/swiftui-expert-skill/references/list-patterns.md
+++ b/.agents/skills/swiftui-expert-skill/references/list-patterns.md
@@ -1,0 +1,446 @@
+# SwiftUI List Patterns Reference
+
+## Table of Contents
+
+- [ForEach Identity and Stability](#foreach-identity-and-stability)
+- [Enumerated Sequences](#enumerated-sequences)
+- [List with Custom Styling](#list-with-custom-styling)
+- [List with Pull-to-Refresh](#list-with-pull-to-refresh)
+- [Empty States with ContentUnavailableView (iOS 17+)](#empty-states-with-contentunavailableview-ios-17)
+- [Custom List Backgrounds](#custom-list-backgrounds)
+- [Table](#table)
+- [Summary Checklist](#summary-checklist)
+
+## ForEach Identity and Stability
+
+**Always provide stable identity for `ForEach`.** Never use `.indices` for dynamic content.
+
+```swift
+// Good - stable identity via Identifiable
+extension User: Identifiable {
+    var id: String { userId }
+}
+
+ForEach(users) { user in
+    UserRow(user: user)
+}
+
+// Good - stable identity via keypath
+ForEach(users, id: \.userId) { user in
+    UserRow(user: user)
+}
+
+// Wrong - indices create static content
+ForEach(users.indices, id: \.self) { index in
+    UserRow(user: users[index])  // Can crash on removal!
+}
+
+// Wrong - unstable identity
+ForEach(users, id: \.self) { user in
+    UserRow(user: user)  // Only works if User is Hashable and stable
+}
+```
+
+**Critical**: Ensure **constant number of views per element** in `ForEach`:
+
+```swift
+// Good - consistent view count
+ForEach(items) { item in
+    ItemRow(item: item)
+}
+
+// Bad - variable view count breaks identity
+ForEach(items) { item in
+    if item.isSpecial {
+        SpecialRow(item: item)
+        DetailRow(item: item)
+    } else {
+        RegularRow(item: item)
+    }
+}
+```
+
+**Avoid inline filtering:**
+
+```swift
+// Bad - unstable identity, changes on every update
+ForEach(items.filter { $0.isEnabled }) { item in
+    ItemRow(item: item)
+}
+
+// Good - prefilter and cache
+@State private var enabledItems: [Item] = []
+
+var body: some View {
+    ForEach(enabledItems) { item in
+        ItemRow(item: item)
+    }
+    .onChange(of: items) { _, newItems in
+        enabledItems = newItems.filter { $0.isEnabled }
+    }
+}
+```
+
+**Avoid `AnyView` in list rows:**
+
+```swift
+// Bad - hides identity, increases cost
+ForEach(items) { item in
+    AnyView(item.isSpecial ? SpecialRow(item: item) : RegularRow(item: item))
+}
+
+// Good - Create a unified row view
+ForEach(items) { item in
+    ItemRow(item: item)
+}
+
+struct ItemRow: View {
+    let item: Item
+
+    var body: some View {
+        if item.isSpecial {
+            SpecialRow(item: item)
+        } else {
+            RegularRow(item: item)
+        }
+    }
+}
+```
+
+**Why**: Stable identity is critical for performance and animations. Unstable identity causes excessive diffing, broken animations, and potential crashes.
+
+### Identifiable ID Must Be Truly Unique
+
+Non-unique IDs cause SwiftUI to treat different items as identical, leading to duplicate rendering or missing views:
+
+```swift
+// Bug -- two articles with the same URL show identical content
+struct Article: Identifiable {
+    let title: String
+    let url: URL
+    var id: String { url.absoluteString }  // Not unique if URLs repeat!
+}
+
+// Fix -- use a genuinely unique identifier
+struct Article: Identifiable {
+    let id: UUID
+    let title: String
+    let url: URL
+}
+```
+
+**Classes get a default `ObjectIdentifier`-based `id`** when conforming to `Identifiable` without providing one. This is only unique for the object's lifetime and can be recycled after deallocation.
+
+## Enumerated Sequences
+
+**Always convert enumerated sequences to arrays. To be able to use them in a ForEach.**
+
+```swift
+let items = ["A", "B", "C"]
+
+// Correct
+ForEach(Array(items.enumerated()), id: \.offset) { index, item in
+    Text("\(index): \(item)")
+}
+
+// Wrong - Doesn't compile, enumerated() isn't an array
+ForEach(items.enumerated(), id: \.offset) { index, item in
+    Text("\(index): \(item)")
+}
+```
+
+## List with Custom Styling
+
+```swift
+// Remove default background and separators
+List(items) { item in
+    ItemRow(item: item)
+        .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+        .listRowSeparator(.hidden)
+}
+.listStyle(.plain)
+.scrollContentBackground(.hidden)
+.background(Color.customBackground)
+.environment(\.defaultMinListRowHeight, 1)  // Allows custom row heights
+```
+
+## List with Pull-to-Refresh
+
+```swift
+List(items) { item in
+    ItemRow(item: item)
+}
+.refreshable {
+    await loadItems()
+}
+```
+
+## Empty States with ContentUnavailableView (iOS 17+)
+
+Use `ContentUnavailableView` for empty list/search states. The built-in `.search` variant is auto-localized:
+
+```swift
+List {
+    ForEach(searchResults) { item in
+        ItemRow(item: item)
+    }
+}
+.overlay {
+    if searchResults.isEmpty, !searchText.isEmpty {
+        ContentUnavailableView.search(text: searchText)
+    }
+}
+```
+
+For non-search empty states, use a custom instance:
+
+```swift
+ContentUnavailableView(
+    "No Articles",
+    systemImage: "doc.richtext.fill",
+    description: Text("Articles you save will appear here.")
+)
+```
+
+## Custom List Backgrounds
+
+Use `.scrollContentBackground(.hidden)` to replace the default list background:
+
+```swift
+List(items) { item in
+    ItemRow(item: item)
+}
+.scrollContentBackground(.hidden)
+.background(Color.customBackground)
+```
+
+Without `.scrollContentBackground(.hidden)`, a custom `.background()` has no visible effect on `List`.
+
+## Table
+
+> **Availability:** iOS 16.0+, iPadOS 16.0+, visionOS 1.0+
+
+A multi-column data container that presents rows of `Identifiable` data with sortable, selectable columns. On compact size classes (iPhone, iPad Slide Over), columns after the first are automatically hidden.
+
+### Basic Table
+
+```swift
+struct Person: Identifiable {
+    let givenName: String
+    let familyName: String
+    let emailAddress: String
+    let id = UUID()
+    var fullName: String { givenName + " " + familyName }
+}
+
+struct PeopleTable: View {
+    @State private var people: [Person] = [ /* ... */ ]
+
+    var body: some View {
+        Table(people) {
+            TableColumn("Given Name", value: \.givenName)
+            TableColumn("Family Name", value: \.familyName)
+            TableColumn("E-Mail Address", value: \.emailAddress)
+        }
+    }
+}
+```
+
+### Table with Selection
+
+Bind to a single `ID` for single-selection, or a `Set<ID>` for multi-selection:
+
+```swift
+struct SelectableTable: View {
+    @State private var people: [Person] = [ /* ... */ ]
+    @State private var selectedPeople = Set<Person.ID>()
+
+    var body: some View {
+        Table(people, selection: $selectedPeople) {
+            TableColumn("Given Name", value: \.givenName)
+            TableColumn("Family Name", value: \.familyName)
+            TableColumn("E-Mail Address", value: \.emailAddress)
+        }
+        Text("\(selectedPeople.count) people selected")
+    }
+}
+```
+
+### Sortable Table
+
+Provide a binding to `[KeyPathComparator]` and re-sort the data in `.onChange(of:)`:
+
+```swift
+struct SortableTable: View {
+    @State private var people: [Person] = [ /* ... */ ]
+    @State private var sortOrder = [KeyPathComparator(\Person.givenName)]
+
+    var body: some View {
+        Table(people, sortOrder: $sortOrder) {
+            TableColumn("Given Name", value: \.givenName)
+            TableColumn("Family Name", value: \.familyName)
+            TableColumn("E-Mail Address", value: \.emailAddress)
+        }
+        .onChange(of: sortOrder) { _, newOrder in
+            people.sort(using: newOrder)
+        }
+    }
+}
+```
+
+**Important:** The table does **not** sort data itself — you must re-sort the collection when `sortOrder` changes.
+
+### Adaptive Table for Compact Size Classes
+
+On iPhone or iPad in Slide Over, only the first column is shown. Customize it to display combined information:
+
+```swift
+struct AdaptiveTable: View {
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    private var isCompact: Bool { horizontalSizeClass == .compact }
+
+    @State private var people: [Person] = [ /* ... */ ]
+    @State private var sortOrder = [KeyPathComparator(\Person.givenName)]
+
+    var body: some View {
+        Table(people, sortOrder: $sortOrder) {
+            TableColumn("Given Name", value: \.givenName) { person in
+                VStack(alignment: .leading) {
+                    Text(isCompact ? person.fullName : person.givenName)
+                    if isCompact {
+                        Text(person.emailAddress)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            TableColumn("Family Name", value: \.familyName)
+            TableColumn("E-Mail Address", value: \.emailAddress)
+        }
+        .onChange(of: sortOrder) { _, newOrder in
+            people.sort(using: newOrder)
+        }
+    }
+}
+```
+
+### Table with Static Rows
+
+Use `init(of:columns:rows:)` when rows are known at compile time:
+
+```swift
+struct Purchase: Identifiable {
+    let price: Decimal
+    let id = UUID()
+}
+
+struct TipTable: View {
+    let currencyStyle = Decimal.FormatStyle.Currency(code: "USD")
+
+    var body: some View {
+        Table(of: Purchase.self) {
+            TableColumn("Base price") { purchase in
+                Text(purchase.price, format: currencyStyle)
+            }
+            TableColumn("With 15% tip") { purchase in
+                Text(purchase.price * 1.15, format: currencyStyle)
+            }
+            TableColumn("With 20% tip") { purchase in
+                Text(purchase.price * 1.2, format: currencyStyle)
+            }
+        } rows: {
+            TableRow(Purchase(price: 20))
+            TableRow(Purchase(price: 50))
+            TableRow(Purchase(price: 75))
+        }
+    }
+}
+```
+
+### Table with Dynamic Number of Columns
+
+> **Availability:** iOS 17.4+, iPadOS 17.4+, Mac Catalyst 17.4+, macOS 14.4+, visionOS 1.1+
+
+If the number of columns is not known at runtime use `TableColumnForEach` to create columns based on a `RandomAccessCollection` of some data type. Either the collection’s elements must conform to `Identifiable` or you need to provide an id parameter to the `TableColumnForEach` initializer.
+
+This can be mixed with static compile time known `TableColumn` usage.
+
+```swift
+struct AudioChannel: Identifiable {
+    let name: String
+    let id: UUID
+}
+
+struct AudioSample: Identifiable {
+    let id: UUID
+    let timestamp: TimeInterval
+    func level(channel: AudioChannel.ID) -> Double {
+        1
+    }
+}
+
+@Observable
+class AudioSampleTrack {
+    let channels: [AudioChannel]
+    var samples: [AudioSample]
+}
+
+struct ContentView: View {
+    var track: AudioSampleTrack
+
+    var body: some View {
+        Table(track.samples) {
+            TableColumn("Timestamp (ms)") { sample in
+                Text(sample.timestamp, format: .number.scale(1000))
+                    .monospacedDigit()
+            }
+            TableColumnForEach(track.channels) { channel in
+                TableColumn(channel.name) { sample in
+                    Text(sample.level(channel: channel.id),
+                         format: .number.precision(.fractionLength(2))
+                    )
+                    .monospacedDigit()
+                }
+                .width(ideal: 70)
+                .alignment(.numeric)
+            }
+        }
+    }
+}
+```
+
+### Table Styles
+
+```swift
+// Inset (no borders)
+Table(people) { /* columns */ }
+    .tableStyle(.inset)
+
+// Hide column headers
+Table(people) { /* columns */ }
+    .tableColumnHeaders(.hidden)
+```
+
+### Platform Behavior
+
+| Platform | Behavior |
+|----------|----------|
+| **iPadOS (regular)** | Full multi-column layout; headers and all columns visible |
+| **iPadOS (compact)** | Only the first column shown; headers hidden |
+| **iPhone (all sizes)** | Only the first column shown; headers hidden; list-like appearance |
+
+> **Best Practice:** Prefer handling the compact size class by showing combined info in the first column. This provides a seamless transition when the size class changes (e.g., entering/exiting Slide Over on iPad).
+
+## Summary Checklist
+
+- [ ] ForEach uses stable identity (never `.indices` for dynamic content)
+- [ ] Identifiable IDs are truly unique across all items
+- [ ] Constant number of views per ForEach element
+- [ ] No inline filtering in ForEach (prefilter and cache instead)
+- [ ] No `AnyView` in list rows
+- [ ] Don't convert enumerated sequences to arrays
+- [ ] Use `.refreshable` for pull-to-refresh
+- [ ] Use `ContentUnavailableView` for empty states (iOS 17+)
+- [ ] Use `.scrollContentBackground(.hidden)` for custom list backgrounds
+- [ ] `Table` adapts for compact size classes (first column shows combined info)
+- [ ] `Table` sorting re-sorts data in `.onChange(of: sortOrder)` (table doesn't sort itself)
+- [ ] `Table` data conforms to `Identifiable`

--- a/.agents/skills/swiftui-expert-skill/references/macos-scenes.md
+++ b/.agents/skills/swiftui-expert-skill/references/macos-scenes.md
@@ -1,0 +1,318 @@
+# macOS Scenes Reference
+
+> SwiftUI scene types for macOS apps — `Settings`, `MenuBarExtra`, `WindowGroup`, `Window`, `UtilityWindow`, and `DocumentGroup`. Covers macOS-only scenes and cross-platform scenes with macOS-specific behavior.
+
+## Table of Contents
+
+- [Quick Lookup Table](#quick-lookup-table)
+- [Settings (macOS-only)](#settings-macos-only)
+- [MenuBarExtra (macOS-only)](#menubarextra-macos-only)
+- [WindowGroup (macOS behavior)](#windowgroup-macos-behavior)
+- [Window](#window)
+- [UtilityWindow (macOS-only)](#utilitywindow-macos-only)
+- [DocumentGroup](#documentgroup)
+- [Platform Conditionals](#platform-conditionals)
+- [Best Practices](#best-practices)
+
+---
+
+## Quick Lookup Table
+
+| API | Availability | macOS-Only? | macOS-Specific Behavior |
+|-----|-------------|:-----------:|------------------------|
+| `WindowGroup` | macOS 11.0+ | No | Multiple window instances, tabbed interface, automatic Window menu commands |
+| `Window` | macOS 13.0+ | No | App quits when sole window closes; adds itself to Windows menu |
+| `UtilityWindow` | macOS 15.0+ | Yes | Floating tool palette; receives `FocusedValues` from active main window |
+| `Settings` | macOS 11.0+ | Yes | Presents preferences window (Cmd+,) |
+| `MenuBarExtra` | macOS 13.0+ | Yes | Persistent icon/menu in the system menu bar |
+| `DocumentGroup` | macOS 11.0+ | No | Document-based menu bar commands (File > New/Open/Save); multiple document windows |
+
+---
+
+## Settings (macOS-only)
+
+Presents the app's preferences window, accessible via **Cmd+,** or the app menu. SwiftUI automatically enables the Settings menu item and manages the window lifecycle.
+
+```swift
+Settings {
+    TabView {
+        Tab("General", systemImage: "gear") { GeneralSettingsView() }
+        Tab("Advanced", systemImage: "star") { AdvancedSettingsView() }
+    }
+    .scenePadding()
+    .frame(maxWidth: 350, minHeight: 100)
+}
+```
+
+Use `TabView` with `Tab` items for multi-pane preferences. Each tab's content is typically a `Form` with `@AppStorage`-backed controls.
+
+### SettingsLink (macOS 14.0+)
+
+A button that opens the Settings scene. Use for in-app navigation to preferences.
+
+```swift
+struct SidebarFooter: View {
+    var body: some View {
+        SettingsLink {
+            Label("Preferences", systemImage: "gear")
+        }
+    }
+}
+```
+
+### openSettings environment action (macOS 14.0+)
+
+Programmatically open (or bring to front) the Settings window.
+
+```swift
+struct OpenSettingsButton: View {
+    @Environment(\.openSettings) private var openSettings
+
+    var body: some View {
+        Button("Open Settings") {
+            openSettings()
+        }
+    }
+}
+```
+
+---
+
+## MenuBarExtra (macOS-only)
+
+Renders a persistent control in the system menu bar. Two styles available:
+- **`.menu`** (default) — standard dropdown menu
+- **`.window`** — popover panel with custom SwiftUI views
+
+### Menu-style (dropdown)
+
+```swift
+MenuBarExtra("My Utility", systemImage: "hammer") {
+    Button("Action One") { /* ... */ }
+    Button("Action Two") { /* ... */ }
+    Divider()
+    Button("Quit") { NSApplication.shared.terminate(nil) }
+}
+```
+
+### Window-style (popover panel)
+
+```swift
+MenuBarExtra("Status", systemImage: "chart.bar") {
+    DashboardView()
+        .frame(width: 240)
+}
+.menuBarExtraStyle(.window)
+```
+
+**Variations:**
+- **Toggleable** — pass `isInserted:` with an `@AppStorage` binding to let users show/hide the extra: `MenuBarExtra("Status", systemImage: "chart.bar", isInserted: $showMenuBarExtra)`
+- **Menu-bar-only app** — use `MenuBarExtra` as the sole scene + set `LSUIElement = true` in Info.plist to hide the Dock icon. The app auto-terminates if the user removes the extra from the menu bar.
+
+---
+
+## WindowGroup (macOS behavior)
+
+On macOS, `WindowGroup` supports:
+- **Multiple window instances** — users can open many windows from File > New Window
+- **Tabbed interface** — users can merge windows into tabs
+- **Automatic Window menu** — commands for window management appear automatically
+
+```swift
+@main
+struct Mail: App {
+    var body: some Scene {
+        // Basic multi-window support
+        WindowGroup {
+            MailViewer()
+        }
+
+        // Data-presenting window opened programmatically
+        WindowGroup("Message", for: Message.ID.self) { $messageID in
+            MessageDetail(messageID: messageID)
+        }
+    }
+}
+
+// Open a specific window programmatically
+struct NewMessageButton: View {
+    var message: Message
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        Button("Open Message") {
+            openWindow(value: message.id)
+        }
+    }
+}
+```
+
+> **Key difference from `Window`:** `WindowGroup` keeps the app running even after all windows are closed. `Window` (as sole scene) quits the app when closed.
+
+---
+
+## Window
+
+A single, unique window scene. The system ensures only one instance exists.
+
+```swift
+@main
+struct Mail: App {
+    var body: some Scene {
+        WindowGroup {
+            MailViewer()
+        }
+
+        // Supplementary singleton window
+        Window("Connection Doctor", id: "connection-doctor") {
+            ConnectionDoctor()
+        }
+    }
+}
+
+// Open programmatically — brings to front if already open
+struct OpenDoctorButton: View {
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        Button("Connection Doctor") {
+            openWindow(id: "connection-doctor")
+        }
+    }
+}
+```
+
+### Window as sole scene
+
+If `Window` is the only scene, the app quits when the window closes:
+
+```swift
+@main
+struct VideoCall: App {
+    var body: some Scene {
+        Window("VideoCall", id: "main") {
+            CameraView()
+        }
+    }
+}
+```
+
+> **Recommendation:** In most cases, prefer `WindowGroup` for the primary scene. Use `Window` for supplementary singleton windows.
+
+---
+
+## UtilityWindow (macOS-only)
+
+A specialized floating window for tool palettes and inspector panels. Available since macOS 15.0.
+
+**Key behaviors:**
+- Receives `FocusedValues` from the focused main scene (like menu bar commands)
+- Floats above main windows (default level: `.floating`)
+- Hides when the app is no longer active
+- Only becomes focused when explicitly needed (e.g., clicking the title bar)
+- Dismissible with the Escape key
+- Not minimizable by default
+- Automatically adds a show/hide item to the View menu
+
+```swift
+@main
+struct PhotoBrowser: App {
+    var body: some Scene {
+        WindowGroup {
+            PhotoGallery()
+        }
+
+        UtilityWindow("Photo Info", id: "photo-info") {
+            PhotoInfoViewer()
+        }
+    }
+}
+
+struct PhotoInfoViewer: View {
+    // Automatically updates based on whichever main window is focused
+    @FocusedValue(PhotoSelection.self) private var selectedPhotos
+
+    var body: some View {
+        if let photos = selectedPhotos {
+            Text("\(photos.count) photos selected")
+        } else {
+            Text("No selection")
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+```
+
+> **Tip:** Remove the automatic View menu item with `.commandsRemoved()` and place a `WindowVisibilityToggle` elsewhere in your commands.
+
+---
+
+## DocumentGroup
+
+Document-based apps with automatic file management. On macOS, provides:
+- **Document-based menu bar commands** (File > New, Open, Save, Revert)
+- **Multiple document windows** simultaneously
+- On iOS, shows a document browser instead
+
+```swift
+DocumentGroup(newDocument: TextFile()) { config in
+    ContentView(document: config.$document)
+}
+```
+
+The document type must conform to `FileDocument` (value type) or `ReferenceFileDocument` (reference type). Key requirements:
+
+```swift
+struct TextFile: FileDocument {
+    static var readableContentTypes: [UTType] { [.plainText] }
+    var text: String = ""
+    init() {}
+    init(configuration: ReadConfiguration) throws {
+        text = String(data: configuration.file.regularFileContents ?? Data(), encoding: .utf8) ?? ""
+    }
+    func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
+        FileWrapper(regularFileWithContents: Data(text.utf8))
+    }
+}
+```
+
+For multiple document types, add additional `DocumentGroup` scenes — use `DocumentGroup(viewing:)` for read-only formats.
+
+---
+
+## Platform Conditionals
+
+Always wrap macOS-only scenes in `#if os(macOS)`:
+
+```swift
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+
+        #if os(macOS)
+        Settings {
+            SettingsView()
+        }
+
+        MenuBarExtra("Status", systemImage: "bolt") {
+            StatusMenu()
+        }
+        #endif
+    }
+}
+```
+
+---
+
+## Best Practices
+
+- **Use `Settings`** for preferences — prefer this over a custom preferences window
+- **Use `MenuBarExtra`** for menu bar items — prefer this over managing AppKit's `NSStatusItem` directly
+- **Use `WindowGroup`** as the primary scene — reserve `Window` for supplementary singletons
+- **Use `UtilityWindow`** for inspectors/palettes — it handles floating, focus, and visibility automatically
+- **Use `DocumentGroup`** for document-based apps — it provides the full File menu and document lifecycle
+- **Gate macOS-only scenes** with `#if os(macOS)` for multiplatform projects
+- **Use `openWindow(id:)`** to open windows programmatically — it brings existing windows to front

--- a/.agents/skills/swiftui-expert-skill/references/macos-views.md
+++ b/.agents/skills/swiftui-expert-skill/references/macos-views.md
@@ -1,0 +1,357 @@
+# macOS Views & Components Reference
+
+> macOS-specific SwiftUI views, file operations, drag & drop, and AppKit interop. Covers `HSplitView`, `VSplitView`, `Table`, `PasteButton`, file dialogs, cross-app drag & drop, and `NSViewRepresentable`.
+
+## Table of Contents
+
+- [Quick Lookup Table](#quick-lookup-table)
+- [HSplitView & VSplitView (macOS-only)](#hsplitview--vsplitview-macos-only)
+- [Table](#table)
+- [PasteButton & CopyButton](#pastebutton--copybutton)
+- [File Operations](#file-operations)
+- [Drag, Drop & Pasteboard](#drag-drop--pasteboard)
+- [AppKit Interop](#appkit-interop)
+- [Best Practices](#best-practices)
+
+---
+
+## Quick Lookup Table
+
+### Views
+
+| API | Availability | macOS-Only? | Usage |
+|-----|-------------|:-----------:|-------|
+| `HSplitView` | macOS 10.15+ | Yes | Horizontal resizable split layout with user-draggable dividers |
+| `VSplitView` | macOS 10.15+ | Yes | Vertical resizable split layout with user-draggable dividers |
+| `Table` | macOS 12.0+ | No | Full multi-column layout with sorting; on iOS compact, columns collapse |
+| `PasteButton` | macOS 10.15+ | No | System button that reads clipboard; does NOT auto-validate on macOS |
+| `CopyButton` | macOS 15.0+ | Yes | System button that copies `Transferable` content to clipboard |
+
+### File Operations
+
+| API | Availability | macOS-Only? | Usage |
+|-----|-------------|:-----------:|-------|
+| `fileImporter()` | macOS 11.0+ | No | Native NSOpenPanel with column/list/gallery view, sidebar, tags, QuickLook |
+| `fileExporter()` | macOS 11.0+ | No | Native NSSavePanel with format dropdown, tags field |
+| `fileMover()` | macOS 11.0+ | No | Native macOS move panel with Finder-like navigation |
+| `fileDialogMessage(_:)` | macOS 13.0+ | Yes | Custom message text in file dialogs |
+| `fileDialogConfirmationLabel(_:)` | macOS 13.0+ | Yes | Custom confirm button text in file dialogs |
+| `fileExporterFilenameLabel(_:)` | macOS 13.0+ | Yes | Custom filename field label in file exporter |
+
+### Drag, Drop & Pasteboard
+
+| API | Availability | macOS-Only? | Usage |
+|-----|-------------|:-----------:|-------|
+| `onDrag(_:)` / `draggable(_:)` | macOS 11.0+ | No | Drag image follows cursor; items draggable between apps |
+| `onDrop(of:delegate:)` / `dropDestination(for:action:)` | macOS 11.0+ | No | Accepts drops from any macOS app including Finder |
+
+### AppKit Interop
+
+| API | Availability | macOS-Only? | Usage |
+|-----|-------------|:-----------:|-------|
+| `NSViewRepresentable` | macOS 10.15+ | Yes | Wrap an AppKit `NSView` in SwiftUI |
+| `NSViewControllerRepresentable` | macOS 10.15+ | Yes | Wrap an AppKit `NSViewController` in SwiftUI |
+| `NSHostingController` | macOS 10.15+ | Yes | Host SwiftUI inside an AppKit view controller |
+| `NSHostingView` | macOS 10.15+ | Yes | Host SwiftUI inside an AppKit `NSView` hierarchy |
+
+---
+
+## HSplitView & VSplitView (macOS-only)
+
+Resizable split layouts with user-draggable dividers. Use for IDE-style panes where all panels are equal peers. `VSplitView` works identically but splits vertically (use `minHeight` instead).
+
+```swift
+HSplitView {
+    FileTreeView()
+        .frame(minWidth: 200)
+    CodeEditorView()
+        .frame(minWidth: 400)
+    PreviewPane()
+        .frame(minWidth: 200)
+}
+```
+
+> **When to use which:**
+> - **`NavigationSplitView`** — sidebar-based navigation (sidebar drives content/detail)
+> - **`HSplitView`/`VSplitView`** — IDE-style layouts where all panes are equal peers
+
+---
+
+## Table
+
+For `Table` basics (creation, selection, sorting, adaptive compact layout), see `list-patterns.md`. This section covers macOS-specific table styling.
+
+### Table styles
+
+```swift
+// Bordered with visible grid lines (macOS-only)
+Table(people) { /* columns */ }
+    .tableStyle(.bordered)
+
+// Bordered with alternating row backgrounds
+Table(people) { /* columns */ }
+    .tableStyle(.bordered(alternatesRowBackgrounds: true))
+
+// Inset (no borders)
+Table(people) { /* columns */ }
+    .tableStyle(.inset)
+
+// Hide column headers
+Table(people) { /* columns */ }
+    .tableColumnHeaders(.hidden)
+```
+
+---
+
+## PasteButton & CopyButton
+
+### PasteButton
+
+System button that reads clipboard content via `Transferable`. On macOS, it does NOT auto-validate pasteboard changes (unlike iOS).
+
+```swift
+struct ClipboardView: View {
+    @State private var pastedText = ""
+
+    var body: some View {
+        HStack {
+            PasteButton(payloadType: String.self) { strings in
+                pastedText = strings[0]
+            }
+            Divider()
+            Text(pastedText)
+            Spacer()
+        }
+    }
+}
+```
+
+### CopyButton (macOS 15.0+, macOS-only)
+
+System button that copies `Transferable` content to the clipboard.
+
+```swift
+struct CopyableContent: View {
+    let shareableText = "Hello, world!"
+
+    var body: some View {
+        HStack {
+            Text(shareableText)
+            CopyButton(item: shareableText)
+        }
+    }
+}
+```
+
+---
+
+## File Operations
+
+### fileImporter
+
+On macOS, presents a native `NSOpenPanel` with column/list/gallery view, sidebar favorites, tags, and QuickLook.
+
+```swift
+.fileImporter(
+    isPresented: $showImporter,
+    allowedContentTypes: [.pdf],
+    allowsMultipleSelection: false
+) { result in
+    if case .success(let urls) = result, let url = urls.first {
+        guard url.startAccessingSecurityScopedResource() else { return }
+        defer { url.stopAccessingSecurityScopedResource() }
+        // use url
+    }
+}
+```
+
+> **Important:** Always call `startAccessingSecurityScopedResource()` on returned URLs, and `stopAccessingSecurityScopedResource()` when done. These are security-scoped bookmarks — access fails without this.
+
+### fileExporter
+
+On macOS, presents a native `NSSavePanel` with format dropdown and tags.
+
+```swift
+.fileExporter(
+    isPresented: $showExporter,
+    document: document,
+    contentType: .plainText,
+    defaultFilename: "MyFile.txt"
+) { result in
+    // handle Result<URL, Error>
+}
+```
+
+### File dialog customization (macOS-only)
+
+Customize text in file dialogs with these macOS-specific modifiers:
+
+```swift
+// Custom message and confirm button on file importer
+.fileImporter(
+    isPresented: $showImporter,
+    allowedContentTypes: [.image]
+) { result in
+    // handle result
+}
+.fileDialogMessage("Select an image to use as your profile photo")
+.fileDialogConfirmationLabel("Use This Photo")
+
+// Custom filename label on file exporter
+.fileExporter(
+    isPresented: $showExporter,
+    document: myDocument,
+    contentType: .png
+) { result in
+    // handle result
+}
+.fileExporterFilenameLabel("Export As:")
+```
+
+---
+
+## Drag, Drop & Pasteboard
+
+On macOS, drag and drop works **across applications** (e.g., drag from your app to Finder, Mail, or other apps).
+
+### Modern approach (Transferable)
+
+```swift
+// Drag source
+struct DraggableCard: View {
+    let item: MyItem
+
+    var body: some View {
+        Text(item.title)
+            .draggable(item)  // Requires Transferable conformance
+    }
+}
+
+// Drop target
+struct DropZone: View {
+    @State private var droppedItems: [MyItem] = []
+
+    var body: some View {
+        VStack {
+            ForEach(droppedItems) { item in
+                Text(item.title)
+            }
+        }
+        .dropDestination(for: MyItem.self) { items, location in
+            droppedItems.append(contentsOf: items)
+            return true
+        }
+        .frame(width: 300, height: 200)
+        .border(.secondary)
+    }
+}
+```
+
+### Legacy approach (NSItemProvider)
+
+```swift
+// Drag source
+Image(systemName: "doc")
+    .onDrag {
+        NSItemProvider(object: fileURL as NSURL)
+    }
+
+// Drop target
+Text("Drop files here")
+    .onDrop(of: [.fileURL], isTargeted: nil) { providers in
+        // handle providers
+        return true
+    }
+```
+
+---
+
+## AppKit Interop
+
+### NSViewRepresentable (macOS-only)
+
+Wraps an AppKit `NSView` for use in SwiftUI. Implement `makeNSView(context:)` and `updateNSView(_:context:)`.
+
+```swift
+struct WebView: NSViewRepresentable {
+    let url: URL
+    func makeNSView(context: Context) -> WKWebView { WKWebView() }
+    func updateNSView(_ nsView: WKWebView, context: Context) {
+        nsView.load(URLRequest(url: url))
+    }
+}
+```
+
+### NSViewRepresentable with Coordinator
+
+Use a Coordinator to forward delegate/target-action callbacks to SwiftUI.
+
+```swift
+struct SearchField: NSViewRepresentable {
+    @Binding var text: String
+
+    func makeNSView(context: Context) -> NSSearchField {
+        let field = NSSearchField()
+        field.delegate = context.coordinator
+        return field
+    }
+    func updateNSView(_ nsView: NSSearchField, context: Context) {
+        nsView.stringValue = text
+    }
+    func makeCoordinator() -> Coordinator { Coordinator(text: $text) }
+
+    class Coordinator: NSObject, NSSearchFieldDelegate {
+        var text: Binding<String>
+        init(text: Binding<String>) { self.text = text }
+        func controlTextDidChange(_ obj: Notification) {
+            if let field = obj.object as? NSSearchField {
+                text.wrappedValue = field.stringValue
+            }
+        }
+    }
+}
+```
+
+> **Warning:** Never set `frame`/`bounds` directly on the managed `NSView` — SwiftUI owns the layout.
+
+### NSViewControllerRepresentable (macOS-only)
+
+Wraps an AppKit `NSViewController` for use in SwiftUI.
+
+```swift
+struct MapViewWrapper: NSViewControllerRepresentable {
+    func makeNSViewController(context: Context) -> MapViewController {
+        MapViewController()
+    }
+
+    func updateNSViewController(_ nsViewController: MapViewController, context: Context) {
+        // Update the controller when SwiftUI state changes
+    }
+}
+```
+
+### NSHostingController & NSHostingView (macOS-only)
+
+Host SwiftUI content inside AppKit (reverse direction — AppKit app embedding SwiftUI views).
+
+```swift
+// Host SwiftUI as a view controller
+let hostingController = NSHostingController(rootView: MySwiftUIView())
+window.contentViewController = hostingController
+
+// Host SwiftUI directly as an NSView
+let hostingView = NSHostingView(rootView: MySwiftUIView())
+someNSView.addSubview(hostingView)
+```
+
+---
+
+## Best Practices
+
+- **Use `NavigationSplitView`** for sidebar-driven navigation — reserve `HSplitView`/`VSplitView` for IDE-style equal peer panes
+- **Make `Table` adaptive** — handle compact size classes by showing combined info in the first column
+- **Always call `startAccessingSecurityScopedResource()`** on URLs from `fileImporter` — they are security-scoped
+- **Use `Transferable`** for drag & drop (modern) — fall back to `NSItemProvider` only for legacy compatibility
+- **Use `NSViewRepresentable` with Coordinator** when you need delegate callbacks from AppKit views
+- **Never set `frame`/`bounds`** directly on views managed by `NSViewRepresentable` — SwiftUI owns the layout
+- **Prefer native SwiftUI** over AppKit interop when possible — only use `NSViewRepresentable` for features SwiftUI doesn't provide

--- a/.agents/skills/swiftui-expert-skill/references/macos-window-styling.md
+++ b/.agents/skills/swiftui-expert-skill/references/macos-window-styling.md
@@ -1,0 +1,303 @@
+# macOS Window & Toolbar Styling Reference
+
+> Window configuration, toolbar styles, sizing, positioning, and navigation patterns specific to macOS SwiftUI apps.
+
+## Table of Contents
+
+- [Quick Lookup Table](#quick-lookup-table)
+- [Toolbar Styles](#toolbar-styles)
+- [Window Style](#window-style)
+- [Window Sizing](#window-sizing)
+- [MenuBarExtra Style (macOS-only)](#menubarextra-style-macos-only)
+- [Navigation Layout (macOS behavior)](#navigation-layout-macos-behavior)
+- [Commands & Keyboard](#commands--keyboard)
+- [Best Practices](#best-practices)
+
+---
+
+## Quick Lookup Table
+
+| API | Availability | macOS-Only? | Usage |
+|-----|-------------|:-----------:|-------|
+| `windowToolbarStyle(_:)` | macOS 11.0+ | Yes | Sets toolbar style: `.unified`, `.unifiedCompact`, `.expanded` |
+| `windowStyle(_:)` | macOS 11.0+ | No | Supports `.hiddenTitleBar` for chromeless windows |
+| `windowResizability(_:)` | macOS 13.0+ | No | Controls resize handle and green zoom button behavior |
+| `defaultSize(width:height:)` | macOS 13.0+ | No | Initial frame size when user creates a new window |
+| `defaultPosition(_:)` | macOS 13.0+ | No | Initial window position on screen |
+| `windowIdealPlacement(_:)` | macOS 15.0+ | No | Closure with display geometry for precise window positioning |
+| `menuBarExtraStyle(_:)` | macOS 13.0+ | Yes | Sets MenuBarExtra to `.menu` or `.window` style |
+| `NavigationSplitView` | macOS 13.0+ | No | Columns always visible side-by-side on macOS; translucent sidebar |
+| `Inspector` | macOS 14.0+ | No | Trailing-edge sidebar panel; resizable by dragging |
+
+---
+
+## Toolbar Styles
+
+### windowToolbarStyle (macOS-only)
+
+Controls how the toolbar and title bar are displayed. Applied to a scene.
+
+```swift
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+        // Title bar and toolbar in a single row
+        .windowToolbarStyle(.unified)
+    }
+}
+```
+
+**Available styles:**
+
+| Style | Description |
+|-------|-------------|
+| `.automatic` | System default |
+| `.unified` | Title bar and toolbar in a single combined row |
+| `.unifiedCompact` | Same as unified but with reduced vertical height |
+| `.expanded` | Title bar displayed above the toolbar (more toolbar space) |
+
+```swift
+// Unified compact — minimal chrome
+.windowToolbarStyle(.unifiedCompact)
+
+// Expanded — title bar above toolbar
+.windowToolbarStyle(.expanded)
+
+// Unified with title hidden
+.windowToolbarStyle(.unified(showsTitle: false))
+```
+
+### Toolbar content
+
+```swift
+struct ContentView: View {
+    @State private var searchText = ""
+
+    var body: some View {
+        NavigationSplitView {
+            SidebarView()
+        } detail: {
+            DetailView()
+        }
+        .toolbar {
+            ToolbarItem(placement: .automatic) {
+                Button(action: addItem) {
+                    Label("Add", systemImage: "plus")
+                }
+            }
+        }
+        .searchable(text: $searchText, placement: .sidebar)
+    }
+}
+```
+
+---
+
+## Window Style
+
+### windowStyle
+
+Set the visual style of a window. Use `.hiddenTitleBar` for chromeless, immersive windows.
+
+```swift
+// Standard title bar (default)
+WindowGroup {
+    ContentView()
+}
+.windowStyle(.titleBar)
+
+// Hidden title bar — chromeless window
+WindowGroup {
+    ContentView()
+}
+.windowStyle(.hiddenTitleBar)
+```
+
+> **Use case:** `.hiddenTitleBar` is useful for media players, custom-chrome apps, or immersive experiences where the standard title bar is unwanted.
+
+---
+
+## Window Sizing
+
+### windowResizability, defaultSize, defaultPosition
+
+These modifiers work together to configure window sizing and placement:
+
+```swift
+WindowGroup {
+    ContentView()
+        .frame(minWidth: 600, minHeight: 400)
+}
+.defaultSize(width: 900, height: 600)
+.defaultPosition(.center)
+.windowResizability(.contentMinSize)
+```
+
+**`windowResizability` options:**
+
+| Value | Behavior |
+|-------|----------|
+| `.automatic` | System decides resize behavior |
+| `.contentSize` | Fixed to content size; no user resize; zoom button disabled |
+| `.contentMinSize` | Resizable with minimum based on content's `minWidth`/`minHeight` |
+
+**`defaultPosition` options:** `.center`, `.topLeading`, `.top`, `.topTrailing`, `.leading`, `.trailing`, `.bottomLeading`, `.bottom`, `.bottomTrailing`
+
+**Guidelines:**
+- Set `minWidth`/`minHeight` via `.frame()` on content, enforce with `.contentMinSize`
+- Use `.defaultSize()` for initial dimensions (larger than minimums)
+- `defaultSize` also accepts `CGSize`
+
+### windowIdealPlacement (macOS 15.0+)
+
+For precise programmatic positioning, use a closure with display geometry:
+
+```swift
+.windowIdealPlacement { context in
+    let screen = context.defaultDisplay.visibleArea
+    return WindowPlacement(x: screen.midX, y: screen.midY,
+                           width: screen.width / 2, height: screen.height)
+}
+```
+
+---
+
+## MenuBarExtra Style (macOS-only)
+
+Choose between dropdown menu and popover panel for `MenuBarExtra`.
+
+```swift
+// Dropdown menu (default)
+MenuBarExtra("Status", systemImage: "chart.bar") {
+    Button("Action") { /* ... */ }
+}
+.menuBarExtraStyle(.menu)
+
+// Popover panel with custom SwiftUI content
+MenuBarExtra("Status", systemImage: "chart.bar") {
+    DashboardView()
+}
+.menuBarExtraStyle(.window)
+```
+
+---
+
+## Navigation Layout (macOS behavior)
+
+### NavigationSplitView
+
+On macOS, `NavigationSplitView` displays columns side-by-side (never overlaid). The sidebar gets a translucent material background. Columns support variable-width resizing by the user.
+
+```swift
+NavigationSplitView {
+    List(items, selection: $selectedId) { item in
+        Text(item.name)
+    }
+    .navigationSplitViewColumnWidth(min: 180, ideal: 220, max: 300)
+} detail: {
+    DetailView(id: selectedId)
+}
+.navigationSplitViewStyle(.balanced)
+```
+
+Use the three-column variant (`sidebar` / `content` / `detail`) for master-detail-detail layouts. Customize column widths with `.navigationSplitViewColumnWidth(min:ideal:max:)`.
+
+### Inspector (macOS 14.0+)
+
+A trailing-edge panel for supplementary information. On macOS, it appears as a sidebar-style panel that can be resized by dragging its edge.
+
+```swift
+struct ContentView: View {
+    @State private var showInspector = false
+
+    var body: some View {
+        MainContent()
+            .inspector(isPresented: $showInspector) {
+                InspectorView()
+                    .inspectorColumnWidth(min: 200, ideal: 250, max: 400)
+            }
+            .toolbar {
+                ToolbarItem {
+                    Button {
+                        showInspector.toggle()
+                    } label: {
+                        Label("Inspector", systemImage: "info.circle")
+                    }
+                }
+            }
+    }
+}
+```
+
+---
+
+## Commands & Keyboard
+
+### Commands, CommandGroup, CommandMenu
+
+Define menu bar commands. On macOS, these populate the menu bar directly. On iOS, they create key commands.
+
+```swift
+.commands {
+    CommandMenu("Tools") {
+        Button("Run Analysis") { /* ... */ }
+            .keyboardShortcut("r", modifiers: [.command, .shift])
+    }
+    CommandGroup(after: .newItem) {
+        Button("New From Template...") { /* ... */ }
+    }
+}
+```
+
+**`CommandGroup` placement options:** `.replacing(_:)` replaces a system group, `.before(_:)` / `.after(_:)` inserts adjacent to it. Common placements: `.newItem`, `.saveItem`, `.help`, `.toolbar`, `.sidebar`.
+
+### KeyboardShortcut
+
+On macOS, shortcuts are displayed alongside menu items and in button tooltips on hover.
+
+```swift
+Button("Save") {
+    save()
+}
+.keyboardShortcut("s", modifiers: .command)
+
+Button("Delete") {
+    delete()
+}
+.keyboardShortcut(.delete, modifiers: .command)
+```
+
+### openWindow
+
+Programmatically open a window. If the target window is already open, brings it to the front.
+
+```swift
+struct ToolbarActions: View {
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        Button("Connection Doctor") {
+            openWindow(id: "connection-doctor")
+        }
+
+        Button("Show Message") {
+            openWindow(value: message.id)  // Type-matched to WindowGroup
+        }
+    }
+}
+```
+
+---
+
+## Best Practices
+
+- **Use `.unified` or `.unifiedCompact`** for most apps — `.expanded` only when you need many toolbar items
+- **Set min frame sizes on content** and use `.windowResizability(.contentMinSize)` to enforce them
+- **Always provide `defaultSize`** so new windows start at a reasonable size
+- **Use `NavigationSplitView`** for sidebar navigation — not `HSplitView`
+- **Use `Inspector`** for supplementary panels — it integrates with the toolbar automatically
+- **Define `Commands`** for all repeatable actions — users expect keyboard shortcuts on macOS
+- **Use `#if os(macOS)`** to wrap macOS-only window configuration in multiplatform projects

--- a/.agents/skills/swiftui-expert-skill/references/performance-patterns.md
+++ b/.agents/skills/swiftui-expert-skill/references/performance-patterns.md
@@ -1,0 +1,403 @@
+# SwiftUI Performance Patterns Reference
+
+## Table of Contents
+
+- [Performance Optimization](#performance-optimization)
+- [Anti-Patterns](#anti-patterns)
+- [Summary Checklist](#summary-checklist)
+
+## Performance Optimization
+
+### 1. Avoid Redundant State Updates
+
+SwiftUI doesn't compare values before triggering updates:
+
+```swift
+// BAD - triggers update even if value unchanged
+.onReceive(publisher) { value in
+    self.currentValue = value  // Always triggers body re-evaluation
+}
+
+// GOOD - only update when different
+.onReceive(publisher) { value in
+    if self.currentValue != value {
+        self.currentValue = value
+    }
+}
+```
+
+### 2. Optimize Hot Paths
+
+Hot paths are frequently executed code (scroll handlers, animations, gestures):
+
+```swift
+// BAD - updates state on every scroll position change
+.onPreferenceChange(ScrollOffsetKey.self) { offset in
+    shouldShowTitle = offset.y <= -32  // Fires constantly during scroll!
+}
+
+// GOOD - only update when threshold crossed
+.onPreferenceChange(ScrollOffsetKey.self) { offset in
+    let shouldShow = offset.y <= -32
+    if shouldShow != shouldShowTitle {
+        shouldShowTitle = shouldShow  // Fires only when crossing threshold
+    }
+}
+```
+
+### 3. Pass Only What Views Need
+
+**Avoid passing large "config" or "context" objects.** Pass only the specific values each view needs.
+
+```swift
+// Good - pass specific values
+ThemeSelector(theme: config.theme)
+FontSizeSlider(fontSize: config.fontSize)
+
+// Avoid - passing entire config (creates broad dependency)
+ThemeSelector(config: config)  // Notified of ALL config changes
+```
+
+With `ObservableObject`, any `@Published` change triggers all observers. With `@Observable`, views update only when accessed properties change, but passing entire objects still creates broader dependencies than necessary.
+
+### 4. Use Equatable Views
+
+For views with expensive bodies, conform to `Equatable`:
+
+```swift
+struct ExpensiveView: View, Equatable {
+    let data: SomeData
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.data.id == rhs.data.id  // Custom equality check
+    }
+
+    var body: some View {
+        // Expensive computation
+    }
+}
+
+// Usage
+ExpensiveView(data: data)
+    .equatable()  // Use custom equality
+```
+
+**Caution**: If you add new state or dependencies to your view, remember to update your `==` function!
+
+### 5. POD Views for Fast Diffing
+
+**POD (Plain Old Data) views use `memcmp` for fastest diffing.** A view is POD if it only contains simple value types and no property wrappers.
+
+```swift
+// POD view - fastest diffing
+struct FastView: View {
+    let title: String
+    let count: Int
+    
+    var body: some View {
+        Text("\(title): \(count)")
+    }
+}
+
+// Non-POD view - uses reflection or custom equality
+struct SlowerView: View {
+    let title: String
+    @State private var isExpanded = false  // Property wrapper makes it non-POD
+    
+    var body: some View {
+        Text(title)
+    }
+}
+```
+
+**Advanced Pattern**: Wrap expensive non-POD views in POD parent views:
+
+```swift
+// POD wrapper for fast diffing
+struct ExpensiveView: View {
+    let value: Int
+    
+    var body: some View {
+        ExpensiveViewInternal(value: value)
+    }
+}
+
+// Internal view with state
+private struct ExpensiveViewInternal: View {
+    let value: Int
+    @State private var item: Item?
+    
+    var body: some View {
+        // Expensive rendering
+    }
+}
+```
+
+**Why**: The POD parent uses fast `memcmp` comparison. Only when `value` changes does the internal view get diffed.
+
+### 6. Lazy Loading
+
+Use lazy containers for large collections:
+
+```swift
+// BAD - creates all views immediately
+ScrollView {
+    VStack {
+        ForEach(items) { item in
+            ExpensiveRow(item: item)
+        }
+    }
+}
+
+// GOOD - creates views on demand
+ScrollView {
+    LazyVStack {
+        ForEach(items) { item in
+            ExpensiveRow(item: item)
+        }
+    }
+}
+```
+
+**iOS 26+ note**: Nested scroll views containing lazy stacks now automatically defer loading their children until they are about to appear, matching the behavior of top-level lazy stacks. This benefits patterns like horizontal photo carousels inside a vertical scroll view.
+
+> Source: "What's new in SwiftUI" (WWDC25, session 256)
+
+### 7. Task Cancellation
+
+Cancel async work when view disappears:
+
+```swift
+struct DataView: View {
+    @State private var data: [Item] = []
+
+    var body: some View {
+        List(data) { item in
+            Text(item.name)
+        }
+        .task {
+            // Automatically cancelled when view disappears
+            data = await fetchData()
+        }
+    }
+}
+```
+
+### 8. Debug View Updates
+
+**Use `Self._printChanges()` or `Self._logChanges()` to debug unexpected view updates.**
+
+```swift
+struct DebugView: View {
+    @State private var count = 0
+    @State private var name = ""
+    
+    var body: some View {
+        #if DEBUG
+        let _ = Self._logChanges()  // Xcode 15.1+: logs to com.apple.SwiftUI subsystem
+        #endif
+        
+        VStack {
+            Text("Count: \(count)")
+            Text("Name: \(name)")
+        }
+    }
+}
+```
+
+- `Self._printChanges()`: Prints which properties changed to standard output.
+- `Self._logChanges()` (iOS 17+): Logs to the `com.apple.SwiftUI` subsystem with category "Changed Body Properties", using `os_log` for structured output.
+
+Both print `@self` when the view value itself changed and `@identity` when the view's persistent data was recycled.
+
+**Why**: This helps identify which state changes are causing view updates. Isolating redraw triggers into single-responsibility subviews is often the fix -- extracting a subview means SwiftUI can skip its body when its inputs haven't changed.
+
+### 9. Eliminate Unnecessary Dependencies
+
+**Narrow state scope to reduce update fan-out.** Instead of passing an entire `@Observable` model to a row view (which creates a dependency on all accessed properties), pass only the specific values the view needs as `let` properties.
+
+```swift
+// Bad - broad dependency on entire model
+struct ItemRow: View {
+    @Environment(AppModel.self) private var model
+    let item: Item
+    var body: some View { Text(item.name).foregroundStyle(model.theme.primaryColor) }
+}
+
+// Good - narrow dependency
+struct ItemRow: View {
+    let item: Item
+    let themeColor: Color
+    var body: some View { Text(item.name).foregroundStyle(themeColor) }
+}
+```
+
+**Avoid storing frequently-changing values in the environment.** Even when a view doesn't read the changed key, SwiftUI still checks all environment readers. This cost adds up with many views and frequent updates (geometry values, timers).
+
+> Source: "Optimize SwiftUI performance with Instruments" (WWDC25, session 306)
+
+### 10. @Observable Dependency Granularity
+
+**Consider per-item `@Observable` state holders (one per row/item) to narrow update scope.** When multiple list items share a dependency on the same `@Observable` array, changing one element causes all items to re-evaluate their bodies.
+
+```swift
+// BAD - all item views depend on the full favorites array
+@Observable
+class ModelData {
+    var favorites: [Landmark] = []
+
+    func isFavorite(_ landmark: Landmark) -> Bool {
+        favorites.contains(landmark)
+    }
+}
+
+struct LandmarkRow: View {
+    let landmark: Landmark
+    @Environment(ModelData.self) private var model
+
+    var body: some View {
+        HStack {
+            Text(landmark.name)
+            if model.isFavorite(landmark) {
+                Image(systemName: "heart.fill")
+            }
+        }
+    }
+}
+
+// GOOD - each item has its own observable view model
+@Observable
+class LandmarkViewModel {
+    var isFavorite: Bool = false
+}
+
+struct LandmarkRow: View {
+    let landmark: Landmark
+    let viewModel: LandmarkViewModel
+
+    var body: some View {
+        HStack {
+            Text(landmark.name)
+            if viewModel.isFavorite {
+                Image(systemName: "heart.fill")
+            }
+        }
+    }
+}
+```
+
+**Why**: With the bad pattern, toggling one favorite marks the entire array as changed, causing every `LandmarkRow` to re-run its body. With per-item view models, only the toggled item's body runs.
+
+> Source: "Optimize SwiftUI performance with Instruments" (WWDC25, session 306)
+
+### 11. Off-Main-Thread Closures
+
+**SwiftUI may call certain closures on a background thread for performance.** These closures must be `Sendable` and should avoid accessing `@MainActor`-isolated state directly. Instead, capture needed values in the closure's capture list.
+
+Closures that may run off the main thread:
+- `Shape.path(in:)`
+- `visualEffect` closure
+- `Layout` protocol methods
+- `onGeometryChange` transform closure
+
+```swift
+// BAD - accessing @MainActor state directly
+.visualEffect { content, geometry in
+    content.blur(radius: self.pulse ? 5 : 0)  // Compiler error: @MainActor isolated
+}
+
+// GOOD - capture the value
+.visualEffect { [pulse] content, geometry in
+    content.blur(radius: pulse ? 5 : 0)
+}
+```
+
+> Source: "Explore concurrency in SwiftUI" (WWDC25, session 266)
+
+### 12. Common Performance Issues
+
+**Be aware of common performance bottlenecks in SwiftUI:**
+
+- View invalidation storms from broad state changes
+- Unstable identity in lists causing excessive diffing
+- Heavy work in `body` (formatting, sorting, image decoding)
+- Layout thrash from deep stacks or preference chains
+
+**When performance issues arise**, suggest the user profile with Instruments (SwiftUI template) to identify specific bottlenecks.
+
+## Anti-Patterns
+
+### 1. Creating Objects in Body
+
+```swift
+// BAD - creates new formatter every body call
+var body: some View {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .long
+    return Text(formatter.string(from: date))
+}
+
+// GOOD - static or stored formatter
+private static let dateFormatter: DateFormatter = {
+    let f = DateFormatter()
+    f.dateStyle = .long
+    return f
+}()
+
+var body: some View {
+    Text(Self.dateFormatter.string(from: date))
+}
+```
+
+### 2. Heavy Computation in Body
+
+**Keep view body simple and pure.** Avoid side effects, dispatching, or complex logic.
+
+```swift
+// BAD - sorts array every body call
+var body: some View {
+    List(items.sorted { $0.name < $1.name }) { item in Text(item.name) }
+}
+
+// GOOD - compute once, update via onChange or a computed property in the model
+@State private var sortedItems: [Item] = []
+
+var body: some View {
+    List(sortedItems) { item in Text(item.name) }
+        .onChange(of: items) { _, newItems in
+            sortedItems = newItems.sorted { $0.name < $1.name }
+        }
+}
+```
+
+Move sorting, filtering, and formatting into models or computed properties. The `body` should be a pure structural representation of state.
+
+### 3. Unnecessary State
+
+```swift
+// BAD - derived state stored separately
+@State private var items: [Item] = []
+@State private var itemCount: Int = 0  // Unnecessary!
+
+// GOOD - compute derived values
+@State private var items: [Item] = []
+
+var itemCount: Int { items.count }  // Computed property
+```
+
+## Summary Checklist
+
+- [ ] State updates check for value changes before assigning
+- [ ] Hot paths minimize state updates
+- [ ] Pass only needed values to views (avoid large config objects)
+- [ ] Large lists use `LazyVStack`/`LazyHStack`
+- [ ] No object creation in `body`
+- [ ] Heavy computation moved out of `body`
+- [ ] Body kept simple and pure (no side effects)
+- [ ] Derived state computed, not stored
+- [ ] Use `Self._logChanges()` or `Self._printChanges()` to debug unexpected updates
+- [ ] Equatable conformance for expensive views (when appropriate)
+- [ ] Consider POD view wrappers for advanced optimization
+- [ ] Consider using granular @Observable dependencies for list items (smaller observable units per row when it measurably reduces updates)
+- [ ] Frequently-changing values not stored in the environment
+- [ ] Sendable closures (Shape, visualEffect, Layout) capture values instead of accessing @MainActor state

--- a/.agents/skills/swiftui-expert-skill/references/scroll-patterns.md
+++ b/.agents/skills/swiftui-expert-skill/references/scroll-patterns.md
@@ -1,0 +1,293 @@
+# SwiftUI ScrollView Patterns Reference
+
+## Table of Contents
+
+- [ScrollViewReader for Programmatic Scrolling](#scrollviewreader-for-programmatic-scrolling)
+- [Scroll Position Tracking](#scroll-position-tracking)
+- [Scroll Transitions and Effects](#scroll-transitions-and-effects)
+- [Scroll Target Behavior](#scroll-target-behavior)
+- [Summary Checklist](#summary-checklist)
+
+## ScrollViewReader for Programmatic Scrolling
+
+**Use `ScrollViewReader` for scroll-to-top, scroll-to-bottom, and anchor-based jumps.**
+
+```swift
+struct ChatView: View {
+    @State private var messages: [Message] = []
+    private let bottomID = "bottom"
+    
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack {
+                    ForEach(messages) { message in
+                        MessageRow(message: message)
+                            .id(message.id)
+                    }
+                    Color.clear
+                        .frame(height: 1)
+                        .id(bottomID)
+                }
+            }
+            .onChange(of: messages.count) { _, _ in
+                withAnimation {
+                    proxy.scrollTo(bottomID, anchor: .bottom)
+                }
+            }
+            .onAppear {
+                proxy.scrollTo(bottomID, anchor: .bottom)
+            }
+        }
+    }
+}
+```
+
+### Scroll-to-Top Pattern
+
+```swift
+struct FeedView: View {
+    @State private var items: [Item] = []
+    @State private var scrollToTop = false
+    private let topID = "top"
+    
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack {
+                    Color.clear
+                        .frame(height: 1)
+                        .id(topID)
+                    
+                    ForEach(items) { item in
+                        ItemRow(item: item)
+                    }
+                }
+            }
+            .onChange(of: scrollToTop) { _, shouldScroll in
+                if shouldScroll {
+                    withAnimation {
+                        proxy.scrollTo(topID, anchor: .top)
+                    }
+                    scrollToTop = false
+                }
+            }
+        }
+    }
+}
+```
+
+**Why**: `ScrollViewReader` provides programmatic scroll control with stable anchors. Always use stable IDs and explicit animations.
+
+## Scroll Position Tracking
+
+### Basic Scroll Position
+
+**Avoid** - Storing scroll position directly triggers view updates on every scroll frame:
+
+```swift
+// ❌ Bad Practice - causes unnecessary re-renders
+struct ContentView: View {
+    @State private var scrollPosition: CGFloat = 0
+
+    var body: some View {
+        ScrollView {
+            content
+                .background(
+                    GeometryReader { geometry in
+                        Color.clear
+                            .preference(
+                                key: ScrollOffsetPreferenceKey.self,
+                                value: geometry.frame(in: .named("scroll")).minY
+                            )
+                    }
+                )
+        }
+        .coordinateSpace(name: "scroll")
+        .onPreferenceChange(ScrollOffsetPreferenceKey.self) { value in
+            scrollPosition = value
+        }
+    }
+}
+```
+
+**Preferred** - Check scroll position and update a flag based on thresholds for smoother, more efficient scrolling:
+
+```swift
+// ✅ Good Practice - only updates state when crossing threshold
+struct ContentView: View {
+    @State private var startAnimation: Bool = false
+
+    var body: some View {
+        ScrollView {
+            content
+                .background(
+                    GeometryReader { geometry in
+                        Color.clear
+                            .preference(
+                                key: ScrollOffsetPreferenceKey.self,
+                                value: geometry.frame(in: .named("scroll")).minY
+                            )
+                    }
+                )
+        }
+        .coordinateSpace(name: "scroll")
+        .onPreferenceChange(ScrollOffsetPreferenceKey.self) { value in
+            if value < -100 {
+                startAnimation = true
+            } else {
+                startAnimation = false
+            }
+        }
+    }
+}
+
+struct ScrollOffsetPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
+```
+
+### Scroll-Based Header Visibility
+
+```swift
+struct ContentView: View {
+    @State private var showHeader = true
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            if showHeader {
+                HeaderView()
+                    .transition(.move(edge: .top))
+            }
+            
+            ScrollView {
+                content
+                    .background(
+                        GeometryReader { geometry in
+                            Color.clear
+                                .preference(
+                                    key: ScrollOffsetPreferenceKey.self,
+                                    value: geometry.frame(in: .named("scroll")).minY
+                                )
+                        }
+                    )
+            }
+            .coordinateSpace(name: "scroll")
+            .onPreferenceChange(ScrollOffsetPreferenceKey.self) { offset in
+                if offset < -50 { // Scrolling down
+                   withAnimation { showHeader = false }
+                } else if offset > 50 { // Scrolling up
+                  withAnimation { showHeader = true }
+                }
+            }
+        }
+    }
+}
+```
+
+## Scroll Transitions and Effects
+
+> **iOS 17+**: All APIs in this section require iOS 17 or later.
+
+### Scroll-Based Opacity
+
+```swift
+struct ParallaxView: View {
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 20) {
+                ForEach(items) { item in
+                    ItemCard(item: item)
+                        .visualEffect { content, geometry in
+                            let frame = geometry.frame(in: .scrollView)
+                            let distance = min(0, frame.minY)
+                            return content
+                                .opacity(1 + distance / 200)
+                        }
+                }
+            }
+        }
+    }
+}
+```
+
+### Parallax Effect
+
+```swift
+struct ParallaxHeader: View {
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                Image("hero")
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(height: 300)
+                    .visualEffect { content, geometry in
+                        let offset = geometry.frame(in: .scrollView).minY
+                        return content
+                            .offset(y: offset > 0 ? -offset * 0.5 : 0)
+                    }
+                    .clipped()
+                
+                ContentView()
+            }
+        }
+    }
+}
+```
+
+## Scroll Target Behavior
+
+> **iOS 17+**: All APIs in this section require iOS 17 or later.
+
+### Paging ScrollView
+
+```swift
+struct PagingView: View {
+    var body: some View {
+        ScrollView(.horizontal) {
+            LazyHStack(spacing: 0) {
+                ForEach(pages) { page in
+                    PageView(page: page)
+                        .containerRelativeFrame(.horizontal)
+                }
+            }
+            .scrollTargetLayout()
+        }
+        .scrollTargetBehavior(.paging)
+    }
+}
+```
+
+### Snap to Items
+
+```swift
+struct SnapScrollView: View {
+    var body: some View {
+        ScrollView(.horizontal) {
+            LazyHStack(spacing: 16) {
+                ForEach(items) { item in
+                    ItemCard(item: item)
+                        .frame(width: 280)
+                }
+            }
+            .scrollTargetLayout()
+        }
+        .scrollTargetBehavior(.viewAligned)
+        .contentMargins(.horizontal, 20)
+    }
+}
+```
+
+## Summary Checklist
+
+- [ ] Use `ScrollViewReader` with stable IDs for programmatic scrolling
+- [ ] Always use explicit animations with `scrollTo()`
+- [ ] Use `.visualEffect` for scroll-based visual changes
+- [ ] Use `.scrollTargetBehavior(.paging)` for paging behavior
+- [ ] Use `.scrollTargetBehavior(.viewAligned)` for snap-to-item behavior
+- [ ] Gate frequent scroll position updates by thresholds
+- [ ] Use preference keys for custom scroll position tracking

--- a/.agents/skills/swiftui-expert-skill/references/sheet-navigation-patterns.md
+++ b/.agents/skills/swiftui-expert-skill/references/sheet-navigation-patterns.md
@@ -1,0 +1,363 @@
+# SwiftUI Sheet, Navigation & Inspector Patterns Reference
+
+## Table of Contents
+
+- [Sheet Patterns](#sheet-patterns)
+- [Navigation Patterns](#navigation-patterns)
+- [Multi-Column Navigation with NavigationSplitView](#multi-column-navigation-with-navigationsplitview)
+- [Inspector](#inspector)
+- [Presentation Modifiers](#presentation-modifiers)
+- [Summary Checklist](#summary-checklist)
+
+## Sheet Patterns
+
+### Item-Driven Sheets (Preferred)
+
+**Use `.sheet(item:)` instead of `.sheet(isPresented:)` when presenting model-based content.**
+
+```swift
+// Good - item-driven
+@State private var selectedItem: Item?
+
+var body: some View {
+    List(items) { item in
+        Button(item.name) {
+            selectedItem = item
+        }
+    }
+    .sheet(item: $selectedItem) { item in
+        ItemDetailSheet(item: item)
+    }
+}
+
+// Avoid - boolean flag requires separate state
+@State private var showSheet = false
+@State private var selectedItem: Item?
+
+var body: some View {
+    List(items) { item in
+        Button(item.name) {
+            selectedItem = item
+            showSheet = true
+        }
+    }
+    .sheet(isPresented: $showSheet) {
+        if let selectedItem {
+            ItemDetailSheet(item: selectedItem)
+        }
+    }
+}
+```
+
+**Why**: `.sheet(item:)` automatically handles presentation state and avoids optional unwrapping in the sheet body.
+
+### Sheets Own Their Actions
+
+**Sheets should handle their own dismiss and actions internally** using `@Environment(\.dismiss)`. Avoid passing `onSave`/`onCancel` closures from the parent -- it creates callback prop-drilling and reduces reusability.
+
+```swift
+struct EditItemSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    let item: Item
+    @State private var name: String
+
+    init(item: Item) {
+        self.item = item
+        _name = State(initialValue: item.name)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form { TextField("Name", text: $name) }
+                .navigationTitle("Edit Item")
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
+                    ToolbarItem(placement: .confirmationAction) { Button("Save") { /* save and dismiss */ } }
+                }
+        }
+    }
+}
+```
+
+### Enum-Based Sheet Management
+
+When presenting multiple different sheets, use an `Identifiable` enum with `.sheet(item:)` instead of multiple boolean state properties:
+
+```swift
+struct ArticlesView: View {
+    enum Sheet: Identifiable {
+        case add, edit(Article), categories
+        var id: String {
+            switch self {
+            case .add: "add"
+            case .edit(let a): "edit-\(a.id)"
+            case .categories: "categories"
+            }
+        }
+    }
+
+    @State private var presentedSheet: Sheet?
+
+    var body: some View {
+        List { /* ... */ }
+            .toolbar {
+                Button("Add") { presentedSheet = .add }
+            }
+            .sheet(item: $presentedSheet) { sheet in
+                switch sheet {
+                case .add: AddArticleView()
+                case .edit(let article): EditArticleView(article: article)
+                case .categories: CategoriesView()
+                }
+            }
+    }
+}
+```
+
+**Why**: A single `@State` property and one `.sheet(item:)` modifier replaces N boolean properties and N sheet modifiers, improving readability and preventing only-one-sheet-at-a-time conflicts.
+
+## Navigation Patterns
+
+### Type-Safe Navigation with NavigationStack
+
+```swift
+struct ContentView: View {
+    var body: some View {
+        NavigationStack {
+            List {
+                NavigationLink("Profile", value: Route.profile)
+                NavigationLink("Settings", value: Route.settings)
+            }
+            .navigationDestination(for: Route.self) { route in
+                switch route {
+                case .profile:
+                    ProfileView()
+                case .settings:
+                    SettingsView()
+                }
+            }
+        }
+    }
+}
+
+enum Route: Hashable {
+    case profile
+    case settings
+}
+```
+
+### Programmatic Navigation
+
+```swift
+struct ContentView: View {
+    @State private var navigationPath = NavigationPath()
+    
+    var body: some View {
+        NavigationStack(path: $navigationPath) {
+            List {
+                Button("Go to Detail") {
+                    navigationPath.append(DetailRoute.item(id: 1))
+                }
+            }
+            .navigationDestination(for: DetailRoute.self) { route in
+                switch route {
+                case .item(let id):
+                    ItemDetailView(id: id)
+                }
+            }
+        }
+    }
+}
+
+enum DetailRoute: Hashable {
+    case item(id: Int)
+}
+```
+
+## Multi-Column Navigation with NavigationSplitView
+
+### Two-Column Layout
+
+Use `NavigationSplitView` for sidebar-driven navigation. Available on iOS 16+, macOS 13+, tvOS 16+, watchOS 9+.
+
+```swift
+struct ContentView: View {
+    @State private var selectedItem: Item.ID?
+
+    var body: some View {
+        NavigationSplitView {
+            List(items, selection: $selectedItem) { item in
+                Text(item.name)
+            }
+            .navigationTitle("Items")
+        } detail: {
+            if let selectedItem, let item = items.first(where: { $0.id == selectedItem }) {
+                ItemDetailView(item: item)
+            } else {
+                ContentUnavailableView("Select an Item", systemImage: "doc")
+            }
+        }
+    }
+}
+```
+
+### Three-Column Layout
+
+```swift
+struct ContentView: View {
+    @State private var departmentId: Department.ID?
+    @State private var employeeIds = Set<Employee.ID>()
+
+    var body: some View {
+        NavigationSplitView {
+            List(model.departments, selection: $departmentId) { dept in
+                Text(dept.name)
+            }
+        } content: {
+            if let department = model.department(id: departmentId) {
+                List(department.employees, selection: $employeeIds) { emp in
+                    Text(emp.name)
+                }
+            } else {
+                Text("Select a department")
+            }
+        } detail: {
+            EmployeeDetails(for: employeeIds)
+        }
+    }
+}
+```
+
+### Configuration
+
+- **Column visibility**: `NavigationSplitView(columnVisibility: $visibility)` with `NavigationSplitViewVisibility` (`.detailOnly`, `.doubleColumn`, `.all`)
+- **Column widths**: `.navigationSplitViewColumnWidth(min:ideal:max:)` on each column
+- **Compact column**: `NavigationSplitView(preferredCompactColumn: $column)` to control which column shows on narrow devices
+- **Style**: `.navigationSplitViewStyle(.balanced)` or `.prominentDetail` (default)
+
+### Platform Behavior
+
+| Platform | Behavior |
+|----------|----------|
+| **macOS** | Columns always visible side-by-side; sidebar has translucent material; variable-width column resizing by dragging |
+| **iPadOS (regular)** | Sidebar can overlay or push detail; supports column visibility toggle via toolbar button |
+| **iOS / iPadOS (compact)** | Collapses into a single `NavigationStack`; sidebar items show disclosure chevrons; back button navigates between columns |
+| **iPhone (all sizes)** | Always collapsed into a stack; sidebar appears as the root list; selections push detail onto the stack |
+| **watchOS / tvOS** | Collapses into a single stack |
+
+## Inspector
+
+> **Availability:** iOS 17.0+, macOS 14.0+
+
+A trailing-edge panel for supplementary information.
+
+On wider size classes (macOS, iPad landscape), it appears as a **trailing column**. On compact size classes (iPhone), it **adapts to a sheet** automatically.
+
+### Basic Inspector
+
+```swift
+struct ShapeEditor: View {
+    @State private var showInspector = false
+
+    var body: some View {
+        MyEditorView()
+            .inspector(isPresented: $showInspector) {
+                InspectorContent()
+            }
+            .toolbar {
+                ToolbarItem {
+                    Button {
+                        showInspector.toggle()
+                    } label: {
+                        Label("Inspector", systemImage: "info.circle")
+                    }
+                }
+            }
+    }
+}
+```
+
+### Inspector with Column Width
+
+```swift
+MyEditorView()
+    .inspector(isPresented: $showInspector) {
+        InspectorContent()
+            .inspectorColumnWidth(min: 200, ideal: 250, max: 400)
+    }
+```
+
+### Inspector with Fixed Width
+
+```swift
+MyEditorView()
+    .inspector(isPresented: $showInspector) {
+        InspectorContent()
+            .inspectorColumnWidth(300)
+    }
+```
+
+### Platform Behavior
+
+| Platform | Behavior |
+|----------|----------|
+| **macOS** | Trailing-edge sidebar panel; resizable by dragging edge; integrates with window toolbar |
+| **iPadOS (regular)** | Trailing column alongside content; toggleable via toolbar button |
+| **iOS / iPadOS (compact)** | Adapts to a sheet presentation; swipe-to-dismiss supported |
+| **iPhone (all sizes)** | Always presented as a sheet (no trailing column); dismiss via swipe or button |
+
+> **Tip:** Use `InspectorCommands` in your app's `.commands` to include the default inspector toggle keyboard shortcut.
+
+## Presentation Modifiers
+
+### Full Screen Cover
+
+```swift
+struct ContentView: View {
+    @State private var showFullScreen = false
+    
+    var body: some View {
+        Button("Show Full Screen") {
+            showFullScreen = true
+        }
+        .fullScreenCover(isPresented: $showFullScreen) {
+            FullScreenView()
+        }
+    }
+}
+```
+
+### Popover
+
+```swift
+struct ContentView: View {
+    @State private var showPopover = false
+    
+    var body: some View {
+        Button("Show Popover") {
+            showPopover = true
+        }
+        .popover(isPresented: $showPopover) {
+            PopoverContentView()
+                .presentationCompactAdaptation(.popover)  // Don't adapt to sheet on iPhone
+        }
+    }
+}
+```
+
+For `alert` and `confirmationDialog` API patterns, see `latest-apis.md`.
+
+## Summary Checklist
+
+- [ ] Use `.sheet(item:)` for model-based sheets
+- [ ] Sheets own their actions and dismiss internally
+- [ ] Use `NavigationStack` with `navigationDestination(for:)` for type-safe navigation
+- [ ] Use `NavigationPath` for programmatic navigation
+- [ ] Use `NavigationSplitView` for sidebar-driven multi-column layouts
+- [ ] Use `Inspector` for trailing-edge supplementary panels
+- [ ] Set column widths with `navigationSplitViewColumnWidth(min:ideal:max:)` or `inspectorColumnWidth(min:ideal:max:)`
+- [ ] Use appropriate presentation modifiers (sheet, fullScreenCover, popover)
+- [ ] Alerts and confirmation dialogs use modern API with actions
+- [ ] Avoid passing dismiss/save callbacks to sheets
+- [ ] Use enum-based `Identifiable` type with `.sheet(item:)` when presenting multiple sheets
+- [ ] Navigation state can be saved/restored when needed

--- a/.agents/skills/swiftui-expert-skill/references/state-management.md
+++ b/.agents/skills/swiftui-expert-skill/references/state-management.md
@@ -1,0 +1,388 @@
+# SwiftUI State Management Reference
+
+## Table of Contents
+
+- [Property Wrapper Selection Guide](#property-wrapper-selection-guide)
+- [@State](#state)
+- [Property Wrappers Inside @Observable Classes](#property-wrappers-inside-observable-classes)
+- [@Binding](#binding)
+- [@FocusState](#focusstate)
+- [@StateObject vs @ObservedObject (Legacy - Pre-iOS 17)](#stateobject-vs-observedobject-legacy---pre-ios-17)
+- [Don't Pass Values as @State](#dont-pass-values-as-state)
+- [@Bindable (iOS 17+)](#bindable-ios-17)
+- [let vs var for Passed Values](#let-vs-var-for-passed-values)
+- [Environment and Preferences](#environment-and-preferences)
+- [Decision Flowchart](#decision-flowchart)
+- [State Privacy Rules](#state-privacy-rules)
+- [Avoid Nested ObservableObject](#avoid-nested-observableobject)
+- [Key Principles](#key-principles)
+
+## Property Wrapper Selection Guide
+
+| Wrapper | Use When | Notes |
+|---------|----------|-------|
+| `@State` | Internal view state that triggers updates | Must be `private` |
+| `@Binding` | Child view needs to modify parent's state | Don't use for read-only |
+| `@Bindable` | iOS 17+: View receives `@Observable` object and needs bindings | For injected observables |
+| `let` | Read-only value passed from parent | Simplest option |
+| `var` | Read-only value that child observes via `.onChange()` | For reactive reads |
+
+**Legacy (Pre-iOS 17):**
+| Wrapper | Use When | Notes |
+|---------|----------|-------|
+| `@StateObject` | View owns an `ObservableObject` instance | Use `@State` with `@Observable` instead |
+| `@ObservedObject` | View receives an `ObservableObject` from outside | Never create inline |
+
+## @State
+
+Always mark `@State` properties as `private`. Use for internal view state that triggers UI updates.
+
+```swift
+// Correct
+@State private var isAnimating = false
+@State private var selectedTab = 0
+```
+
+**Why Private?** Marking state as `private` makes it clear what's created by the view versus what's passed in. It also prevents accidentally passing initial values that will be ignored (see "Don't Pass Values as @State" below).
+
+### iOS 17+ with @Observable (Preferred)
+
+**Always prefer `@Observable` over `ObservableObject`.** With iOS 17's `@Observable` macro, use `@State` instead of `@StateObject`:
+
+```swift
+@Observable
+@MainActor  // Always mark @Observable classes with @MainActor
+final class DataModel {
+    var name = "Some Name"
+    var count = 0
+}
+
+struct MyView: View {
+    @State private var model = DataModel()  // Use @State, not @StateObject
+
+    var body: some View {
+        VStack {
+            TextField("Name", text: $model.name)
+            Stepper("Count: \(model.count)", value: $model.count)
+        }
+    }
+}
+```
+
+**Critical**: When a view *owns* an `@Observable` object, always use `@State` -- not `let`. Without `@State`, SwiftUI may recreate the instance when a parent view redraws, losing accumulated state. `@State` tells SwiftUI to preserve the instance across view redraws. Using `@State` also provides bindings directly (no need for `@Bindable`).
+
+**Note**: You may want to mark `@Observable` classes with `@MainActor` to ensure thread safety with SwiftUI, unless your project or package uses Default Actor Isolation set to `MainActor`—in which case, the explicit attribute is redundant and can be omitted.
+
+## Property Wrappers Inside @Observable Classes
+
+**Critical**: The `@Observable` macro transforms stored properties to add observation tracking. Property wrappers (like `@AppStorage`, `@SceneStorage`, `@Query`) also transform properties with their own storage. These two transformations conflict, causing a compiler error.
+
+**Always annotate property-wrapper properties with `@ObservationIgnored` inside `@Observable` classes.**
+
+```swift
+@Observable
+@MainActor
+final class SettingsModel {
+    // WRONG - compiler error: property wrappers conflict with @Observable
+    // @AppStorage("username") var username = ""
+
+    // CORRECT - @ObservationIgnored prevents the conflict
+    @ObservationIgnored @AppStorage("username") var username = ""
+    @ObservationIgnored @AppStorage("isDarkMode") var isDarkMode = false
+
+    // Regular stored properties work fine with @Observable
+    var isLoading = false
+}
+```
+
+This applies to **any** property wrapper used inside an `@Observable` class, including but not limited to:
+- `@AppStorage`
+- `@SceneStorage`
+- `@Query` (SwiftData)
+
+**Note**: Since `@ObservationIgnored` disables observation tracking for that property, SwiftUI won't detect changes through the Observation framework. However, property wrappers like `@AppStorage` already notify SwiftUI of changes through their own mechanisms (e.g., UserDefaults KVO), so views still update correctly.
+
+**Never remove `@ObservationIgnored`** from property-wrapper properties in `@Observable` classes — doing so causes a compiler error.
+
+## @Binding
+
+Use only when child view needs to **modify** parent's state. If child only reads the value, use `let` instead.
+
+```swift
+// Parent
+struct ParentView: View {
+    @State private var isSelected = false
+
+    var body: some View {
+        ChildView(isSelected: $isSelected)
+    }
+}
+
+// Child - will modify the value
+struct ChildView: View {
+    @Binding var isSelected: Bool
+
+    var body: some View {
+        Button("Toggle") {
+            isSelected.toggle()
+        }
+    }
+}
+```
+
+### When NOT to use @Binding
+
+- **Don't use `@Binding` for read-only values.** If the child only displays the value and never modifies it, use `let` instead. `@Binding` adds unnecessary overhead and implies a write contract that doesn't exist.
+
+## @FocusState
+
+See `references/focus-patterns.md` for comprehensive focus management guidance including `@FocusState`, `@FocusedValue`, `.focusable()`, default focus, and common pitfalls.
+
+Always mark `@FocusState` as `private`.
+
+## @StateObject vs @ObservedObject (Legacy - Pre-iOS 17)
+
+**Note**: Always prefer `@Observable` with `@State` for iOS 17+.
+
+The key distinction is **ownership**: `@StateObject` when the view **creates and owns** the object; `@ObservedObject` when the view **receives** it from outside.
+
+```swift
+// View creates it → @StateObject
+@StateObject private var viewModel = MyViewModel()
+
+// View receives it → @ObservedObject
+@ObservedObject var viewModel: MyViewModel
+```
+
+**Never** create an `ObservableObject` inline with `@ObservedObject` -- it recreates the instance on every view update.
+
+### @StateObject instantiation in View's initializer
+
+Prefer storing the `@StateObject` in the parent view and passing it down. If you must create one in a custom initializer, pass the expression directly to `StateObject(wrappedValue:)` so the `@autoclosure` prevents redundant allocations:
+
+```swift
+// Inside a View's init(movie:):
+// WRONG — assigning to a local first defeats @autoclosure
+let vm = MovieDetailsViewModel(movie: movie)
+_viewModel = StateObject(wrappedValue: vm)
+
+// CORRECT — inline expression defers creation
+_viewModel = StateObject(wrappedValue: MovieDetailsViewModel(movie: movie))
+```
+
+**Modern Alternative**: Use `@Observable` with `@State` instead.
+
+## Don't Pass Values as @State
+
+**Critical**: Never declare passed values as `@State` or `@StateObject`. They only accept an initial value and ignore subsequent updates from the parent.
+
+```swift
+// WRONG - child ignores parent updates
+struct ChildView: View {
+    @State var item: Item  // Shows initial value forever!
+    var body: some View { Text(item.name) }
+}
+
+// CORRECT - child receives updates
+struct ChildView: View {
+    let item: Item  // Or @Binding if child needs to modify
+    var body: some View { Text(item.name) }
+}
+```
+
+**Prevention**: Always mark `@State` and `@StateObject` as `private`. This prevents them from appearing in the generated initializer.
+
+## @Bindable (iOS 17+)
+
+Use when receiving an `@Observable` object from outside and needing bindings:
+
+```swift
+@Observable
+final class UserModel {
+    var name = ""
+    var email = ""
+}
+
+struct ParentView: View {
+    @State private var user = UserModel()
+
+    var body: some View {
+        EditUserView(user: user)
+    }
+}
+
+struct EditUserView: View {
+    @Bindable var user: UserModel  // Received from parent, needs bindings
+
+    var body: some View {
+        Form {
+            TextField("Name", text: $user.name)
+            TextField("Email", text: $user.email)
+        }
+    }
+}
+```
+
+## let vs var for Passed Values
+
+### Use `let` for read-only display
+
+```swift
+struct ProfileHeader: View {
+    let username: String
+    let avatarURL: URL
+
+    var body: some View {
+        HStack {
+            AsyncImage(url: avatarURL)
+            Text(username)
+        }
+    }
+}
+```
+
+### Use `var` when reacting to changes with `.onChange()`
+
+```swift
+struct ReactiveView: View {
+    var externalValue: Int  // Watch with .onChange()
+    @State private var displayText = ""
+
+    var body: some View {
+        Text(displayText)
+            .onChange(of: externalValue) { oldValue, newValue in
+                displayText = "Changed from \(oldValue) to \(newValue)"
+            }
+    }
+}
+```
+
+## Environment and Preferences
+
+### @Environment
+
+Access environment values provided by SwiftUI or parent views:
+
+```swift
+struct MyView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        Button("Done") { dismiss() }
+            .foregroundStyle(colorScheme == .dark ? .white : .black)
+    }
+}
+```
+
+### Custom Environment Values with @Entry
+
+Use the `@Entry` macro (Xcode 16+, backward compatible to iOS 13) to define custom environment values without boilerplate:
+
+```swift
+extension EnvironmentValues {
+    @Entry var accentTheme: Theme = .default
+}
+
+// Inject
+ContentView()
+    .environment(\.accentTheme, customTheme)
+
+// Access
+struct ThemedView: View {
+    @Environment(\.accentTheme) private var theme
+}
+```
+
+The `@Entry` macro replaces the manual `EnvironmentKey` conformance pattern. It also works with `TransactionValues`, `ContainerValues`, and `FocusedValues`.
+
+### @Environment with @Observable (iOS 17+ - Preferred)
+
+**Always prefer this pattern** for sharing state through the environment:
+
+```swift
+@Observable
+@MainActor
+final class AppState {
+    var isLoggedIn = false
+}
+
+// Inject
+ContentView()
+    .environment(AppState())
+
+// Access
+struct ChildView: View {
+    @Environment(AppState.self) private var appState
+}
+```
+
+### @EnvironmentObject (Legacy - Pre-iOS 17)
+
+Legacy pattern: inject with `.environmentObject(AppState())`, access with `@EnvironmentObject var appState: AppState`. Prefer `@Observable` with `@Environment` instead.
+
+## Decision Flowchart
+
+```
+Is this value owned by this view?
+├─ YES: Is it a simple value type?
+│       ├─ YES → @State private var
+│       └─ NO (class):
+│           ├─ Use @Observable → @State private var (mark class @MainActor)
+│           └─ Legacy ObservableObject → @StateObject private var
+│
+└─ NO (passed from parent):
+    ├─ Does child need to MODIFY it?
+    │   ├─ YES → @Binding var
+    │   └─ NO: Does child need BINDINGS to its properties?
+    │       ├─ YES (@Observable) → @Bindable var
+    │       └─ NO: Does child react to changes?
+    │           ├─ YES → var + .onChange()
+    │           └─ NO → let
+    │
+    └─ Is it a legacy ObservableObject from parent?
+        └─ YES → @ObservedObject var (consider migrating to @Observable)
+```
+
+## State Privacy Rules
+
+**All view-owned state should be `private`:**
+
+```swift
+// Correct - clear what's created vs passed
+struct MyView: View {
+    // Created by view - private
+    @State private var isExpanded = false
+    @State private var viewModel = ViewModel()
+    @AppStorage("theme") private var theme = "light"
+    @Environment(\.colorScheme) private var colorScheme
+    
+    // Passed from parent - not private
+    let title: String
+    @Binding var isSelected: Bool
+    @Bindable var user: User
+    
+    var body: some View {
+        // ...
+    }
+}
+```
+
+**Why**: This makes dependencies explicit and improves code completion for the generated initializer.
+
+## Avoid Nested ObservableObject
+
+**Note**: This limitation only applies to `ObservableObject`. `@Observable` fully supports nested observed objects.
+
+SwiftUI can't track changes through nested `ObservableObject` properties. Workaround: pass the nested object directly to child views as `@ObservedObject`. With `@Observable`, nesting works automatically.
+
+## Key Principles
+
+1. **Always prefer `@Observable` over `ObservableObject`** for new code
+2. **Mark `@Observable` classes with `@MainActor` for thread safety (unless using default actor isolation)`**
+3. Use `@State` with `@Observable` classes (not `@StateObject`)
+4. Use `@Bindable` for injected `@Observable` objects that need bindings
+5. **Always mark `@State` and `@StateObject` as `private`**
+6. **Never declare passed values as `@State` or `@StateObject`**
+7. With `@Observable`, nested objects work fine; with `ObservableObject`, pass nested objects directly to child views
+8. **Always add `@ObservationIgnored` to property wrappers** (e.g., `@AppStorage`, `@SceneStorage`, `@Query`) inside `@Observable` classes — they conflict with the macro's property transformation

--- a/.agents/skills/swiftui-expert-skill/references/text-patterns.md
+++ b/.agents/skills/swiftui-expert-skill/references/text-patterns.md
@@ -1,0 +1,32 @@
+# SwiftUI Text Patterns Reference
+
+## Table of Contents
+
+- [Text Initialization: Verbatim vs Localized](#text-initialization-verbatim-vs-localized)
+
+## Text Initialization: Verbatim vs Localized
+
+**Default: always use `Text("…")`.** Only use `Text(verbatim:)` when explicitly required for a string literal that must not be localized.
+
+```swift
+// Localized literal - "Save" is used as the localization key and looked up in Localizable.strings (only if one exists in the project)
+Text("Save")
+
+// String variable - bypasses localization automatically; no verbatim needed
+let filename: String = model.exportFilename
+Text(filename)
+
+// Non-localized literal - use verbatim only when the literal must not be localized
+Text(verbatim: "pencil")
+```
+
+### Decision Flow
+
+```
+Is the input a String variable or dynamic value?
+└─ YES → Text(variable)          // bypasses localization automatically
+
+Is the string literal intended for localization?
+├─ YES → Text("…")               // default; key looked up in Localizable.strings
+└─ NO  → Text(verbatim: "…")     // only when explicitly non-localized
+```

--- a/.agents/skills/swiftui-expert-skill/references/view-structure.md
+++ b/.agents/skills/swiftui-expert-skill/references/view-structure.md
@@ -1,0 +1,780 @@
+# SwiftUI View Structure Reference
+
+## Table of Contents
+
+- [View Structure Principles](#view-structure-principles)
+- [Recommended View File Structure](#recommended-view-file-structure)
+- [Struct or Method / Computed Property?](#struct-or-method--computed-property)
+- [Prefer Modifiers Over Conditional Views](#prefer-modifiers-over-conditional-views)
+- [Extract Subviews, Not Computed Properties](#extract-subviews-not-computed-properties)
+- [@ViewBuilder](#viewbuilder)
+- [Keep View Body Simple and Avoid High-Cost Operations](#keep-view-body-simple-and-avoid-high-cost-operations)
+- [When to Extract Subviews](#when-to-extract-subviews)
+- [Container View Pattern](#container-view-pattern)
+- [Utilize Lazy Containers for Large Data Sets](#utilize-lazy-containers-for-large-data-sets)
+- [ZStack vs overlay/background](#zstack-vs-overlaybackground)
+- [Compositing Group Before Clipping](#compositing-group-before-clipping)
+- [Split State-Driven Parts into Custom View Types](#split-state-driven-parts-into-custom-view-types)
+- [Reusable Styling with ViewModifier](#reusable-styling-with-viewmodifier)
+- [Skeleton Loading with Redacted Views](#skeleton-loading-with-redacted-views)
+- [AnyView](#anyview)
+- [UIViewRepresentable Essentials](#uiviewrepresentable-essentials)
+- [Troubleshooting](#troubleshooting)
+- [Summary Checklist](#summary-checklist)
+
+## View Structure Principles
+
+SwiftUI's diffing algorithm compares view hierarchies to determine what needs updating. Proper view composition directly impacts performance.
+
+## Recommended View File Structure
+
+Use a consistent order when declaring SwiftUI views:
+
+1. Environment Properties
+2. State Properties
+3. Private Properties
+4. Initializer (if needed)
+5. Body
+6. Computed Properties/Methods for Subviews
+
+```swift
+struct ContentView: View {
+    // MARK: - Environment Properties
+    @Environment(\.colorScheme) var colorScheme
+
+    // MARK: - State Properties
+    @Binding var isToggled: Bool
+    @State private var viewModel: SomeViewModel
+
+    // MARK: - Private Properties
+    private let title: String = "SwiftUI Guide"
+
+    // MARK: - Initializer (if needed)
+    init(isToggled: Binding<Bool>) {
+        self._isToggled = isToggled
+    }
+
+    // MARK: - Body
+    var body: some View {
+        VStack {
+            header
+            content
+        }
+    }
+
+    // MARK: - Computed Subviews
+    private var header: some View {
+        Text(title).font(.largeTitle).padding()
+    }
+
+    private var content: some View {
+        VStack {
+            Text("Counter: \(counter)")
+        }
+    }
+}
+```
+
+## Struct or Method / Computed Property?
+
+If a `View` is intended to be reusable across multiple screens, encapsulate it within a separate `struct`. If its usage is confined to a single context, it can be declared as a function or computed property within the containing `View`.
+
+However, if a view maintains state using `@State`, `@Binding`, `@ObservedObject`, `@Environment`, `@StateObject`, or similar wrappers, it should generally be a separate `struct`.
+
+- For simple, static views: a computed property is acceptable.
+- For views requiring parameters: a method is more appropriate, but only when those parameters are stable. If parameters change per-call (e.g. inside a `ForEach` where each call receives a different item), prefer a separate `struct` so SwiftUI can diff inputs and skip body evaluation.
+- For reusable, stateful, or logically independent UI sections: prefer a dedicated `struct`.
+
+```swift
+struct ContentView: View {
+    var titleView: some View {
+        Text("Hello from Property")
+            .font(.largeTitle)
+            .foregroundColor(.blue)
+    }
+
+    func messageView(text: String, color: Color) -> some View {
+        Text(text)
+            .font(.title)
+            .foregroundColor(color)
+            .padding()
+    }
+
+    var body: some View {
+        VStack {
+            titleView
+            messageView(text: "Hello from Method", color: .red)
+        }
+    }
+}
+```
+
+## Prefer Modifiers Over Conditional Views
+
+**Prefer "no-effect" modifiers over conditionally including views.** When you introduce a branch, consider whether you're representing multiple views or two states of the same view.
+
+### Use Opacity Instead of Conditional Inclusion
+
+```swift
+// Good - same view, different states
+SomeView()
+    .opacity(isVisible ? 1 : 0)
+
+// Avoid - creates/destroys view identity
+if isVisible {
+    SomeView()
+}
+```
+
+**Why**: Conditional view inclusion can cause loss of state, poor animation performance, and breaks view identity. Using modifiers maintains view identity across state changes.
+
+### When Conditionals Are Appropriate
+
+Use conditionals when you truly have **different views**, not different states:
+
+```swift
+// Correct - fundamentally different views
+if isLoggedIn {
+    DashboardView()
+} else {
+    LoginView()
+}
+
+// Correct - optional content
+if let user {
+    UserProfileView(user: user)
+}
+```
+
+### Conditional View Modifier Extensions Break Identity
+
+A common pattern is an `if`-based `View` extension for conditional modifiers. This changes the view's return type between branches, which destroys view identity and breaks animations:
+
+```swift
+// Problematic -- different return types per branch
+extension View {
+    @ViewBuilder func `if`<T: View>(_ condition: Bool, transform: (Self) -> T) -> some View {
+        if condition {
+            transform(self)  // Returns T
+        } else {
+            self              // Returns Self
+        }
+    }
+}
+```
+
+Prefer applying the modifier directly with a ternary or always-present modifier:
+
+```swift
+// Good -- same view identity maintained
+Text("Hello")
+    .opacity(isHighlighted ? 1 : 0.5)
+
+// Good -- modifier always present, value changes
+Text("Hello")
+    .foregroundStyle(isError ? .red : .primary)
+```
+
+## Extract Subviews, Not Computed Properties
+
+### The Problem with @ViewBuilder Functions
+
+When you use `@ViewBuilder` functions or computed properties for complex views, the entire function re-executes on every parent state change:
+
+```swift
+// BAD - re-executes complexSection() on every tap
+struct ParentView: View {
+    @State private var count = 0
+
+    var body: some View {
+        VStack {
+            Button("Tap: \(count)") { count += 1 }
+            complexSection()  // Re-executes every tap!
+        }
+    }
+
+    @ViewBuilder
+    func complexSection() -> some View {
+        // Complex views that re-execute unnecessarily
+        ForEach(0..<100) { i in
+            HStack {
+                Image(systemName: "star")
+                Text("Item \(i)")
+                Spacer()
+                Text("Detail")
+            }
+        }
+    }
+}
+```
+
+### The Solution: Separate Structs
+
+Extract to separate `struct` views. SwiftUI can skip their `body` when inputs don't change:
+
+```swift
+// GOOD - ComplexSection body SKIPPED when its inputs don't change
+struct ParentView: View {
+    @State private var count = 0
+
+    var body: some View {
+        VStack {
+            Button("Tap: \(count)") { count += 1 }
+            ComplexSection()  // Body skipped during re-evaluation
+        }
+    }
+}
+
+struct ComplexSection: View {
+    var body: some View {
+        ForEach(0..<100) { i in
+            HStack {
+                Image(systemName: "star")
+                Text("Item \(i)")
+                Spacer()
+                Text("Detail")
+            }
+        }
+    }
+}
+```
+
+### Why This Works
+
+1. SwiftUI compares the `ComplexSection` struct (which has no properties)
+2. Since nothing changed, SwiftUI skips calling `ComplexSection.body`
+3. The complex view code never executes unnecessarily
+
+## @ViewBuilder
+
+Use `@ViewBuilder` functions for small, simple sections (a few views, no expensive computation) that don't affect performance. They work particularly well for static content that doesn't depend on any `@State` or `@Binding`, since SwiftUI won't need to diff them independently. Extract to a separate `struct` when the section is complex, depends on state, or needs to be skipped during re-evaluation.
+
+The `@ViewBuilder` attribute is only required when a function or computed property returns multiple different views conditionally, for example through `if` or `switch`:
+
+```swift
+@ViewBuilder
+private var conditionalView: some View {
+    if isExpanded {
+        VStack {
+            Text("Expanded View")
+            Image(systemName: "star")
+        }
+    } else {
+        Text("Collapsed View")
+    }
+}
+```
+
+If every branch returns the same concrete type, `@ViewBuilder` is unnecessary:
+
+```swift
+var conditionalText: some View {
+    if Bool.random() {
+        Text("Hello")
+    } else {
+        Text("World")
+    }
+}
+```
+
+Prefer `@ViewBuilder` when:
+
+- there is conditional branching between multiple view types
+- extracting a separate `struct` would not provide meaningful separation
+
+## Keep View Body Simple and Avoid High-Cost Operations
+
+Refrain from performing complex operations within the `body` of your view. Instead of passing a ready-to-use sequence with filtering, mapping, or sorting directly into `ForEach`, prepare the sequence outside the body.
+
+```swift
+// Avoid such things ...
+var body: some View {
+    List {
+        ForEach(model.values.filter { $0 > 0 }, id: \.self) {
+            Text(String($0))
+                .padding()
+        }
+    }
+}
+```
+
+Prefer:
+
+```swift
+struct FilteredListView: View {
+    private let filteredValues: [Int]
+
+    init(values: [Int]) {
+        self.filteredValues = values.filter { $0 > 0 } // Perform filtering once
+    }
+
+    var body: some View {
+        List {
+            content
+        }
+    }
+
+    private var content: some View {
+        ForEach(filteredValues, id: \.self) { value in
+            Text(String(value))
+                .padding()
+        }
+    }
+}
+```
+
+The reason this matters is that the system can call `body` multiple times during a single layout phase. Complex body computation makes those calls more expensive than necessary.
+
+General guidance:
+
+- avoid filtering, sorting, and mapping inline in `body`
+- avoid constructing expensive formatters in `body`
+- avoid heavy branching in large view trees
+- move data preparation into init, model layer, or dedicated helpers
+
+## When to Extract Subviews
+
+Extract complex views into separate subviews when:
+- The view has multiple logical sections or responsibilities
+- The view contains reusable components
+- The view body becomes difficult to read or understand
+- You need to isolate state changes for performance
+- The view is becoming large (keep views small for better performance)
+- The section may evolve independently over time
+
+## Container View Pattern
+
+### Avoid Closure-Based Content
+
+Closures can't be compared, causing unnecessary re-renders:
+
+```swift
+// BAD - closure prevents SwiftUI from skipping updates
+struct MyContainer<Content: View>: View {
+    let content: () -> Content
+
+    var body: some View {
+        VStack {
+            Text("Header")
+            content()  // Always called, can't compare closures
+        }
+    }
+}
+
+// Usage forces re-render on every parent update
+MyContainer {
+    ExpensiveView()
+}
+```
+
+### Use @ViewBuilder Property Instead
+
+```swift
+// GOOD - view can be compared
+struct MyContainer<Content: View>: View {
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack {
+            Text("Header")
+            content  // SwiftUI can compare and skip if unchanged
+        }
+    }
+}
+
+// Usage - SwiftUI can diff ExpensiveView
+MyContainer {
+    ExpensiveView()
+}
+```
+
+## Utilize Lazy Containers for Large Data Sets
+
+When displaying extensive lists or grids, prefer `LazyVStack`, `LazyHStack`, `LazyVGrid`, or `LazyHGrid`. These containers load views only when they appear on the screen, reducing memory usage and improving performance.
+
+```swift
+struct ContentView: View {
+    let items = Array(0..<1000)
+
+    var body: some View {
+        ScrollView {
+            LazyVStack {
+                ForEach(items, id: \.self) { item in
+                    Text("Item \(item)")
+                }
+            }
+        }
+    }
+}
+```
+
+Prefer lazy containers when:
+
+- rendering large collections
+- row views are non-trivial
+- memory usage matters
+- the content is inside `ScrollView`
+
+## ZStack vs overlay/background
+
+Use `ZStack` to **compose multiple peer views** that should be layered together and jointly define layout.
+
+Prefer `overlay` / `background` when you’re **decorating a primary view**.  
+Not primarily because they don’t affect layout size, but because they **express intent and improve readability**: the view being modified remains the clear layout anchor.
+
+A key difference is **size proposal behavior**:
+- In `overlay` / `background`, the child view implicitly adopts the size proposed to the parent when it doesn’t define its own size, making decorative attachments feel natural and predictable.
+- In `ZStack`, each child participates independently in layout, and no implicit size inheritance exists. This makes it better suited for peer composition, but less intuitive for simple decoration.
+
+Use `ZStack` (or another container) when the “decoration” **must explicitly participate in layout sizing**—for example, when reserving space, extending tappable/visible bounds, or preventing overlap with neighboring views.
+
+### Examples
+
+```swift
+// GOOD - decoration via overlay (layout anchored to button)
+Button("Continue") { }
+    .overlay(alignment: .trailing) {
+        Image(systemName: "lock.fill").padding(.trailing, 8)
+    }
+
+// BAD - ZStack when overlay suffices (layout no longer anchored to button)
+ZStack(alignment: .trailing) {
+    Button("Continue") { }
+    Image(systemName: "lock.fill").padding(.trailing, 8)
+}
+
+// GOOD - background shape takes parent size
+HStack(spacing: 12) { Text("Inbox"); Text("Next") }
+    .background { Capsule().strokeBorder(.blue, lineWidth: 2) }
+```
+
+## Compositing Group Before Clipping
+
+**Always add `.compositingGroup()` before `.clipShape()` when clipping layered views (`.overlay` or `.background`).** Without it, each layer is antialiased separately and then composited. Where antialiased edges overlap — typically at rounded corners — you get visible color fringes (semi-transparent pixels of different colors blending together).
+
+```swift
+let shape = RoundedRectangle(cornerRadius: 16)
+
+// BAD - each layer antialiased separately, producing color fringes at corners
+Color.red
+    .overlay(.white, in: shape)
+    .clipShape(shape)
+    .frame(width: 200, height: 150)
+
+// GOOD - layers composited first, antialiasing applied once during clipping
+Color.red
+    .overlay(.white, in: .rect)
+    .compositingGroup()
+    .clipShape(shape)
+    .frame(width: 200, height: 150)
+```
+
+`.compositingGroup()` forces all child layers to be rendered into a single offscreen buffer before the clip is applied. This means antialiasing only happens once — on the final composited result — eliminating the fringe artifacts.
+
+## Split State-Driven Parts into Custom View Types
+
+Large views often depend on multiple independent state sources. If a single view body depends on all of them, then any state change can cause the entire body to re-evaluate.
+
+```swift
+struct BigAndComplicatedView: View {
+    @State private var counter = 0
+    @State private var isToggled = false
+    @StateObject private var viewModel = SomeViewModel()
+
+    let title = "Big and Complicated View"
+
+    var body: some View {
+        VStack {
+            Text(title)
+                .font(.largeTitle)
+
+            Text("Counter: \(counter)")
+                .font(.title)
+
+            Toggle("Enable Feature", isOn: $isToggled)
+                .padding()
+
+            Button("Increment Counter") {
+                counter += 1
+            }
+
+            Text("ViewModel Data: \(viewModel.data)")
+                .padding()
+
+            Button("Fetch Data") {
+                viewModel.fetchData()
+            }
+        }
+    }
+}
+```
+
+### Better: Split Into Smaller Components
+
+```swift
+struct BigAndComplicatedView: View {
+    @State private var counter = 0
+    @State private var isToggled = false
+    @StateObject private var viewModel = SomeViewModel()
+
+    var body: some View {
+        VStack {
+            titleView
+            CounterView(counter: $counter)
+            ToggleView(isToggled: $isToggled)
+            ViewModelDataView(data: viewModel.data) {
+                viewModel.updateData()
+            }
+            .equatable()
+        }
+    }
+
+    private var titleView: some View {
+        Text("Big and Complicated View")
+            .font(.largeTitle)
+    }
+}
+```
+
+Why this is better:
+
+- changing `counter` only affects `CounterView`
+- toggling only affects `ToggleView`
+- updating the model data only affects `ViewModelDataView`
+
+### Notes on Equatable
+
+Using `Equatable` for a view is not a universal best practice, but it can be useful in targeted cases where:
+
+- the input is small and well-defined
+- the comparison logic is meaningful
+- you want to reduce unnecessary body evaluation for a specific subtree
+
+Do not use `Equatable` as a blanket optimization technique.
+
+## Reusable Styling with ViewModifier
+
+Extract repeated modifier combinations into a `ViewModifier` struct. Expose via a `View` extension for autocompletion:
+
+```swift
+private struct CardStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .padding()
+            .background(Color(.secondarySystemBackground))
+            .clipShape(.rect(cornerRadius: 12))
+    }
+}
+
+extension View {
+    func cardStyle() -> some View {
+        modifier(CardStyle())
+    }
+}
+```
+
+### Custom ButtonStyle
+
+Use the `ButtonStyle` protocol for reusable button designs. Use `PrimitiveButtonStyle` only when you need custom interaction handling (e.g., simultaneous gestures):
+
+```swift
+struct PrimaryButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .bold()
+            .foregroundStyle(.white)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .background(Color.accentColor)
+            .clipShape(Capsule())
+            .scaleEffect(configuration.isPressed ? 0.95 : 1)
+            .animation(.smooth, value: configuration.isPressed)
+    }
+}
+```
+
+### Discoverability with Static Member Lookup
+
+Make custom styles and modifiers discoverable via leading-dot syntax:
+
+```swift
+extension ButtonStyle where Self == PrimaryButtonStyle {
+    static var primary: PrimaryButtonStyle { .init() }
+}
+
+// Usage: .buttonStyle(.primary)
+```
+
+This pattern works for any SwiftUI style protocol (`ButtonStyle`, `ListStyle`, `ToggleStyle`, etc.).
+
+## Skeleton Loading with Redacted Views
+
+Use `.redacted(reason: .placeholder)` to show skeleton views while data loads. Use `.unredacted()` to opt out specific views:
+
+```swift
+VStack(alignment: .leading) {
+    Text(article?.title ?? String(repeating: "X", count: 20))
+        .font(.headline)
+    Text(article?.author ?? String(repeating: "X", count: 12))
+        .font(.subheadline)
+    Text("SwiftLee")
+        .font(.caption)
+        .unredacted()
+}
+.redacted(reason: article == nil ? .placeholder : [])
+```
+
+Apply `.redacted` on a container to redact all children at once.
+
+## AnyView
+
+`AnyView` is type erasure. SwiftUI uses structural identity based on type information to determine when views should be updated.
+
+```swift
+private var nameView: some View {
+    if isEditable {
+        TextField("Your name", text: $name)
+    } else {
+        Text(name)
+    }
+}
+```
+
+Avoid patterns like:
+
+```swift
+private var nameView: some View {
+    if isEditable {
+        return AnyView(TextField("Your name", text: $name))
+    } else {
+        return AnyView(Text(name))
+    }
+}
+```
+
+Because `AnyView` erases type information, SwiftUI loses some optimization opportunities. Prefer `@ViewBuilder` or conditional branches with concrete view types.
+
+Use `AnyView` only when type erasure is truly necessary for API design.
+
+## UIViewRepresentable Essentials
+
+When bridging UIKit views into SwiftUI:
+
+- `makeUIView(context:)` is called **once** to create the UIKit view
+- `updateUIView(_:context:)` is called on **every SwiftUI redraw** to sync state
+- The representable struct itself is **recreated on every redraw** -- avoid heavy work in its init
+- Use a `Coordinator` for delegate callbacks and two-way communication
+
+```swift
+struct MapView: UIViewRepresentable {
+    let coordinate: CLLocationCoordinate2D
+
+    func makeUIView(context: Context) -> MKMapView {
+        let map = MKMapView()
+        map.delegate = context.coordinator
+        return map
+    }
+
+    func updateUIView(_ map: MKMapView, context: Context) {
+        map.setCenter(coordinate, animated: true)
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    class Coordinator: NSObject, MKMapViewDelegate { }
+}
+```
+
+## Troubleshooting
+
+### Debug SwiftUI Renderings
+
+If it is needed to debug render cycles and read console output you can leverage the `_printChanges()` or `_logChanges()` methods on `View`. These methods print information about when the view is being evaluated and what changes are triggering updates. This can be very helpful when your view body is called multiple times and you want to know why.
+
+```swift
+struct ContentView: View {
+    @State private var counter: Int = 99
+
+    init() {
+        print(Self.self, #function)
+    }
+
+    var body: some View {
+        let _ = Self._printChanges()
+
+        VStack {
+            Text("Counter: \(counter)")
+            Button {
+                counter += 1
+            } label: {
+                Text("Counter +1")
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding()
+    }
+}
+```
+
+As an alternative to `Self._printChanges()`, you can use `_logChanges()`
+
+```swift
+struct ContentView: View {
+    @State private var counter: Int = 99
+
+    var body: some View {
+        let _ = Self._logChanges()
+
+        VStack {
+            Text("Counter: \(counter)")
+            Button {
+                counter += 1
+            } label: {
+                Text("Counter +1")
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding()
+    }
+}
+```
+
+Use these tools only for debugging and remove them from production code.
+
+### Handling "The Compiler Is Unable to Type-Check This Expression in Reasonable Time"
+
+If you encounter:
+
+> The compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions
+
+it is often caused by overly complex view structures or expressions.
+
+Ways to fix it:
+
+- break large expressions into smaller computed values
+- extract subviews
+- split long modifier chains
+- simplify nested generics and builders
+- avoid huge inline closures
+
+## Summary Checklist
+
+- [ ] Follow a consistent view file structure (Environment → State → Private → Init → Body → Subviews)
+- [ ] Prefer modifiers over conditional views for state changes
+- [ ] Avoid `if`-based conditional modifier extensions (they break view identity)
+- [ ] Extract complex views into separate subviews, not computed properties
+- [ ] Keep views small for readability and performance
+- [ ] Use `@ViewBuilder` only where it actually adds value
+- [ ] Avoid heavy filtering, mapping, sorting, or formatter creation inside `body`
+- [ ] Use lazy containers for large data sets
+- [ ] Container views use `@ViewBuilder let content: Content`
+- [ ] Prefer `overlay` / `background` for decoration and `ZStack` for peer composition
+- [ ] `.compositingGroup()` before `.clipShape()` on layered views to avoid antialiasing fringes
+- [ ] Split state-heavy areas into smaller view types
+- [ ] Extract repeated styling into `ViewModifier` or `ButtonStyle`
+- [ ] Expose reusable styles via static member lookup when it improves discoverability
+- [ ] Use `.redacted(reason: .placeholder)` for loading skeletons
+- [ ] Avoid `AnyView` unless type erasure is truly needed
+- [ ] In `UIViewRepresentable`, keep heavy work out of struct init
+- [ ] Use `_printChanges()` / `_logChanges()` to debug rendering behavior
+- [ ] Break up overly complex expressions when the compiler struggles

--- a/.agents/skills/xcode-build-benchmark/SKILL.md
+++ b/.agents/skills/xcode-build-benchmark/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: xcode-build-benchmark
+description: Benchmark Xcode clean and incremental builds with repeatable inputs, timing summaries, and timestamped `.build-benchmark/` artifacts. Use when a developer wants a baseline, wants to compare before and after changes, asks to measure build performance, mentions build times, build duration, how long builds take, or wants to know if builds got faster or slower.
+---
+
+# Xcode Build Benchmark
+
+Use this skill to produce a repeatable Xcode build baseline before anyone tries to optimize build times.
+
+## Core Rules
+
+- Measure before recommending changes.
+- Capture clean and incremental builds separately.
+- Keep the command, destination, configuration, scheme, and warm-up rules consistent across runs.
+- Write a timestamped JSON artifact to `.build-benchmark/`.
+- Do not change project files as part of benchmarking.
+
+## Inputs To Collect
+
+Confirm or infer:
+
+- workspace or project path
+- scheme
+- configuration
+- destination
+- whether the user wants simulator or device numbers
+- whether a custom `DerivedData` path is needed
+
+If the project has both clean-build and incremental-build pain, benchmark both. That is the default.
+
+## Worktree Considerations
+
+When benchmarking inside a git worktree, SPM packages with `exclude:` paths that reference gitignored directories (e.g., `__Snapshots__`) will cause `xcodebuild -resolvePackageDependencies` to crash. Create those missing directories before running any builds.
+
+## Default Workflow
+
+1. Normalize the build command and note every flag that affects caching or module reuse.
+2. Run one warm-up build if needed to validate that the command succeeds.
+3. Run 3 clean builds.
+4. If `COMPILATION_CACHE_ENABLE_CACHING = YES` is detected, run 3 cached clean builds. These measure clean build time with a warm compilation cache -- the realistic scenario for branch switching, pulling changes, or Clean Build Folder. The script handles this automatically by building once to warm the cache, then deleting DerivedData (but not the compilation cache) before each measured run. Pass `--no-cached-clean` to skip.
+5. Run 3 zero-change builds (build immediately after a successful build with no edits). This measures the fixed overhead floor: dependency computation, project description transfer, build description creation, script phases, codesigning, and validation. A zero-change build that takes more than a few seconds indicates avoidable per-build overhead. Use the default `benchmark_builds.py` invocation (no `--touch-file` flag).
+6. Optionally run 3 incremental builds with a file touch to measure a real edit-rebuild loop. Use `--touch-file path/to/SomeFile.swift` to touch a representative source file before each build.
+7. Save the raw results and summary into `.build-benchmark/`.
+8. Report medians and spread, not just the single fastest run.
+
+## Preferred Command Path
+
+Use the shared helper when possible:
+
+```bash
+python3 scripts/benchmark_builds.py \
+  --workspace App.xcworkspace \
+  --scheme MyApp \
+  --configuration Debug \
+  --destination "platform=iOS Simulator,name=iPhone 16" \
+  --output-dir .build-benchmark
+```
+
+If you cannot use the helper script, run equivalent `xcodebuild` commands with `-showBuildTimingSummary` and preserve the raw output.
+
+## Required Output
+
+Return:
+
+- clean build median, min, max
+- cached clean build median, min, max (when COMPILATION_CACHE_ENABLE_CACHING is enabled)
+- zero-change build median, min, max (fixed overhead floor)
+- incremental build median, min, max (if `--touch-file` was used)
+- biggest timing-summary categories
+- environment details that could affect comparisons
+- path to the saved artifact
+
+If results are noisy, say so and recommend rerunning under calmer conditions.
+
+## When To Stop
+
+Stop after measurement if the user only asked for benchmarking. If they want optimization guidance, hand off the artifact to the relevant specialist by reading its SKILL.md and applying its workflow to the same project context:
+
+- [`xcode-compilation-analyzer`](../xcode-compilation-analyzer/SKILL.md)
+- [`xcode-project-analyzer`](../xcode-project-analyzer/SKILL.md)
+- [`spm-build-analysis`](../spm-build-analysis/SKILL.md)
+- [`xcode-build-orchestrator`](../xcode-build-orchestrator/SKILL.md) for full orchestration
+
+## Additional Resources
+
+- For the benchmark contract, see [references/benchmarking-workflow.md](references/benchmarking-workflow.md)
+- For the shared artifact format, see [references/benchmark-artifacts.md](references/benchmark-artifacts.md)
+- For the JSON schema, see [schemas/build-benchmark.schema.json](schemas/build-benchmark.schema.json)

--- a/.agents/skills/xcode-build-benchmark/references/benchmark-artifacts.md
+++ b/.agents/skills/xcode-build-benchmark/references/benchmark-artifacts.md
@@ -1,0 +1,94 @@
+# Benchmark Artifacts
+
+All skills in this repository should treat `.build-benchmark/` as the canonical location for measured build evidence.
+
+## Goals
+
+- Keep build measurements reproducible.
+- Make clean and incremental build data easy to compare.
+- Preserve enough context for later specialist analysis without rerunning the benchmark.
+
+## Wall-Clock vs Cumulative Task Time
+
+The `duration_seconds` field on each run and the `median_seconds` in the summary represent **wall-clock time** -- how long the developer actually waits. This is the primary success metric.
+
+The `timing_summary_categories` are **aggregated task times** parsed from Xcode's Build Timing Summary. Because Xcode runs many tasks in parallel across CPU cores, these totals typically exceed the wall-clock duration. A large cumulative `SwiftCompile` value is diagnostic evidence of compiler workload, not proof that compilation is blocking the build. Always compare category totals against the wall-clock median before concluding that a category is a bottleneck.
+
+## File Layout
+
+Recommended outputs:
+
+- `.build-benchmark/<timestamp>-<scheme>.json`
+- `.build-benchmark/<timestamp>-<scheme>-clean-1.log`
+- `.build-benchmark/<timestamp>-<scheme>-clean-2.log`
+- `.build-benchmark/<timestamp>-<scheme>-clean-3.log`
+- `.build-benchmark/<timestamp>-<scheme>-cached-clean-1.log` (when COMPILATION_CACHE_ENABLE_CACHING is enabled)
+- `.build-benchmark/<timestamp>-<scheme>-cached-clean-2.log`
+- `.build-benchmark/<timestamp>-<scheme>-cached-clean-3.log`
+- `.build-benchmark/<timestamp>-<scheme>-incremental-1.log`
+- `.build-benchmark/<timestamp>-<scheme>-incremental-2.log`
+- `.build-benchmark/<timestamp>-<scheme>-incremental-3.log`
+
+Use an ISO-like UTC timestamp without spaces so the files sort naturally.
+
+## Artifact Requirements
+
+Each JSON artifact should include:
+
+- schema version
+- creation timestamp
+- project context
+- environment details when available
+- the normalized build command
+- separate `clean` and `incremental` run arrays
+- summary statistics for each build type
+- parsed timing-summary categories
+- free-form notes for caveats or noise
+
+## Clean, Cached Clean, And Incremental Separation
+
+Do not merge different build type measurements into a single list. They answer different questions:
+
+- **Clean builds** show full build-system, package, and module setup cost with a cold compilation cache.
+- **Cached clean builds** show clean build cost when the compilation cache is warm. This is the realistic scenario for branch switching, pulling changes, or Clean Build Folder. Only present when `COMPILATION_CACHE_ENABLE_CACHING = YES` is detected.
+- **Incremental builds** show edit-loop productivity and script or cache invalidation problems.
+
+## Raw Logs
+
+Store raw `xcodebuild` output beside the JSON artifact whenever possible. That allows later skills to:
+
+- re-parse timing summaries
+- inspect failed builds
+- search for long type-check warnings
+- correlate build-system phases with recommendations
+
+## Measurement Caveats
+
+### COMPILATION_CACHE_ENABLE_CACHING
+
+`COMPILATION_CACHE_ENABLE_CACHING = YES` stores compiled artifacts in a system-managed cache outside DerivedData so that repeated compilations of identical inputs are served from cache. The standard clean-build benchmark (`xcodebuild clean` between runs) may add overhead from cache population without showing the corresponding cache-hit benefit.
+
+The benchmark script automatically detects `COMPILATION_CACHE_ENABLE_CACHING = YES` and runs a **cached clean** benchmark phase. This phase:
+
+1. Builds once to warm the compilation cache.
+2. Deletes DerivedData (but not the compilation cache) before each measured run.
+3. Rebuilds, measuring the cache-hit clean build time.
+
+The cached clean metric captures the realistic developer experience: branch switching, pulling changes, and Clean Build Folder. Use the cached clean median as the primary comparison metric when evaluating `COMPILATION_CACHE_ENABLE_CACHING` impact.
+
+To skip this phase, pass `--no-cached-clean`.
+
+### First-Run Variance
+
+The first clean build after the warmup cycle often runs 20-40% slower than subsequent clean builds due to cold OS-level caches (disk I/O, dynamic linker cache, etc.). The benchmark script mitigates this by running a warmup clean+build cycle before measured runs. If variance between the first and later clean runs is still high, prefer the median or min over the mean, and note the variance in the artifact's `notes` field.
+
+## Shared Consumer Expectations
+
+Any skill reading a benchmark artifact should be able to identify:
+
+- what was measured
+- how it was measured
+- whether the run succeeded
+- whether the results are stable enough to compare
+
+For the authoritative field-level schema, see [../schemas/build-benchmark.schema.json](../schemas/build-benchmark.schema.json).

--- a/.agents/skills/xcode-build-benchmark/references/benchmarking-workflow.md
+++ b/.agents/skills/xcode-build-benchmark/references/benchmarking-workflow.md
@@ -1,0 +1,67 @@
+# Benchmarking Workflow
+
+Use this reference when you need the full operational contract for collecting Xcode build measurements.
+
+## Goal
+
+Produce a benchmark artifact that another skill can trust without rerunning the same setup discovery.
+
+## Benchmark Contract
+
+- Measure both clean and incremental builds unless the user narrows the scope.
+- Use the same scheme, configuration, destination, and command flags for all measured runs.
+- Record the exact command and any environment overrides.
+- Keep clean and incremental runs in separate arrays in the artifact.
+- Save wall-clock timing plus any parsed timing-summary categories.
+
+## Suggested Run Counts
+
+- Clean builds: 3 measured runs
+- Incremental builds: 3 measured runs
+- Warm-up: 0 to 1 validation run, excluded from the summary unless the user explicitly wants it included
+
+## Clean Build Rules
+
+- Clear build products with `xcodebuild clean` or an equivalent clean-build-folder step before each measured clean run.
+- Do not change scheme, destination, or configuration between runs.
+- If the command fails, store the failure and stop rather than mixing failed and successful runs.
+
+## Incremental Build Rules
+
+- Use the same build command after a successful baseline build.
+- Do not clean between incremental runs.
+- If the user wants edit-loop benchmarking, note the file change strategy explicitly in the artifact.
+- If there are no source edits between runs, label the result as no-edit incremental timing.
+
+## What To Capture
+
+At minimum, keep:
+
+- timestamp
+- host machine info if available
+- Xcode version if available
+- workspace or project path
+- scheme, configuration, destination
+- exact `xcodebuild` command
+- duration per run
+- success or failure
+- parsed timing-summary categories
+- notes on warm-up behavior or unusual noise
+
+## Reporting Guidance
+
+Use medians for the headline number. Also include:
+
+- min and max
+- range
+- category totals from the timing summary
+- obvious outliers or instability
+
+## Handoff Expectations
+
+The next optimization skill should be able to answer:
+
+- Is the main problem clean, incremental, or both?
+- Which build categories dominate time?
+- Which command produced the evidence?
+- Is the baseline trustworthy enough to compare before and after changes?

--- a/.agents/skills/xcode-build-benchmark/schemas/build-benchmark.schema.json
+++ b/.agents/skills/xcode-build-benchmark/schemas/build-benchmark.schema.json
@@ -1,0 +1,230 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Xcode Build Benchmark Artifact",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "created_at",
+    "build",
+    "runs",
+    "summary"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": ["1.0.0", "1.1.0", "1.2.0"]
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "build": {
+      "type": "object",
+      "required": [
+        "entrypoint",
+        "scheme",
+        "configuration",
+        "destination",
+        "command"
+      ],
+      "properties": {
+        "entrypoint": {
+          "type": "string",
+          "enum": [
+            "project",
+            "workspace"
+          ]
+        },
+        "path": {
+          "type": "string"
+        },
+        "scheme": {
+          "type": "string"
+        },
+        "configuration": {
+          "type": "string"
+        },
+        "destination": {
+          "type": "string"
+        },
+        "derived_data_path": {
+          "type": "string"
+        },
+        "command": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "environment": {
+      "type": "object",
+      "properties": {
+        "host": {
+          "type": "string"
+        },
+        "xcode_version": {
+          "type": "string"
+        },
+        "macos_version": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "runs": {
+      "type": "object",
+      "required": [
+        "clean",
+        "incremental"
+      ],
+      "properties": {
+        "clean": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/run"
+          }
+        },
+        "cached_clean": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/run"
+          }
+        },
+        "incremental": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/run"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "summary": {
+      "type": "object",
+      "required": [
+        "clean",
+        "incremental"
+      ],
+      "properties": {
+        "clean": {
+          "$ref": "#/definitions/stats"
+        },
+        "cached_clean": {
+          "$ref": "#/definitions/stats"
+        },
+        "incremental": {
+          "$ref": "#/definitions/stats"
+        }
+      },
+      "additionalProperties": false
+    },
+    "notes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "definitions": {
+    "run": {
+      "type": "object",
+      "required": [
+        "id",
+        "build_type",
+        "duration_seconds",
+        "success",
+        "command"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "build_type": {
+          "type": "string",
+          "enum": [
+            "clean",
+            "cached-clean",
+            "incremental"
+          ]
+        },
+        "duration_seconds": {
+          "type": "number",
+          "minimum": 0
+        },
+        "success": {
+          "type": "boolean"
+        },
+        "command": {
+          "type": "string"
+        },
+        "exit_code": {
+          "type": "integer"
+        },
+        "raw_log_path": {
+          "type": "string"
+        },
+        "timing_summary_categories": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/category"
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "category": {
+      "type": "object",
+      "required": [
+        "name",
+        "seconds"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "seconds": {
+          "type": "number",
+          "minimum": 0
+        },
+        "task_count": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": true
+    },
+    "stats": {
+      "type": "object",
+      "required": [
+        "count",
+        "min_seconds",
+        "max_seconds",
+        "median_seconds",
+        "average_seconds"
+      ],
+      "properties": {
+        "count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "min_seconds": {
+          "type": "number",
+          "minimum": 0
+        },
+        "max_seconds": {
+          "type": "number",
+          "minimum": 0
+        },
+        "median_seconds": {
+          "type": "number",
+          "minimum": 0
+        },
+        "average_seconds": {
+          "type": "number",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/.agents/skills/xcode-build-benchmark/scripts/benchmark_builds.py
+++ b/.agents/skills/xcode-build-benchmark/scripts/benchmark_builds.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import platform
+import re
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Benchmark Xcode clean and incremental builds.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--workspace", help="Path to the .xcworkspace file")
+    group.add_argument("--project", help="Path to the .xcodeproj file")
+    parser.add_argument("--scheme", required=True, help="Scheme to build")
+    parser.add_argument("--configuration", default="Debug", help="Build configuration")
+    parser.add_argument("--destination", help="xcodebuild destination string")
+    parser.add_argument("--derived-data-path", help="DerivedData path override")
+    parser.add_argument("--output-dir", default=".build-benchmark", help="Output directory for artifacts")
+    parser.add_argument("--repeats", type=int, default=3, help="Measured runs per build type")
+    parser.add_argument("--skip-warmup", action="store_true", help="Skip the validation build")
+    parser.add_argument(
+        "--touch-file",
+        help="Path to a source file to touch before each incremental build. "
+        "When provided, measures a real edit-rebuild loop instead of a zero-change build.",
+    )
+    parser.add_argument(
+        "--no-cached-clean",
+        action="store_true",
+        help="Skip cached clean builds even when COMPILATION_CACHE_ENABLE_CACHING is detected.",
+    )
+    parser.add_argument(
+        "--extra-arg",
+        action="append",
+        default=[],
+        help="Additional xcodebuild argument to append. Can be passed multiple times.",
+    )
+    return parser.parse_args()
+
+
+def command_base(args: argparse.Namespace) -> List[str]:
+    command = ["xcodebuild"]
+    if args.workspace:
+        command.extend(["-workspace", args.workspace])
+    if args.project:
+        command.extend(["-project", args.project])
+    command.extend(["-scheme", args.scheme, "-configuration", args.configuration])
+    if args.destination:
+        command.extend(["-destination", args.destination])
+    if args.derived_data_path:
+        command.extend(["-derivedDataPath", args.derived_data_path])
+    command.extend(args.extra_arg)
+    return command
+
+
+def shell_join(parts: List[str]) -> str:
+    return " ".join(subprocess.list2cmdline([part]) for part in parts)
+
+
+_TASK_COUNT_RE = re.compile(r"^(.+?)\s*\((\d+)\s+tasks?\)$")
+
+
+def _extract_task_count(name: str) -> tuple[str, Optional[int]]:
+    """Split 'Category (N tasks)' into ('Category', N)."""
+    match = _TASK_COUNT_RE.match(name)
+    if match:
+        return match.group(1).strip(), int(match.group(2))
+    return name, None
+
+
+def parse_timing_summary(output: str) -> List[Dict]:
+    categories: Dict[str, float] = {}
+    task_counts: Dict[str, Optional[int]] = {}
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        for suffix in (" seconds", " second", " sec"):
+            if not line.endswith(suffix):
+                continue
+            trimmed = line[: -len(suffix)]
+            if "|" in trimmed:
+                name_part, _, seconds_text = trimmed.rpartition("|")
+            else:
+                name_part, _, seconds_text = trimmed.rpartition(" ")
+            try:
+                seconds = float(seconds_text.strip())
+            except ValueError:
+                continue
+            cleaned_name = name_part.replace("  ", " ").strip(" -:")
+            if len(cleaned_name) < 3:
+                continue
+            base_name, count = _extract_task_count(cleaned_name)
+            categories[base_name] = categories.get(base_name, 0.0) + seconds
+            if count is not None:
+                task_counts[base_name] = (task_counts.get(base_name) or 0) + count
+            break
+    result: List[Dict] = []
+    for name, seconds in sorted(categories.items(), key=lambda item: item[1], reverse=True):
+        entry: Dict = {"name": name, "seconds": round(seconds, 3)}
+        if name in task_counts:
+            entry["task_count"] = task_counts[name]
+        result.append(entry)
+    return result
+
+
+def run_command(command: List[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(command, capture_output=True, text=True)
+
+
+def stats_for(runs: List[Dict[str, object]]) -> Dict[str, float]:
+    durations = [run["duration_seconds"] for run in runs if run.get("success")]
+    if not durations:
+        return {
+            "count": 0,
+            "min_seconds": 0.0,
+            "max_seconds": 0.0,
+            "median_seconds": 0.0,
+            "average_seconds": 0.0,
+        }
+    return {
+        "count": len(durations),
+        "min_seconds": round(min(durations), 3),
+        "max_seconds": round(max(durations), 3),
+        "median_seconds": round(statistics.median(durations), 3),
+        "average_seconds": round(statistics.fmean(durations), 3),
+    }
+
+
+def xcode_version() -> str:
+    result = run_command(["xcodebuild", "-version"])
+    return result.stdout.strip() if result.returncode == 0 else "unknown"
+
+
+def detect_compilation_caching(base_command: List[str]) -> bool:
+    """Check whether COMPILATION_CACHE_ENABLE_CACHING is enabled in the resolved build settings."""
+    result = run_command([*base_command, "-showBuildSettings"])
+    if result.returncode != 0:
+        return False
+    for line in result.stdout.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("COMPILATION_CACHE_ENABLE_CACHING") and "=" in stripped:
+            value = stripped.split("=", 1)[1].strip()
+            return value == "YES"
+    return False
+
+
+def measure_build(
+    base_command: List[str],
+    artifact_stem: str,
+    output_dir: Path,
+    build_type: str,
+    run_index: int,
+) -> Dict[str, object]:
+    build_command = [*base_command, "build", "-showBuildTimingSummary"]
+    started = time.perf_counter()
+    result = run_command(build_command)
+    elapsed = round(time.perf_counter() - started, 3)
+    log_path = output_dir / f"{artifact_stem}-{build_type}-{run_index}.log"
+    log_path.write_text(result.stdout + result.stderr)
+    return {
+        "id": f"{build_type}-{run_index}",
+        "build_type": build_type,
+        "duration_seconds": elapsed,
+        "success": result.returncode == 0,
+        "exit_code": result.returncode,
+        "command": shell_join(build_command),
+        "raw_log_path": str(log_path),
+        "timing_summary_categories": parse_timing_summary(result.stdout + result.stderr),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    artifact_stem = f"{timestamp}-{args.scheme.replace(' ', '-').lower()}"
+    base_command = command_base(args)
+
+    if not args.skip_warmup:
+        warmup = run_command([*base_command, "build"])
+        if warmup.returncode != 0:
+          sys.stderr.write(warmup.stdout + warmup.stderr)
+          return warmup.returncode
+        warmup_clean = run_command([*base_command, "clean"])
+        if warmup_clean.returncode != 0:
+            sys.stderr.write(warmup_clean.stdout + warmup_clean.stderr)
+            return warmup_clean.returncode
+        warmup_rebuild = run_command([*base_command, "build"])
+        if warmup_rebuild.returncode != 0:
+            sys.stderr.write(warmup_rebuild.stdout + warmup_rebuild.stderr)
+            return warmup_rebuild.returncode
+
+    runs: Dict[str, list] = {"clean": [], "incremental": []}
+
+    for index in range(1, args.repeats + 1):
+        clean_result = run_command([*base_command, "clean"])
+        clean_log_path = output_dir / f"{artifact_stem}-clean-prep-{index}.log"
+        clean_log_path.write_text(clean_result.stdout + clean_result.stderr)
+        if clean_result.returncode != 0:
+            sys.stderr.write(clean_result.stdout + clean_result.stderr)
+            return clean_result.returncode
+        runs["clean"].append(measure_build(base_command, artifact_stem, output_dir, "clean", index))
+
+    # --- Cached clean builds ---------------------------------------------------
+    # When COMPILATION_CACHE_ENABLE_CACHING is enabled, the compilation cache lives outside
+    # DerivedData and survives product deletion.  We measure "cached clean"
+    # builds by pointing DerivedData at a temp directory, warming the cache with
+    # one build, then deleting the DerivedData directory (but not the cache)
+    # before each measured rebuild.  This captures the realistic scenario:
+    # branch switching, pulling changes, or Clean Build Folder.
+    should_cached_clean = not args.no_cached_clean and detect_compilation_caching(base_command)
+    if should_cached_clean:
+        dd_path = Path(args.derived_data_path) if args.derived_data_path else Path(
+            tempfile.mkdtemp(prefix="xcode-bench-dd-")
+        )
+        cached_cmd = list(base_command)
+        if not args.derived_data_path:
+            cached_cmd.extend(["-derivedDataPath", str(dd_path)])
+
+        cache_warmup = run_command([*cached_cmd, "build"])
+        if cache_warmup.returncode != 0:
+            sys.stderr.write("Warning: cached clean warmup build failed, skipping cached clean benchmarks.\n")
+            sys.stderr.write(cache_warmup.stdout + cache_warmup.stderr)
+            should_cached_clean = False
+
+    if should_cached_clean:
+        runs["cached_clean"] = []
+        for index in range(1, args.repeats + 1):
+            shutil.rmtree(dd_path, ignore_errors=True)
+            runs["cached_clean"].append(
+                measure_build(cached_cmd, artifact_stem, output_dir, "cached-clean", index)
+            )
+        shutil.rmtree(dd_path, ignore_errors=True)
+
+    # --- Incremental / zero-change builds --------------------------------------
+    incremental_label = "incremental"
+    if args.touch_file:
+        touch_path = Path(args.touch_file)
+        if not touch_path.exists():
+            sys.stderr.write(f"--touch-file path does not exist: {touch_path}\n")
+            return 1
+        incremental_label = "incremental"
+    else:
+        incremental_label = "zero-change"
+
+    for index in range(1, args.repeats + 1):
+        if args.touch_file:
+            touch_path.touch()
+        runs["incremental"].append(
+            measure_build(base_command, artifact_stem, output_dir, incremental_label, index)
+        )
+
+    summary: Dict[str, object] = {
+        "clean": stats_for(runs["clean"]),
+        "incremental": stats_for(runs["incremental"]),
+    }
+    if "cached_clean" in runs:
+        summary["cached_clean"] = stats_for(runs["cached_clean"])
+
+    artifact = {
+        "schema_version": "1.2.0" if "cached_clean" in runs else "1.1.0",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "build": {
+            "entrypoint": "workspace" if args.workspace else "project",
+            "path": args.workspace or args.project,
+            "scheme": args.scheme,
+            "configuration": args.configuration,
+            "destination": args.destination or "",
+            "derived_data_path": args.derived_data_path or "",
+            "command": shell_join(base_command),
+        },
+        "environment": {
+            "host": platform.node(),
+            "macos_version": platform.platform(),
+            "xcode_version": xcode_version(),
+            "cwd": os.getcwd(),
+        },
+        "runs": runs,
+        "summary": summary,
+        "notes": [f"touch-file: {args.touch_file}"] if args.touch_file else [],
+    }
+
+    artifact_path = output_dir / f"{artifact_stem}.json"
+    artifact_path.write_text(json.dumps(artifact, indent=2) + "\n")
+
+    print(f"Saved benchmark artifact: {artifact_path}")
+    print(f"Clean median: {artifact['summary']['clean']['median_seconds']}s")
+    if "cached_clean" in artifact["summary"]:
+        print(f"Cached clean median: {artifact['summary']['cached_clean']['median_seconds']}s")
+    inc_label = "Incremental" if args.touch_file else "Zero-change"
+    print(f"{inc_label} median: {artifact['summary']['incremental']['median_seconds']}s")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/xcode-build-fixer/SKILL.md
+++ b/.agents/skills/xcode-build-fixer/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: xcode-build-fixer
+description: Apply approved Xcode build optimization changes following best practices, then re-benchmark to verify improvement. Use when a developer has an approved optimization plan from xcode-build-orchestrator, wants to apply specific build fixes, needs help implementing build setting changes, script phase guards, source-level compilation fixes, or SPM restructuring that was recommended by an analysis skill.
+---
+
+# Xcode Build Fixer
+
+Use this skill to implement approved build optimization changes and verify them with a benchmark.
+
+## Core Rules
+
+- Only apply changes that have explicit developer approval.
+- Apply one logical fix at a time so changes are reviewable and reversible.
+- Re-benchmark after applying changes to verify improvement.
+- Report exactly what changed, which files were touched, and the measured delta.
+- If a change produces no improvement or causes a regression, flag it immediately.
+
+## Inputs
+
+The fixer expects one of:
+
+- An approved optimization plan at `.build-benchmark/optimization-plan.md` with checked approval boxes.
+- An explicit developer instruction describing the fix to apply (e.g., "set `DEBUG_INFORMATION_FORMAT` to `dwarf` for Debug").
+
+When working from an optimization plan, read the approval checklist and implement only the checked items.
+
+## Fix Categories
+
+### Build Settings
+
+Change `project.pbxproj` values to match the recommendations in [build-settings-best-practices.md](references/build-settings-best-practices.md).
+
+Typical fixes:
+
+- Set `DEBUG_INFORMATION_FORMAT = dwarf` for Debug
+- Set `SWIFT_COMPILATION_MODE = singlefile` for Debug
+- Enable `COMPILATION_CACHE_ENABLE_CACHING = YES`
+- Enable `EAGER_LINKING = YES` for Debug
+- Align cross-target settings to eliminate module variants
+
+When editing `project.pbxproj`, locate the correct `buildSettings` block by matching the target name and configuration name. Verify the change with `xcodebuild -showBuildSettings` after applying.
+
+### Script Phases
+
+Fix run script phases that waste time during incremental or debug builds.
+
+Typical fixes:
+
+- Add input and output file declarations so Xcode can skip unchanged scripts.
+- Add configuration guards: `[[ "$CONFIGURATION" != "Release" ]] && exit 0` for release-only scripts.
+- Move input/output lists into `.xcfilelist` files when the list is long.
+- Enable `Based on dependency analysis` when inputs and outputs are declared.
+
+### Source-Level Compilation Fixes
+
+Apply code changes that reduce type-checker and compiler overhead. See [references/fix-patterns.md](references/fix-patterns.md) for before/after patterns.
+
+Typical fixes:
+
+- Add explicit type annotations to complex expressions.
+- Break long chained or nested expressions into intermediate typed variables.
+- Mark classes `final` when they are not subclassed.
+- Tighten access control (`private`/`fileprivate`) for internal-only symbols.
+- Extract monolithic SwiftUI `body` properties into smaller composed subviews.
+- Replace deeply nested result-builder code with separate typed helpers.
+- Add explicit return types to closures passed to generic functions.
+
+### SPM Restructuring
+
+Restructure Swift packages to improve build parallelism and reduce rebuild scope.
+
+Typical fixes:
+
+- Move shared types to a lower-layer module to eliminate circular or upward dependencies.
+- Split oversized modules (200+ files) by feature area.
+- Extract protocol definitions into lightweight interface modules.
+- Remove unnecessary `@_exported import` usage.
+- Align build options across targets that import the same packages to prevent module variant duplication.
+- Pin branch-tracked dependencies to tagged versions or commit hashes for deterministic resolution.
+
+Before applying version pin changes:
+
+- Run `git ls-remote --tags <url>` to confirm tags exist. If the upstream has no tags, pin to a specific revision hash instead.
+- Verify the pinned version resolves successfully with `xcodebuild -resolvePackageDependencies` before proceeding.
+
+## Execution Workflow
+
+1. Read the approved optimization plan or developer instruction.
+2. For each approved item, identify the exact files and locations to change.
+3. Apply the change.
+4. Verify the change compiles: run a quick `xcodebuild build` to confirm no errors were introduced.
+5. After all approved changes are applied, re-benchmark using the same inputs from the original baseline:
+   ```bash
+   python3 scripts/benchmark_builds.py \
+     --project App.xcodeproj \
+     --scheme MyApp \
+     --configuration Debug \
+     --destination "platform=iOS Simulator,name=iPhone 16" \
+     --output-dir .build-benchmark
+   ```
+6. Compare post-change medians to the baseline and report deltas.
+
+## Evaluating Regressions
+
+Not every slower number is a true regression. The fixer must evaluate the full picture before recommending a revert.
+
+### Compilation caching trade-off
+
+A change like `COMPILATION_CACHE_ENABLE_CACHING = YES` may make a standard clean build slightly slower (cache population overhead) while making cached clean builds significantly faster. Since cached clean builds reflect the realistic developer workflow (branch switching, pulling changes, Clean Build Folder with a warm cache), a slower standard clean build paired with a faster cached clean build is a net improvement, not a regression. The same logic applies to any change where the first-time cost is higher but subsequent builds benefit.
+
+### Compare all build types
+
+Evaluate standard clean, cached clean (when available), and incremental builds together. A change is only a clear regression if it makes the metrics that matter to the developer's daily workflow worse. If only the cold-start clean build is slower but the developer rarely does truly cold builds, that may be acceptable.
+
+### Per-change vs. cumulative
+
+A single change that regresses on its own may still be worth keeping if it enables a larger cumulative improvement (e.g., enabling compilation caching makes one build type slower but unlocks cache benefits for everything else).
+
+### Best-practice settings are not revert candidates
+
+Some build settings are Apple's recommended modern defaults. These should be applied and kept regardless of whether the immediate benchmark shows a measurable improvement. They are not speculative optimizations -- they align the project with Apple's toolchain direction and will compound in value over future Xcode releases. The fixer must never recommend reverting these settings based on a single benchmark result.
+
+Best-practice settings that should always be kept once applied:
+
+- `COMPILATION_CACHE_ENABLE_CACHING = YES` -- Apple is actively investing in this; the cache improves with each Xcode release and compounds across real workflows
+- `EAGER_LINKING = YES` (Debug) -- allows the linker to overlap with compilation
+- `SWIFT_USE_INTEGRATED_DRIVER = YES` -- eliminates inter-process scheduling overhead
+- `DEBUG_INFORMATION_FORMAT = dwarf` (Debug) -- avoids unnecessary dSYM generation
+- `SWIFT_COMPILATION_MODE = singlefile` (Debug) -- incremental recompilation
+- `ONLY_ACTIVE_ARCH = YES` (Debug) -- no reason to build all architectures locally
+
+When reporting on these settings, use language like: "Applied recommended build setting. No immediate benchmark improvement measured, but this aligns with Apple's recommended configuration and positions the project for future Xcode improvements."
+
+### When to recommend revert (speculative changes only)
+
+For changes that are not best-practice settings (e.g., source refactors, linkage experiments, script phase modifications, dependency restructuring):
+
+- If the cumulative pass shows wall-clock regression across all measured build types (standard clean, cached clean, and incremental are all slower), recommend reverting all speculative changes unless the developer explicitly asks to keep specific items for non-performance reasons.
+- For each individual speculative change: if it shows no median improvement and no cached/incremental benefit either, flag it with `Recommend revert` and the measured delta.
+- Distinguish between "outlier reduction only" (improved worst-case but not median) and "median improvement" (improved typical developer wait).
+- When a change trades off one build type for another (e.g., slower standard clean but faster cached clean), present both numbers clearly and let the developer decide. Frame it as: "Standard clean builds are X.Xs slower, but cached clean builds (the realistic daily workflow) are Y.Ys faster."
+
+## Reporting
+
+Lead with the wall-clock result in plain language:
+
+> "Your clean build now takes X.Xs (was Y.Ys) -- Z.Zs faster."
+> "Your incremental build now takes X.Xs (was Y.Ys) -- Z.Zs faster."
+
+Then include:
+
+- Post-change clean build wall-clock median
+- Post-change incremental build wall-clock median
+- Absolute and percentage wall-clock deltas for both
+- Confidence notes if benchmark noise is high
+- List of files modified per fix
+- Any deviations from the original recommendation
+
+If cumulative task metrics improved but wall-clock did not, say plainly: "Compiler workload decreased but build wait time did not improve. This is expected when Xcode runs these tasks in parallel with other equally long work."
+
+If a fix produced no measurable wall-time improvement, note `No measurable wall-time improvement` and suggest whether to keep (e.g. for code quality) or revert.
+
+For changes valuable for non-benchmark reasons (deterministic package resolution, branch-switch caching), label them: "No wait-time improvement expected from this change. The benefit is [deterministic builds / faster branch switching / reduced CI cost]."
+
+Note: `COMPILATION_CACHE_ENABLE_CACHING` has been measured at 5-14% faster clean builds across tested projects (87 to 1,991 Swift files). The benefit compounds in real developer workflows where the cache persists between builds -- branch switching, pulling changes, and CI with persistent DerivedData. The benchmark script auto-detects this setting and runs a cached clean phase for validation.
+
+## Execution Report
+
+After the optimization pass is complete, produce a structured execution report. This gives the developer a clear summary of what was attempted, what worked, and what the final state is.
+
+Structure:
+
+```markdown
+## Execution Report
+
+### Baseline
+- Clean build median: X.Xs
+- Cached clean build median: X.Xs (if applicable)
+- Incremental build median: X.Xs
+
+### Changes Applied
+
+| # | Change | Actionability | Measured Result | Status |
+|---|--------|---------------|-----------------|--------|
+| 1 | Description | repo-local | Clean: X.Xs→Y.Ys, Incr: X.Xs→Y.Ys | Kept / Reverted / Blocked |
+| 2 | ... | ... | ... | ... |
+
+### Final Cumulative Result
+- Clean build median: X.Xs (was Y.Ys) -- Z.Zs faster/slower
+- Cached clean build median: X.Xs (was Y.Ys) -- Z.Zs faster/slower
+- Incremental build median: X.Xs (was Y.Ys) -- Z.Zs faster/slower
+- **Net result:** Faster / Slower / Unchanged
+
+### Blocked or Non-Actionable Findings
+- Finding: reason it could not be addressed from the repo
+```
+
+Status values:
+
+- `Kept` -- Change improved or maintained build times and was kept.
+- `Kept (best practice)` -- Change is a recommended build setting; kept regardless of immediate benchmark result.
+- `Reverted` -- Change regressed build times and was reverted.
+- `Blocked` -- Change could not be applied due to project structure, Xcode behavior, or external constraints.
+- `No improvement` -- Change compiled but showed no measurable wall-time benefit. Include whether it was kept (for non-performance reasons) or reverted.
+
+## Escalation
+
+If during implementation you discover issues outside this skill's scope:
+
+- Project-level analysis gaps: hand off to [`xcode-project-analyzer`](../xcode-project-analyzer/SKILL.md)
+- Compilation hotspot analysis: hand off to [`xcode-compilation-analyzer`](../xcode-compilation-analyzer/SKILL.md)
+- Package graph issues: hand off to [`spm-build-analysis`](../spm-build-analysis/SKILL.md)
+
+## Additional Resources
+
+- For concrete before/after fix patterns, see [references/fix-patterns.md](references/fix-patterns.md)
+- For build settings best practices, see [references/build-settings-best-practices.md](references/build-settings-best-practices.md)
+- For the recommendation format, see [references/recommendation-format.md](references/recommendation-format.md)

--- a/.agents/skills/xcode-build-fixer/references/build-settings-best-practices.md
+++ b/.agents/skills/xcode-build-fixer/references/build-settings-best-practices.md
@@ -1,0 +1,216 @@
+# Build Settings Best Practices
+
+This reference lists Xcode build settings that affect build performance. Use it to audit a project and produce a pass/fail checklist.
+
+The scope is strictly **build performance**. Do not flag language-migration settings like `SWIFT_STRICT_CONCURRENCY` or `SWIFT_UPCOMING_FEATURE_*` -- those are developer adoption choices unrelated to build speed.
+
+## How To Read This Reference
+
+Each setting includes:
+
+- **Setting name** and the Xcode build-settings key
+- **Recommended value** for Debug and Release
+- **Why it matters** for build time
+- **Risk** of changing it
+
+Use checkmark and cross indicators when reporting:
+
+- `[x]` -- setting matches the recommended value
+- `[ ]` -- setting does not match; include the actual value and the expected value
+
+## Debug Configuration
+
+These settings optimize for fast iteration during development.
+
+### Compilation Mode
+
+- **Key:** `SWIFT_COMPILATION_MODE`
+- **Recommended:** `singlefile` (Xcode UI: "Incremental"; or unset -- Xcode defaults to singlefile for Debug)
+- **Why:** Single-file mode recompiles only changed files. `wholemodule` recompiles the entire target on every change.
+- **Risk:** Low
+
+### Swift Optimization Level
+
+- **Key:** `SWIFT_OPTIMIZATION_LEVEL`
+- **Recommended:** `-Onone`
+- **Why:** Optimization passes add significant compile time. Debug builds do not benefit from runtime speed improvements.
+- **Risk:** Low
+
+### GCC Optimization Level
+
+- **Key:** `GCC_OPTIMIZATION_LEVEL`
+- **Recommended:** `0`
+- **Why:** Same rationale as Swift optimization level, but for C/C++/Objective-C sources.
+- **Risk:** Low
+
+### Build Active Architecture Only
+
+- **Key:** `ONLY_ACTIVE_ARCH` (`BUILD_ACTIVE_ARCHITECTURE_ONLY`)
+- **Recommended:** `YES`
+- **Why:** Building all architectures doubles or triples compile and link time for no debug benefit.
+- **Risk:** Low
+
+### Debug Information Format
+
+- **Key:** `DEBUG_INFORMATION_FORMAT`
+- **Recommended:** `dwarf`
+- **Why:** `dwarf-with-dsym` generates a separate dSYM bundle which adds overhead. Plain `dwarf` embeds debug info directly in the binary, which is sufficient for local debugging.
+- **Risk:** Low
+
+### Enable Testability
+
+- **Key:** `ENABLE_TESTABILITY`
+- **Recommended:** `YES`
+- **Why:** Required for `@testable import`. Adds minor overhead by exporting internal symbols, but this is expected during development.
+- **Risk:** Low
+
+### Active Compilation Conditions
+
+- **Key:** `SWIFT_ACTIVE_COMPILATION_CONDITIONS`
+- **Recommended:** Should include `DEBUG`
+- **Why:** Guards conditional compilation blocks (e.g., `#if DEBUG`) and ensures debug-only code paths are included.
+- **Risk:** Low
+
+### Eager Linking
+
+- **Key:** `EAGER_LINKING`
+- **Recommended:** `YES`
+- **Why:** Allows the linker to start work before all compilation tasks finish, reducing wall-clock build time. Particularly effective for Debug builds where link time is a meaningful fraction of total build time.
+- **Risk:** Low
+
+## Release Configuration
+
+These settings optimize for production builds.
+
+### Compilation Mode
+
+- **Key:** `SWIFT_COMPILATION_MODE`
+- **Recommended:** `wholemodule`
+- **Why:** Whole-module optimization produces faster runtime code. Build time is secondary for release.
+- **Risk:** Low
+
+### Swift Optimization Level
+
+- **Key:** `SWIFT_OPTIMIZATION_LEVEL`
+- **Recommended:** `-O` or `-Osize`
+- **Why:** Produces optimized binaries. `-Osize` trades some speed for smaller binary size.
+- **Risk:** Low
+
+### GCC Optimization Level
+
+- **Key:** `GCC_OPTIMIZATION_LEVEL`
+- **Recommended:** `s`
+- **Why:** Optimizes C/C++/Objective-C for size, matching the typical release expectation.
+- **Risk:** Low
+
+### Build Active Architecture Only
+
+- **Key:** `ONLY_ACTIVE_ARCH`
+- **Recommended:** `NO`
+- **Why:** Release builds must include all supported architectures for distribution.
+- **Risk:** Low
+
+### Debug Information Format
+
+- **Key:** `DEBUG_INFORMATION_FORMAT`
+- **Recommended:** `dwarf-with-dsym`
+- **Why:** dSYM bundles are required for crash symbolication in production.
+- **Risk:** Low
+
+### Enable Testability
+
+- **Key:** `ENABLE_TESTABILITY`
+- **Recommended:** `NO`
+- **Why:** Removes internal-symbol export overhead from release builds. Testing should use Debug configuration.
+- **Risk:** Low
+
+## General (All Configurations)
+
+### Compilation Caching
+
+- **Key:** `COMPILATION_CACHE_ENABLE_CACHING`
+- **Recommended:** `YES`
+- **Why:** Caches compilation results for Swift and C-family sources so repeated compilations of the same inputs are served from cache. The biggest wins come from branch switching and clean builds where source files are recompiled unchanged. This is an opt-in feature. The umbrella setting controls both `SWIFT_ENABLE_COMPILE_CACHE` and `CLANG_ENABLE_COMPILE_CACHE` under the hood; those can be toggled independently if needed.
+- **Measurement:** Measured 5-14% faster clean builds across tested projects (87 to 1,991 Swift files). The benefit compounds in real developer workflows where the cache persists between builds -- branch switching, pulling changes, and CI with persistent DerivedData -- though the exact savings depend on how many files change between builds.
+- **Risk:** Low -- can also be enabled via per-user project settings so it does not need to be committed to the shared project file.
+
+### Integrated Swift Driver
+
+- **Key:** `SWIFT_USE_INTEGRATED_DRIVER`
+- **Recommended:** `YES`
+- **Why:** Uses the integrated Swift driver which runs inside the build system process, eliminating inter-process overhead for compilation scheduling. Enabled by default in modern Xcode but worth verifying in migrated projects.
+- **Risk:** Low
+
+### Clang Module Compilation
+
+- **Key:** `CLANG_ENABLE_MODULES`
+- **Recommended:** `YES`
+- **Why:** Enables Clang module compilation for C/Objective-C sources, caching module maps on disk instead of reprocessing headers on every import. Eliminates redundant header parsing across translation units.
+- **Risk:** Low
+
+### Explicit Module Builds
+
+- **Key:** `SWIFT_ENABLE_EXPLICIT_MODULES` (C/ObjC enabled by default in Xcode 16+; for Swift use `_EXPERIMENTAL_SWIFT_EXPLICIT_MODULES`)
+- **Recommended:** Evaluate per-project
+- **Why:** Makes module compilation visible to the build system as discrete tasks, improving parallelism and scheduling. Reduces redundant module rebuilds by making dependency edges explicit. Some projects see regressions due to the overhead of dependency scanning, so benchmark before and after enabling.
+- **Risk:** Medium -- test thoroughly; currently experimental for Swift targets.
+
+## Cross-Target Consistency
+
+These checks find settings differences between targets that cause redundant build work.
+
+### Project-Level vs Target-Level Overrides
+
+Build-affecting settings should be set at the project level unless a target has a specific reason to override. Unnecessary per-target overrides cause confusion and can silently create module variants.
+
+Settings to check for project-level consistency:
+
+- `SWIFT_COMPILATION_MODE`
+- `SWIFT_OPTIMIZATION_LEVEL`
+- `ONLY_ACTIVE_ARCH`
+- `DEBUG_INFORMATION_FORMAT`
+
+### Module Variant Duplication
+
+When multiple targets import the same SPM package but compile with different Swift compiler options, the build system produces separate module variants for each combination. This inflates `SwiftEmitModule` task counts.
+
+Check for drift in:
+
+- `SWIFT_OPTIMIZATION_LEVEL`
+- `SWIFT_COMPILATION_MODE`
+- `OTHER_SWIFT_FLAGS`
+- Target-level build settings that override project defaults
+
+### Out of Scope
+
+Do **not** flag the following as build-performance issues:
+
+- `SWIFT_STRICT_CONCURRENCY` -- language migration choice
+- `SWIFT_UPCOMING_FEATURE_*` -- language migration choice
+- `SWIFT_APPROACHABLE_CONCURRENCY` -- language migration choice
+- `SWIFT_ACTIVE_COMPILATION_CONDITIONS` values beyond `DEBUG` (e.g., `WIDGETS`, `APPCLIP`) -- intentional per-target customization
+
+## Checklist Output Format
+
+When reporting results, use this structure:
+
+```markdown
+### Debug Configuration
+- [x] `SWIFT_COMPILATION_MODE`: `singlefile` (recommended: `singlefile`)
+- [ ] `DEBUG_INFORMATION_FORMAT`: `dwarf-with-dsym` (recommended: `dwarf`)
+- [x] `SWIFT_OPTIMIZATION_LEVEL`: `-Onone` (recommended: `-Onone`)
+...
+
+### Release Configuration
+- [x] `SWIFT_COMPILATION_MODE`: `wholemodule` (recommended: `wholemodule`)
+...
+
+### General (All Configurations)
+- [ ] `COMPILATION_CACHE_ENABLE_CACHING`: `NO` (recommended: `YES`)
+...
+
+### Cross-Target Consistency
+- [x] All targets inherit `SWIFT_OPTIMIZATION_LEVEL` from project level
+- [ ] `OTHER_SWIFT_FLAGS` differs between Stock Analyzer and StockAnalyzerClip
+...
+```

--- a/.agents/skills/xcode-build-fixer/references/fix-patterns.md
+++ b/.agents/skills/xcode-build-fixer/references/fix-patterns.md
@@ -1,0 +1,290 @@
+# Fix Patterns
+
+Concrete before/after examples for each fix category. Reference this when applying approved changes to ensure consistency.
+
+## Build Settings Fixes
+
+### Debug Information Format (Debug)
+
+Before (`project.pbxproj`):
+```
+DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+```
+
+After:
+```
+DEBUG_INFORMATION_FORMAT = dwarf;
+```
+
+### Compilation Mode (Debug)
+
+Before:
+```
+SWIFT_COMPILATION_MODE = wholemodule;
+```
+
+After:
+```
+SWIFT_COMPILATION_MODE = singlefile;
+```
+
+### Enable Compilation Caching
+
+Before (setting absent or):
+```
+COMPILATION_CACHE_ENABLE_CACHING = NO;
+```
+
+After:
+```
+COMPILATION_CACHE_ENABLE_CACHING = YES;
+```
+
+### Enable Eager Linking (Debug)
+
+Before (setting absent):
+
+After:
+```
+EAGER_LINKING = YES;
+```
+
+## Script Phase Fixes
+
+### Add Configuration Guard
+
+Before:
+```bash
+# Upload dSYMs to crash reporter
+./scripts/upload-dsyms.sh
+```
+
+After:
+```bash
+# Upload dSYMs to crash reporter
+[[ "$CONFIGURATION" != "Release" ]] && exit 0
+./scripts/upload-dsyms.sh
+```
+
+### Add Input/Output Declarations
+
+When a script has no declared inputs or outputs, Xcode runs it on every build. Declare them in the build phase or use `.xcfilelist` files for long lists.
+
+Before (in Xcode build phase):
+```
+Input Files: (none)
+Output Files: (none)
+```
+
+After:
+```
+Input Files:
+  $(SRCROOT)/scripts/generate-constants.sh
+  $(SRCROOT)/Config/constants.json
+
+Output Files:
+  $(DERIVED_FILE_DIR)/GeneratedConstants.swift
+```
+
+## Source-Level Fixes
+
+### Add Explicit Type Annotations
+
+Before:
+```swift
+let result = items.map { $0.value }.filter { $0 > threshold }.reduce(0, +)
+```
+
+After:
+```swift
+let mapped: [Double] = items.map { $0.value }
+let filtered: [Double] = mapped.filter { $0 > threshold }
+let result: Double = filtered.reduce(0, +)
+```
+
+### Break Complex Expressions
+
+Before:
+```swift
+let config = try JSONDecoder().decode(
+    AppConfig.self,
+    from: Data(contentsOf: Bundle.main.url(forResource: "config", withExtension: "json")!)
+)
+```
+
+After:
+```swift
+let configURL: URL = Bundle.main.url(forResource: "config", withExtension: "json")!
+let configData: Data = try Data(contentsOf: configURL)
+let config: AppConfig = try JSONDecoder().decode(AppConfig.self, from: configData)
+```
+
+### Mark Classes Final
+
+Before:
+```swift
+class NetworkService {
+    func fetchData() async throws -> Data { ... }
+}
+```
+
+After:
+```swift
+final class NetworkService {
+    func fetchData() async throws -> Data { ... }
+}
+
+```
+
+Only apply when the class is not subclassed anywhere in the project. Search for `: NetworkService` and `class ... : NetworkService` before marking `final`.
+
+### Tighten Access Control
+
+Before:
+```swift
+class ViewModel {
+    var internalState: State = .idle
+    func processQueue() { ... }
+}
+```
+
+After:
+```swift
+class ViewModel {
+    private var internalState: State = .idle
+    private func processQueue() { ... }
+}
+```
+
+Apply `private` when the symbol is only used within the same declaration. Apply `fileprivate` when used within the same file but outside the declaration.
+
+### Extract SwiftUI Subviews
+
+Before:
+```swift
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            HStack {
+                Image(systemName: "person")
+                Text(user.name)
+                Spacer()
+                Button("Edit") { showEdit = true }
+            }
+            List(items) { item in
+                HStack {
+                    Text(item.title)
+                    Spacer()
+                    Text(item.subtitle)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}
+```
+
+After:
+```swift
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            UserHeaderView(user: user, showEdit: $showEdit)
+            ItemListView(items: items)
+        }
+    }
+}
+
+struct UserHeaderView: View {
+    let user: User
+    @Binding var showEdit: Bool
+
+    var body: some View {
+        HStack {
+            Image(systemName: "person")
+            Text(user.name)
+            Spacer()
+            Button("Edit") { showEdit = true }
+        }
+    }
+}
+
+struct ItemListView: View {
+    let items: [Item]
+
+    var body: some View {
+        List(items) { item in
+            ItemRowView(item: item)
+        }
+    }
+}
+
+struct ItemRowView: View {
+    let item: Item
+
+    var body: some View {
+        HStack {
+            Text(item.title)
+            Spacer()
+            Text(item.subtitle)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+```
+
+### Add Explicit Closure Return Types
+
+Before:
+```swift
+let handler = { value in
+    guard let result = try? process(value) else { return nil }
+    return result.transformed()
+}
+```
+
+After:
+```swift
+let handler: (InputType) -> OutputType? = { (value: InputType) -> OutputType? in
+    guard let result = try? process(value) else { return nil }
+    return result.transformed()
+}
+```
+
+## SPM Restructuring Fixes
+
+### Extract Shared Types to Lower-Layer Module
+
+Before (`Package.swift`):
+```swift
+.target(name: "FeatureA", dependencies: ["FeatureB"]),
+.target(name: "FeatureB", dependencies: ["FeatureA"]),
+```
+
+After:
+```swift
+.target(name: "SharedContracts", dependencies: []),
+.target(name: "FeatureA", dependencies: ["SharedContracts"]),
+.target(name: "FeatureB", dependencies: ["SharedContracts"]),
+```
+
+Move the shared protocols and types into `SharedContracts` so both features depend downward instead of on each other.
+
+### Extract Interface Module
+
+Before:
+```swift
+.target(name: "Networking", dependencies: ["Models"]),
+.target(name: "FeatureA", dependencies: ["Networking"]),
+.target(name: "FeatureB", dependencies: ["Networking"]),
+```
+
+After:
+```swift
+.target(name: "NetworkingInterface", dependencies: []),
+.target(name: "Networking", dependencies: ["NetworkingInterface", "Models"]),
+.target(name: "FeatureA", dependencies: ["NetworkingInterface"]),
+.target(name: "FeatureB", dependencies: ["NetworkingInterface"]),
+```
+
+Feature modules compile against the lightweight interface without waiting for the full implementation to build.

--- a/.agents/skills/xcode-build-fixer/references/recommendation-format.md
+++ b/.agents/skills/xcode-build-fixer/references/recommendation-format.md
@@ -1,0 +1,85 @@
+# Recommendation Format
+
+All optimization skills should report recommendations in a shared structure so the orchestrator can merge and prioritize them cleanly.
+
+## Required Fields
+
+Each recommendation should include:
+
+- `title`
+- `wait_time_impact` -- plain-language statement of expected wall-clock impact, e.g. "Expected to reduce your clean build by ~3s", "Reduces parallel compile work but unlikely to reduce build wait time", or "Impact on wait time is uncertain -- re-benchmark to confirm"
+- `actionability` -- classifies how fixable the issue is from the project (see values below)
+- `category`
+- `observed_evidence`
+- `estimated_impact`
+- `confidence`
+- `approval_required`
+- `benchmark_verification_status`
+
+### Actionability Values
+
+Every recommendation must include an `actionability` classification:
+
+- `repo-local` -- Fix lives entirely in project files, source code, or local configuration. The developer can apply it without side effects outside the repo.
+- `package-manager` -- Requires CocoaPods or SPM configuration changes that may have broad side effects (e.g., linkage mode, dependency restructuring). These should be benchmarked before and after.
+- `xcode-behavior` -- Observed cost is driven by Xcode internals and is not suppressible from the project. Report the finding for awareness but do not promise a fix.
+- `upstream` -- Requires changes in a third-party dependency or external tool. The developer cannot fix it locally.
+
+## Suggested Optional Fields
+
+- `scope`
+- `affected_files`
+- `affected_targets`
+- `affected_packages`
+- `implementation_notes`
+- `risk_level`
+
+## JSON Example
+
+```json
+{
+  "recommendations": [
+    {
+      "title": "Guard a release-only symbol upload script",
+      "wait_time_impact": "Expected to reduce your incremental build by approximately 6 seconds.",
+      "actionability": "repo-local",
+      "category": "project",
+      "observed_evidence": [
+        "Incremental builds spend 6.3 seconds in a run script phase.",
+        "The script runs for Debug builds even though the output is only needed in Release."
+      ],
+      "estimated_impact": "High incremental-build improvement",
+      "confidence": "High",
+      "approval_required": true,
+      "benchmark_verification_status": "Not yet verified",
+      "scope": "Target build phase",
+      "risk_level": "Low"
+    }
+  ]
+}
+```
+
+## Markdown Rendering Guidance
+
+When rendering for human review, preserve the same field order:
+
+1. title
+2. wait-time impact
+3. actionability
+4. observed evidence
+5. estimated impact
+6. confidence
+7. approval required
+8. benchmark verification status
+
+That makes it easier for the developer to approve or reject specific items quickly.
+
+## Verification Status Values
+
+Recommended values:
+
+- `Not yet verified`
+- `Queued for verification`
+- `Verified improvement`
+- `No measurable improvement`
+- `Inconclusive due to benchmark noise`

--- a/.agents/skills/xcode-build-fixer/scripts/benchmark_builds.py
+++ b/.agents/skills/xcode-build-fixer/scripts/benchmark_builds.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import platform
+import re
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Benchmark Xcode clean and incremental builds.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--workspace", help="Path to the .xcworkspace file")
+    group.add_argument("--project", help="Path to the .xcodeproj file")
+    parser.add_argument("--scheme", required=True, help="Scheme to build")
+    parser.add_argument("--configuration", default="Debug", help="Build configuration")
+    parser.add_argument("--destination", help="xcodebuild destination string")
+    parser.add_argument("--derived-data-path", help="DerivedData path override")
+    parser.add_argument("--output-dir", default=".build-benchmark", help="Output directory for artifacts")
+    parser.add_argument("--repeats", type=int, default=3, help="Measured runs per build type")
+    parser.add_argument("--skip-warmup", action="store_true", help="Skip the validation build")
+    parser.add_argument(
+        "--touch-file",
+        help="Path to a source file to touch before each incremental build. "
+        "When provided, measures a real edit-rebuild loop instead of a zero-change build.",
+    )
+    parser.add_argument(
+        "--no-cached-clean",
+        action="store_true",
+        help="Skip cached clean builds even when COMPILATION_CACHE_ENABLE_CACHING is detected.",
+    )
+    parser.add_argument(
+        "--extra-arg",
+        action="append",
+        default=[],
+        help="Additional xcodebuild argument to append. Can be passed multiple times.",
+    )
+    return parser.parse_args()
+
+
+def command_base(args: argparse.Namespace) -> List[str]:
+    command = ["xcodebuild"]
+    if args.workspace:
+        command.extend(["-workspace", args.workspace])
+    if args.project:
+        command.extend(["-project", args.project])
+    command.extend(["-scheme", args.scheme, "-configuration", args.configuration])
+    if args.destination:
+        command.extend(["-destination", args.destination])
+    if args.derived_data_path:
+        command.extend(["-derivedDataPath", args.derived_data_path])
+    command.extend(args.extra_arg)
+    return command
+
+
+def shell_join(parts: List[str]) -> str:
+    return " ".join(subprocess.list2cmdline([part]) for part in parts)
+
+
+_TASK_COUNT_RE = re.compile(r"^(.+?)\s*\((\d+)\s+tasks?\)$")
+
+
+def _extract_task_count(name: str) -> tuple[str, Optional[int]]:
+    """Split 'Category (N tasks)' into ('Category', N)."""
+    match = _TASK_COUNT_RE.match(name)
+    if match:
+        return match.group(1).strip(), int(match.group(2))
+    return name, None
+
+
+def parse_timing_summary(output: str) -> List[Dict]:
+    categories: Dict[str, float] = {}
+    task_counts: Dict[str, Optional[int]] = {}
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        for suffix in (" seconds", " second", " sec"):
+            if not line.endswith(suffix):
+                continue
+            trimmed = line[: -len(suffix)]
+            if "|" in trimmed:
+                name_part, _, seconds_text = trimmed.rpartition("|")
+            else:
+                name_part, _, seconds_text = trimmed.rpartition(" ")
+            try:
+                seconds = float(seconds_text.strip())
+            except ValueError:
+                continue
+            cleaned_name = name_part.replace("  ", " ").strip(" -:")
+            if len(cleaned_name) < 3:
+                continue
+            base_name, count = _extract_task_count(cleaned_name)
+            categories[base_name] = categories.get(base_name, 0.0) + seconds
+            if count is not None:
+                task_counts[base_name] = (task_counts.get(base_name) or 0) + count
+            break
+    result: List[Dict] = []
+    for name, seconds in sorted(categories.items(), key=lambda item: item[1], reverse=True):
+        entry: Dict = {"name": name, "seconds": round(seconds, 3)}
+        if name in task_counts:
+            entry["task_count"] = task_counts[name]
+        result.append(entry)
+    return result
+
+
+def run_command(command: List[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(command, capture_output=True, text=True)
+
+
+def stats_for(runs: List[Dict[str, object]]) -> Dict[str, float]:
+    durations = [run["duration_seconds"] for run in runs if run.get("success")]
+    if not durations:
+        return {
+            "count": 0,
+            "min_seconds": 0.0,
+            "max_seconds": 0.0,
+            "median_seconds": 0.0,
+            "average_seconds": 0.0,
+        }
+    return {
+        "count": len(durations),
+        "min_seconds": round(min(durations), 3),
+        "max_seconds": round(max(durations), 3),
+        "median_seconds": round(statistics.median(durations), 3),
+        "average_seconds": round(statistics.fmean(durations), 3),
+    }
+
+
+def xcode_version() -> str:
+    result = run_command(["xcodebuild", "-version"])
+    return result.stdout.strip() if result.returncode == 0 else "unknown"
+
+
+def detect_compilation_caching(base_command: List[str]) -> bool:
+    """Check whether COMPILATION_CACHE_ENABLE_CACHING is enabled in the resolved build settings."""
+    result = run_command([*base_command, "-showBuildSettings"])
+    if result.returncode != 0:
+        return False
+    for line in result.stdout.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("COMPILATION_CACHE_ENABLE_CACHING") and "=" in stripped:
+            value = stripped.split("=", 1)[1].strip()
+            return value == "YES"
+    return False
+
+
+def measure_build(
+    base_command: List[str],
+    artifact_stem: str,
+    output_dir: Path,
+    build_type: str,
+    run_index: int,
+) -> Dict[str, object]:
+    build_command = [*base_command, "build", "-showBuildTimingSummary"]
+    started = time.perf_counter()
+    result = run_command(build_command)
+    elapsed = round(time.perf_counter() - started, 3)
+    log_path = output_dir / f"{artifact_stem}-{build_type}-{run_index}.log"
+    log_path.write_text(result.stdout + result.stderr)
+    return {
+        "id": f"{build_type}-{run_index}",
+        "build_type": build_type,
+        "duration_seconds": elapsed,
+        "success": result.returncode == 0,
+        "exit_code": result.returncode,
+        "command": shell_join(build_command),
+        "raw_log_path": str(log_path),
+        "timing_summary_categories": parse_timing_summary(result.stdout + result.stderr),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    artifact_stem = f"{timestamp}-{args.scheme.replace(' ', '-').lower()}"
+    base_command = command_base(args)
+
+    if not args.skip_warmup:
+        warmup = run_command([*base_command, "build"])
+        if warmup.returncode != 0:
+          sys.stderr.write(warmup.stdout + warmup.stderr)
+          return warmup.returncode
+        warmup_clean = run_command([*base_command, "clean"])
+        if warmup_clean.returncode != 0:
+            sys.stderr.write(warmup_clean.stdout + warmup_clean.stderr)
+            return warmup_clean.returncode
+        warmup_rebuild = run_command([*base_command, "build"])
+        if warmup_rebuild.returncode != 0:
+            sys.stderr.write(warmup_rebuild.stdout + warmup_rebuild.stderr)
+            return warmup_rebuild.returncode
+
+    runs: Dict[str, list] = {"clean": [], "incremental": []}
+
+    for index in range(1, args.repeats + 1):
+        clean_result = run_command([*base_command, "clean"])
+        clean_log_path = output_dir / f"{artifact_stem}-clean-prep-{index}.log"
+        clean_log_path.write_text(clean_result.stdout + clean_result.stderr)
+        if clean_result.returncode != 0:
+            sys.stderr.write(clean_result.stdout + clean_result.stderr)
+            return clean_result.returncode
+        runs["clean"].append(measure_build(base_command, artifact_stem, output_dir, "clean", index))
+
+    # --- Cached clean builds ---------------------------------------------------
+    # When COMPILATION_CACHE_ENABLE_CACHING is enabled, the compilation cache lives outside
+    # DerivedData and survives product deletion.  We measure "cached clean"
+    # builds by pointing DerivedData at a temp directory, warming the cache with
+    # one build, then deleting the DerivedData directory (but not the cache)
+    # before each measured rebuild.  This captures the realistic scenario:
+    # branch switching, pulling changes, or Clean Build Folder.
+    should_cached_clean = not args.no_cached_clean and detect_compilation_caching(base_command)
+    if should_cached_clean:
+        dd_path = Path(args.derived_data_path) if args.derived_data_path else Path(
+            tempfile.mkdtemp(prefix="xcode-bench-dd-")
+        )
+        cached_cmd = list(base_command)
+        if not args.derived_data_path:
+            cached_cmd.extend(["-derivedDataPath", str(dd_path)])
+
+        cache_warmup = run_command([*cached_cmd, "build"])
+        if cache_warmup.returncode != 0:
+            sys.stderr.write("Warning: cached clean warmup build failed, skipping cached clean benchmarks.\n")
+            sys.stderr.write(cache_warmup.stdout + cache_warmup.stderr)
+            should_cached_clean = False
+
+    if should_cached_clean:
+        runs["cached_clean"] = []
+        for index in range(1, args.repeats + 1):
+            shutil.rmtree(dd_path, ignore_errors=True)
+            runs["cached_clean"].append(
+                measure_build(cached_cmd, artifact_stem, output_dir, "cached-clean", index)
+            )
+        shutil.rmtree(dd_path, ignore_errors=True)
+
+    # --- Incremental / zero-change builds --------------------------------------
+    incremental_label = "incremental"
+    if args.touch_file:
+        touch_path = Path(args.touch_file)
+        if not touch_path.exists():
+            sys.stderr.write(f"--touch-file path does not exist: {touch_path}\n")
+            return 1
+        incremental_label = "incremental"
+    else:
+        incremental_label = "zero-change"
+
+    for index in range(1, args.repeats + 1):
+        if args.touch_file:
+            touch_path.touch()
+        runs["incremental"].append(
+            measure_build(base_command, artifact_stem, output_dir, incremental_label, index)
+        )
+
+    summary: Dict[str, object] = {
+        "clean": stats_for(runs["clean"]),
+        "incremental": stats_for(runs["incremental"]),
+    }
+    if "cached_clean" in runs:
+        summary["cached_clean"] = stats_for(runs["cached_clean"])
+
+    artifact = {
+        "schema_version": "1.2.0" if "cached_clean" in runs else "1.1.0",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "build": {
+            "entrypoint": "workspace" if args.workspace else "project",
+            "path": args.workspace or args.project,
+            "scheme": args.scheme,
+            "configuration": args.configuration,
+            "destination": args.destination or "",
+            "derived_data_path": args.derived_data_path or "",
+            "command": shell_join(base_command),
+        },
+        "environment": {
+            "host": platform.node(),
+            "macos_version": platform.platform(),
+            "xcode_version": xcode_version(),
+            "cwd": os.getcwd(),
+        },
+        "runs": runs,
+        "summary": summary,
+        "notes": [f"touch-file: {args.touch_file}"] if args.touch_file else [],
+    }
+
+    artifact_path = output_dir / f"{artifact_stem}.json"
+    artifact_path.write_text(json.dumps(artifact, indent=2) + "\n")
+
+    print(f"Saved benchmark artifact: {artifact_path}")
+    print(f"Clean median: {artifact['summary']['clean']['median_seconds']}s")
+    if "cached_clean" in artifact["summary"]:
+        print(f"Cached clean median: {artifact['summary']['cached_clean']['median_seconds']}s")
+    inc_label = "Incremental" if args.touch_file else "Zero-change"
+    print(f"{inc_label} median: {artifact['summary']['incremental']['median_seconds']}s")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/xcode-build-orchestrator/SKILL.md
+++ b/.agents/skills/xcode-build-orchestrator/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: xcode-build-orchestrator
+description: Orchestrate Xcode build optimization by benchmarking first, running the specialist analysis skills, prioritizing findings, requesting explicit approval, delegating approved fixes to xcode-build-fixer, and re-benchmarking after changes. Use when a developer wants an end-to-end build optimization workflow, asks to speed up Xcode builds, wants a full build audit, or needs a recommend-first optimization pass covering compilation, project settings, and packages.
+---
+
+# Xcode Build Orchestrator
+
+Use this skill as the recommend-first entrypoint for end-to-end Xcode build optimization work.
+
+## Non-Negotiable Rules
+
+- Wall-clock build time (how long the developer waits) is the primary success metric. Every recommendation must state its expected impact on the developer's actual wait time.
+- Start in recommendation mode.
+- Benchmark before making changes.
+- Do not modify project files, source files, packages, or scripts without explicit developer approval.
+- Preserve the evidence trail for every recommendation.
+- Re-benchmark after approved changes and report the wall-clock delta.
+
+## Two-Phase Workflow
+
+The orchestration is designed as two distinct phases separated by developer review.
+
+### Phase 1 -- Analyze (recommend-only)
+
+Run this phase in agent mode because the agent needs to execute builds, run benchmark scripts, write benchmark artifacts, and generate the optimization report. However, treat Phase 1 as **recommend-only**: do not modify any project files, source files, packages, or build settings. The only files the agent creates during this phase are benchmark artifacts and the optimization plan inside `.build-benchmark/`.
+
+1. Collect the build target context: workspace or project, scheme, configuration, destination, and current pain point. When both `.xcworkspace` and `.xcodeproj` exist, prefer `.xcodeproj` unless the workspace contains sub-projects required for the build. Workspaces that reference external projects may fail if those projects are not checked out.
+2. Run `xcode-build-benchmark` to establish a baseline if no fresh benchmark exists. The benchmark script auto-detects `COMPILATION_CACHE_ENABLE_CACHING = YES` and includes cached clean builds that measure the realistic developer experience (warm cache). If the build fails to compile, check `git log` for a recent buildable commit. When working in a worktree, cherry-picking a targeted build fix from a feature branch is acceptable to reach a buildable state. If SPM packages reference gitignored directories in their `exclude:` paths (e.g., `__Snapshots__`), create those directories before building -- worktrees do not contain gitignored content and `xcodebuild -resolvePackageDependencies` will crash otherwise.
+3. Verify the benchmark artifact has non-empty `timing_summary_categories`. If empty, the timing summary parser may have failed -- re-parse the raw logs or inspect them manually. If `COMPILATION_CACHE_ENABLE_CACHING` is enabled, also verify the artifact includes `cached_clean` runs.
+   - **Benchmark confidence check**: For each build type (clean, cached clean, incremental), compare the min and max values. If the spread (max - min) exceeds 20% of the median, flag the benchmark as having high variance and recommend running additional repetitions (5+ runs) before drawing conclusions. High variance makes it difficult to distinguish real improvements from noise. After applying changes, only claim an improvement if the post-change median falls outside the baseline's min-max range.
+4. If incremental builds are the primary pain point and Xcode 16.4+ is available, recommend the developer enable **Task Backtraces** (Scheme Editor > Build tab > Build Debugging > "Task Backtraces"). This reveals why each task re-ran, which is critical for diagnosing unexpected replanning or input invalidation. Include any Task Backtrace evidence in the analysis.
+5. Determine whether compile tasks are likely blocking wall-clock progress or just consuming parallel CPU time. Compare the sum of all timing-summary category seconds against the wall-clock median: if the sum is 2x+ the median, most work is parallelized and compile hotspot fixes are unlikely to reduce wait time. If `SwiftCompile`, `CompileC`, `SwiftEmitModule`, or `Planning Swift module` dominate the timing summary **and** appear likely to be on the critical path, run `diagnose_compilation.py` to capture type-checking hotspots. If they are parallelized, still run diagnostics but label findings as "parallel efficiency improvements" rather than "build time improvements."
+6. Run the specialist analyses that fit the evidence by reading each skill's SKILL.md and applying its workflow:
+   - [`xcode-compilation-analyzer`](../xcode-compilation-analyzer/SKILL.md)
+   - [`xcode-project-analyzer`](../xcode-project-analyzer/SKILL.md)
+   - [`spm-build-analysis`](../spm-build-analysis/SKILL.md)
+7. Merge findings into a single prioritized improvement plan.
+8. Generate the markdown optimization report using `generate_optimization_report.py` and save it to `.build-benchmark/optimization-plan.md`. This report includes the build settings audit, timing analysis, prioritized recommendations, and an approval checklist.
+9. Stop and present the plan to the developer for review.
+
+The developer reviews `.build-benchmark/optimization-plan.md`, checks the approval boxes for the recommendations they want implemented, and then triggers phase 2.
+
+### Phase 2 -- Execute and verify (agent mode)
+
+Run this phase in agent mode after the developer has reviewed and approved recommendations from the plan. Delegate all implementation work to [`xcode-build-fixer`](../xcode-build-fixer/SKILL.md) by reading its SKILL.md and applying its workflow.
+
+10. Read `.build-benchmark/optimization-plan.md` and identify the approved items from the approval checklist.
+11. Hand off to `xcode-build-fixer` with the approved plan. The fixer applies each approved change, verifies compilation, and re-benchmarks.
+12. Append verification results to the optimization plan: post-change medians, absolute and percentage deltas, and confidence notes.
+13. Report before and after results, plus any remaining follow-up opportunities.
+
+## Prioritization Rules
+
+The goal is to reduce how long the developer waits for builds to finish.
+
+1. Identify the developer's primary pain (clean build, incremental build, or both) and the measured wall-clock median.
+2. Determine what is likely **blocking** wall-clock progress:
+   - If the sum of all timing-summary category seconds is 2x+ the wall-clock median, most work is parallelized. Compile hotspot fixes are unlikely to reduce wait time.
+   - If a single serial category (e.g. `PhaseScriptExecution`, `CompileAssetCatalog`, `CodeSign`) accounts for a large fraction of wall-clock, that is the real bottleneck.
+   - If `Planning Swift module` or `SwiftEmitModule` dominates incremental builds, the cause is likely invalidation or module size, not individual file compile speed.
+3. Rank recommendations by likely wall-time savings, not cumulative task reduction.
+4. Source-level compile fixes should not outrank project/graph/configuration fixes unless evidence suggests they are on the critical path.
+
+Prefer changes that are measurable, reversible, and low-risk.
+
+## Recommendation Impact Language
+
+Every recommendation presented to the developer must include one of these impact statements:
+
+- "Expected to reduce your [clean/incremental] build by approximately X seconds."
+- "Reduces parallel compile work but is unlikely to reduce your build wait time because other tasks take equally long."
+- "Impact on wait time is uncertain -- re-benchmark after applying to confirm."
+- "No wait-time improvement expected. The benefit is [deterministic builds / faster branch switching / reduced CI cost]."
+- For COMPILATION_CACHE_ENABLE_CACHING specifically: "Measured 5-14% faster clean builds across tested projects. The benefit compounds in real workflows where the cache persists between builds -- branch switching, pulling changes, and CI with persistent DerivedData."
+
+Never quote cumulative task-time savings as the headline impact. If a change reduces 5 seconds of parallel compile work but another equally long task still runs, the developer's wait time does not change.
+
+## Approval Gate
+
+Before implementing anything, present a short approval list that includes:
+
+- recommendation name
+- expected wait-time impact (using the impact language above)
+- evidence summary
+- affected files or settings
+- whether the change is low, medium, or high risk
+
+Wait for explicit developer approval.
+
+## Post-Approval Execution
+
+After approval, delegate to `xcode-build-fixer`:
+
+- the fixer implements only the approved items
+- changes are applied atomically and kept scoped
+- any deviations from the original recommendation plan are noted
+- the fixer re-benchmarks with the same benchmark contract
+
+## Final Report
+
+Lead with the wall-clock result in plain language, e.g.: "Your clean build now takes 82s (was 86s) -- 4s faster." Then include:
+
+- baseline clean and incremental wall-clock medians
+- post-change clean and incremental wall-clock medians
+- absolute and percentage wall-clock deltas
+- what changed
+- what was intentionally left unchanged
+- confidence notes if noise prevents a strong conclusion -- if benchmark variance is high (min-to-max spread exceeds 20% of median), say so explicitly rather than presenting noisy numbers as definitive improvements or regressions
+- if cumulative task metrics improved but wall-clock did not, say plainly: "Compiler workload decreased but build wait time did not improve. This is expected when Xcode runs these tasks in parallel with other equally long work."
+- a ready-to-paste community results row and a link to open a PR (see the report template)
+
+## Preferred Command Paths
+
+### Benchmark
+
+```bash
+python3 scripts/benchmark_builds.py \
+  --project App.xcodeproj \
+  --scheme MyApp \
+  --configuration Debug \
+  --destination "platform=iOS Simulator,name=iPhone 16" \
+  --output-dir .build-benchmark
+```
+
+For macOS apps use `--destination "platform=macOS"`. For watchOS use `--destination "platform=watchOS Simulator,name=Apple Watch Series 10"`. For tvOS use `--destination "platform=tvOS Simulator,name=Apple TV"`. Omit `--destination` to use the scheme's default.
+
+To measure real incremental builds (file-touched rebuild) instead of zero-change builds, add `--touch-file path/to/SomeFile.swift`.
+
+### Compilation Diagnostics
+
+```bash
+python3 scripts/diagnose_compilation.py \
+  --project App.xcodeproj \
+  --scheme MyApp \
+  --configuration Debug \
+  --destination "platform=iOS Simulator,name=iPhone 16" \
+  --threshold 100 \
+  --output-dir .build-benchmark
+```
+
+### Optimization Report
+
+```bash
+python3 scripts/generate_optimization_report.py \
+  --benchmark .build-benchmark/<artifact>.json \
+  --project-path App.xcodeproj \
+  --diagnostics .build-benchmark/<diagnostics>.json \
+  --output .build-benchmark/optimization-plan.md
+```
+
+## Additional Resources
+
+- For the report template, see [references/orchestration-report-template.md](references/orchestration-report-template.md)
+- For benchmark artifact requirements, see [references/benchmark-artifacts.md](references/benchmark-artifacts.md)
+- For the recommendation format, see [references/recommendation-format.md](references/recommendation-format.md)
+- For build settings best practices, see [references/build-settings-best-practices.md](references/build-settings-best-practices.md)

--- a/.agents/skills/xcode-build-orchestrator/references/benchmark-artifacts.md
+++ b/.agents/skills/xcode-build-orchestrator/references/benchmark-artifacts.md
@@ -1,0 +1,94 @@
+# Benchmark Artifacts
+
+All skills in this repository should treat `.build-benchmark/` as the canonical location for measured build evidence.
+
+## Goals
+
+- Keep build measurements reproducible.
+- Make clean and incremental build data easy to compare.
+- Preserve enough context for later specialist analysis without rerunning the benchmark.
+
+## Wall-Clock vs Cumulative Task Time
+
+The `duration_seconds` field on each run and the `median_seconds` in the summary represent **wall-clock time** -- how long the developer actually waits. This is the primary success metric.
+
+The `timing_summary_categories` are **aggregated task times** parsed from Xcode's Build Timing Summary. Because Xcode runs many tasks in parallel across CPU cores, these totals typically exceed the wall-clock duration. A large cumulative `SwiftCompile` value is diagnostic evidence of compiler workload, not proof that compilation is blocking the build. Always compare category totals against the wall-clock median before concluding that a category is a bottleneck.
+
+## File Layout
+
+Recommended outputs:
+
+- `.build-benchmark/<timestamp>-<scheme>.json`
+- `.build-benchmark/<timestamp>-<scheme>-clean-1.log`
+- `.build-benchmark/<timestamp>-<scheme>-clean-2.log`
+- `.build-benchmark/<timestamp>-<scheme>-clean-3.log`
+- `.build-benchmark/<timestamp>-<scheme>-cached-clean-1.log` (when COMPILATION_CACHE_ENABLE_CACHING is enabled)
+- `.build-benchmark/<timestamp>-<scheme>-cached-clean-2.log`
+- `.build-benchmark/<timestamp>-<scheme>-cached-clean-3.log`
+- `.build-benchmark/<timestamp>-<scheme>-incremental-1.log`
+- `.build-benchmark/<timestamp>-<scheme>-incremental-2.log`
+- `.build-benchmark/<timestamp>-<scheme>-incremental-3.log`
+
+Use an ISO-like UTC timestamp without spaces so the files sort naturally.
+
+## Artifact Requirements
+
+Each JSON artifact should include:
+
+- schema version
+- creation timestamp
+- project context
+- environment details when available
+- the normalized build command
+- separate `clean` and `incremental` run arrays
+- summary statistics for each build type
+- parsed timing-summary categories
+- free-form notes for caveats or noise
+
+## Clean, Cached Clean, And Incremental Separation
+
+Do not merge different build type measurements into a single list. They answer different questions:
+
+- **Clean builds** show full build-system, package, and module setup cost with a cold compilation cache.
+- **Cached clean builds** show clean build cost when the compilation cache is warm. This is the realistic scenario for branch switching, pulling changes, or Clean Build Folder. Only present when `COMPILATION_CACHE_ENABLE_CACHING = YES` is detected.
+- **Incremental builds** show edit-loop productivity and script or cache invalidation problems.
+
+## Raw Logs
+
+Store raw `xcodebuild` output beside the JSON artifact whenever possible. That allows later skills to:
+
+- re-parse timing summaries
+- inspect failed builds
+- search for long type-check warnings
+- correlate build-system phases with recommendations
+
+## Measurement Caveats
+
+### COMPILATION_CACHE_ENABLE_CACHING
+
+`COMPILATION_CACHE_ENABLE_CACHING = YES` stores compiled artifacts in a system-managed cache outside DerivedData so that repeated compilations of identical inputs are served from cache. The standard clean-build benchmark (`xcodebuild clean` between runs) may add overhead from cache population without showing the corresponding cache-hit benefit.
+
+The benchmark script automatically detects `COMPILATION_CACHE_ENABLE_CACHING = YES` and runs a **cached clean** benchmark phase. This phase:
+
+1. Builds once to warm the compilation cache.
+2. Deletes DerivedData (but not the compilation cache) before each measured run.
+3. Rebuilds, measuring the cache-hit clean build time.
+
+The cached clean metric captures the realistic developer experience: branch switching, pulling changes, and Clean Build Folder. Use the cached clean median as the primary comparison metric when evaluating `COMPILATION_CACHE_ENABLE_CACHING` impact.
+
+To skip this phase, pass `--no-cached-clean`.
+
+### First-Run Variance
+
+The first clean build after the warmup cycle often runs 20-40% slower than subsequent clean builds due to cold OS-level caches (disk I/O, dynamic linker cache, etc.). The benchmark script mitigates this by running a warmup clean+build cycle before measured runs. If variance between the first and later clean runs is still high, prefer the median or min over the mean, and note the variance in the artifact's `notes` field.
+
+## Shared Consumer Expectations
+
+Any skill reading a benchmark artifact should be able to identify:
+
+- what was measured
+- how it was measured
+- whether the run succeeded
+- whether the results are stable enough to compare
+
+For the authoritative field-level schema, see the `build-benchmark.schema.json` bundled with the xcode-build-benchmark skill.

--- a/.agents/skills/xcode-build-orchestrator/references/build-settings-best-practices.md
+++ b/.agents/skills/xcode-build-orchestrator/references/build-settings-best-practices.md
@@ -1,0 +1,216 @@
+# Build Settings Best Practices
+
+This reference lists Xcode build settings that affect build performance. Use it to audit a project and produce a pass/fail checklist.
+
+The scope is strictly **build performance**. Do not flag language-migration settings like `SWIFT_STRICT_CONCURRENCY` or `SWIFT_UPCOMING_FEATURE_*` -- those are developer adoption choices unrelated to build speed.
+
+## How To Read This Reference
+
+Each setting includes:
+
+- **Setting name** and the Xcode build-settings key
+- **Recommended value** for Debug and Release
+- **Why it matters** for build time
+- **Risk** of changing it
+
+Use checkmark and cross indicators when reporting:
+
+- `[x]` -- setting matches the recommended value
+- `[ ]` -- setting does not match; include the actual value and the expected value
+
+## Debug Configuration
+
+These settings optimize for fast iteration during development.
+
+### Compilation Mode
+
+- **Key:** `SWIFT_COMPILATION_MODE`
+- **Recommended:** `singlefile` (Xcode UI: "Incremental"; or unset -- Xcode defaults to singlefile for Debug)
+- **Why:** Single-file mode recompiles only changed files. `wholemodule` recompiles the entire target on every change.
+- **Risk:** Low
+
+### Swift Optimization Level
+
+- **Key:** `SWIFT_OPTIMIZATION_LEVEL`
+- **Recommended:** `-Onone`
+- **Why:** Optimization passes add significant compile time. Debug builds do not benefit from runtime speed improvements.
+- **Risk:** Low
+
+### GCC Optimization Level
+
+- **Key:** `GCC_OPTIMIZATION_LEVEL`
+- **Recommended:** `0`
+- **Why:** Same rationale as Swift optimization level, but for C/C++/Objective-C sources.
+- **Risk:** Low
+
+### Build Active Architecture Only
+
+- **Key:** `ONLY_ACTIVE_ARCH` (`BUILD_ACTIVE_ARCHITECTURE_ONLY`)
+- **Recommended:** `YES`
+- **Why:** Building all architectures doubles or triples compile and link time for no debug benefit.
+- **Risk:** Low
+
+### Debug Information Format
+
+- **Key:** `DEBUG_INFORMATION_FORMAT`
+- **Recommended:** `dwarf`
+- **Why:** `dwarf-with-dsym` generates a separate dSYM bundle which adds overhead. Plain `dwarf` embeds debug info directly in the binary, which is sufficient for local debugging.
+- **Risk:** Low
+
+### Enable Testability
+
+- **Key:** `ENABLE_TESTABILITY`
+- **Recommended:** `YES`
+- **Why:** Required for `@testable import`. Adds minor overhead by exporting internal symbols, but this is expected during development.
+- **Risk:** Low
+
+### Active Compilation Conditions
+
+- **Key:** `SWIFT_ACTIVE_COMPILATION_CONDITIONS`
+- **Recommended:** Should include `DEBUG`
+- **Why:** Guards conditional compilation blocks (e.g., `#if DEBUG`) and ensures debug-only code paths are included.
+- **Risk:** Low
+
+### Eager Linking
+
+- **Key:** `EAGER_LINKING`
+- **Recommended:** `YES`
+- **Why:** Allows the linker to start work before all compilation tasks finish, reducing wall-clock build time. Particularly effective for Debug builds where link time is a meaningful fraction of total build time.
+- **Risk:** Low
+
+## Release Configuration
+
+These settings optimize for production builds.
+
+### Compilation Mode
+
+- **Key:** `SWIFT_COMPILATION_MODE`
+- **Recommended:** `wholemodule`
+- **Why:** Whole-module optimization produces faster runtime code. Build time is secondary for release.
+- **Risk:** Low
+
+### Swift Optimization Level
+
+- **Key:** `SWIFT_OPTIMIZATION_LEVEL`
+- **Recommended:** `-O` or `-Osize`
+- **Why:** Produces optimized binaries. `-Osize` trades some speed for smaller binary size.
+- **Risk:** Low
+
+### GCC Optimization Level
+
+- **Key:** `GCC_OPTIMIZATION_LEVEL`
+- **Recommended:** `s`
+- **Why:** Optimizes C/C++/Objective-C for size, matching the typical release expectation.
+- **Risk:** Low
+
+### Build Active Architecture Only
+
+- **Key:** `ONLY_ACTIVE_ARCH`
+- **Recommended:** `NO`
+- **Why:** Release builds must include all supported architectures for distribution.
+- **Risk:** Low
+
+### Debug Information Format
+
+- **Key:** `DEBUG_INFORMATION_FORMAT`
+- **Recommended:** `dwarf-with-dsym`
+- **Why:** dSYM bundles are required for crash symbolication in production.
+- **Risk:** Low
+
+### Enable Testability
+
+- **Key:** `ENABLE_TESTABILITY`
+- **Recommended:** `NO`
+- **Why:** Removes internal-symbol export overhead from release builds. Testing should use Debug configuration.
+- **Risk:** Low
+
+## General (All Configurations)
+
+### Compilation Caching
+
+- **Key:** `COMPILATION_CACHE_ENABLE_CACHING`
+- **Recommended:** `YES`
+- **Why:** Caches compilation results for Swift and C-family sources so repeated compilations of the same inputs are served from cache. The biggest wins come from branch switching and clean builds where source files are recompiled unchanged. This is an opt-in feature. The umbrella setting controls both `SWIFT_ENABLE_COMPILE_CACHE` and `CLANG_ENABLE_COMPILE_CACHE` under the hood; those can be toggled independently if needed.
+- **Measurement:** Measured 5-14% faster clean builds across tested projects (87 to 1,991 Swift files). The benefit compounds in real developer workflows where the cache persists between builds -- branch switching, pulling changes, and CI with persistent DerivedData -- though the exact savings depend on how many files change between builds.
+- **Risk:** Low -- can also be enabled via per-user project settings so it does not need to be committed to the shared project file.
+
+### Integrated Swift Driver
+
+- **Key:** `SWIFT_USE_INTEGRATED_DRIVER`
+- **Recommended:** `YES`
+- **Why:** Uses the integrated Swift driver which runs inside the build system process, eliminating inter-process overhead for compilation scheduling. Enabled by default in modern Xcode but worth verifying in migrated projects.
+- **Risk:** Low
+
+### Clang Module Compilation
+
+- **Key:** `CLANG_ENABLE_MODULES`
+- **Recommended:** `YES`
+- **Why:** Enables Clang module compilation for C/Objective-C sources, caching module maps on disk instead of reprocessing headers on every import. Eliminates redundant header parsing across translation units.
+- **Risk:** Low
+
+### Explicit Module Builds
+
+- **Key:** `SWIFT_ENABLE_EXPLICIT_MODULES` (C/ObjC enabled by default in Xcode 16+; for Swift use `_EXPERIMENTAL_SWIFT_EXPLICIT_MODULES`)
+- **Recommended:** Evaluate per-project
+- **Why:** Makes module compilation visible to the build system as discrete tasks, improving parallelism and scheduling. Reduces redundant module rebuilds by making dependency edges explicit. Some projects see regressions due to the overhead of dependency scanning, so benchmark before and after enabling.
+- **Risk:** Medium -- test thoroughly; currently experimental for Swift targets.
+
+## Cross-Target Consistency
+
+These checks find settings differences between targets that cause redundant build work.
+
+### Project-Level vs Target-Level Overrides
+
+Build-affecting settings should be set at the project level unless a target has a specific reason to override. Unnecessary per-target overrides cause confusion and can silently create module variants.
+
+Settings to check for project-level consistency:
+
+- `SWIFT_COMPILATION_MODE`
+- `SWIFT_OPTIMIZATION_LEVEL`
+- `ONLY_ACTIVE_ARCH`
+- `DEBUG_INFORMATION_FORMAT`
+
+### Module Variant Duplication
+
+When multiple targets import the same SPM package but compile with different Swift compiler options, the build system produces separate module variants for each combination. This inflates `SwiftEmitModule` task counts.
+
+Check for drift in:
+
+- `SWIFT_OPTIMIZATION_LEVEL`
+- `SWIFT_COMPILATION_MODE`
+- `OTHER_SWIFT_FLAGS`
+- Target-level build settings that override project defaults
+
+### Out of Scope
+
+Do **not** flag the following as build-performance issues:
+
+- `SWIFT_STRICT_CONCURRENCY` -- language migration choice
+- `SWIFT_UPCOMING_FEATURE_*` -- language migration choice
+- `SWIFT_APPROACHABLE_CONCURRENCY` -- language migration choice
+- `SWIFT_ACTIVE_COMPILATION_CONDITIONS` values beyond `DEBUG` (e.g., `WIDGETS`, `APPCLIP`) -- intentional per-target customization
+
+## Checklist Output Format
+
+When reporting results, use this structure:
+
+```markdown
+### Debug Configuration
+- [x] `SWIFT_COMPILATION_MODE`: `singlefile` (recommended: `singlefile`)
+- [ ] `DEBUG_INFORMATION_FORMAT`: `dwarf-with-dsym` (recommended: `dwarf`)
+- [x] `SWIFT_OPTIMIZATION_LEVEL`: `-Onone` (recommended: `-Onone`)
+...
+
+### Release Configuration
+- [x] `SWIFT_COMPILATION_MODE`: `wholemodule` (recommended: `wholemodule`)
+...
+
+### General (All Configurations)
+- [ ] `COMPILATION_CACHE_ENABLE_CACHING`: `NO` (recommended: `YES`)
+...
+
+### Cross-Target Consistency
+- [x] All targets inherit `SWIFT_OPTIMIZATION_LEVEL` from project level
+- [ ] `OTHER_SWIFT_FLAGS` differs between Stock Analyzer and StockAnalyzerClip
+...
+```

--- a/.agents/skills/xcode-build-orchestrator/references/orchestration-report-template.md
+++ b/.agents/skills/xcode-build-orchestrator/references/orchestration-report-template.md
@@ -1,0 +1,143 @@
+# Orchestration Report Template
+
+Use this structure when the orchestrator consolidates benchmark evidence and specialist findings. The `generate_optimization_report.py` script produces this format automatically when given the benchmark and diagnostics artifacts.
+
+```markdown
+# Xcode Build Optimization Plan
+
+## Project Context
+- **Project:** `App.xcodeproj`
+- **Scheme:** `MyApp`
+- **Configuration:** `Debug`
+- **Destination:** `platform=iOS Simulator,name=iPhone 16`
+- **Xcode:** Xcode 26.x
+- **Date:** 2026-01-01T00:00:00Z
+- **Benchmark artifact:** `.build-benchmark/<timestamp>-<scheme>.json`
+
+## Baseline Benchmarks
+
+| Metric | Clean | Cached Clean | Zero-Change |
+|--------|-------|-------------|-------------|
+| Median | 0.000s | 0.000s | 0.000s |
+| Min | 0.000s | 0.000s | 0.000s |
+| Max | 0.000s | 0.000s | 0.000s |
+| Runs | 3 | 3 | 3 |
+
+> **Cached Clean** = clean build with a warm compilation cache. This is the realistic scenario for branch switching, pulling changes, or Clean Build Folder. Only present when `COMPILATION_CACHE_ENABLE_CACHING = YES` is detected. "Zero-Change" = rebuild with no edits (measures fixed overhead). Use `--touch-file` in the benchmark script to measure true incremental builds where a source file is modified.
+
+### Clean Build Timing Summary
+
+> **Note:** These are aggregated task times across all CPU cores. Because Xcode runs many tasks in parallel, these totals typically exceed the actual build wait time shown above. A large number here does not mean it is blocking your build.
+
+| Category | Tasks | Seconds |
+|----------|------:|--------:|
+| SwiftCompile | 325 | 271.245s |
+| SwiftEmitModule | 30 | 23.625s |
+| ... | ... | ... |
+
+## Build Settings Audit
+
+### Debug Configuration
+- [x] `SWIFT_COMPILATION_MODE`: `(unset)` (recommended: `singlefile`)
+- [x] `SWIFT_OPTIMIZATION_LEVEL`: `-Onone` (recommended: `-Onone`)
+- [x] `GCC_OPTIMIZATION_LEVEL`: `0` (recommended: `0`)
+- [x] `ONLY_ACTIVE_ARCH`: `YES` (recommended: `YES`)
+- [x] `DEBUG_INFORMATION_FORMAT`: `dwarf` (recommended: `dwarf`)
+- [x] `ENABLE_TESTABILITY`: `YES` (recommended: `YES`)
+- [x] `EAGER_LINKING`: `YES` (recommended: `YES`)
+
+### General (All Configurations)
+- [x] `COMPILATION_CACHE_ENABLE_CACHING`: `YES` (recommended: `YES`)
+- [x] `SWIFT_USE_INTEGRATED_DRIVER`: `YES` (recommended: `YES`)
+- [x] `CLANG_ENABLE_MODULES`: `YES` (recommended: `YES`)
+
+### Release Configuration
+- [x] `SWIFT_COMPILATION_MODE`: `wholemodule` (recommended: `wholemodule`)
+- [x] `SWIFT_OPTIMIZATION_LEVEL`: `-O` (recommended: `-O`)
+- ...
+
+### Cross-Target Consistency
+- [x] `SWIFT_COMPILATION_MODE` is consistent across all targets
+- [ ] `OTHER_SWIFT_FLAGS` has target-level overrides: ...
+
+## Compilation Diagnostics
+
+| Duration | Kind | File | Line | Name |
+|---------:|------|------|-----:|------|
+| 150ms | function-body | MyView.swift | 42 | body |
+| ... | ... | ... | ... | ... |
+
+## Prioritized Recommendations
+
+### 1. Recommendation title
+**Wait-Time Impact:** Expected to reduce your clean build by approximately 3 seconds.
+**Category:** project
+**Evidence:** ...
+**Impact:** High
+**Confidence:** High
+**Risk:** Low
+
+## Approval Checklist
+- [ ] **1. Recommendation title** -- Wait-Time Impact: ~3s clean build reduction | Risk: Low
+- [ ] **2. Another recommendation** -- Wait-Time Impact: Uncertain, re-benchmark to confirm | Risk: Low
+
+## Next Steps
+
+After implementing approved changes, re-benchmark with the same inputs:
+
+...
+
+Compare the new wall-clock medians against the baseline. Report results as:
+"Your [clean/incremental] build now takes X.Xs (was Y.Ys) -- Z.Zs faster/slower."
+
+## Execution Report (post-approval)
+
+### Baseline
+- Clean build median: X.Xs
+- Cached clean build median: X.Xs (if applicable)
+- Incremental build median: X.Xs
+
+### Changes Applied
+
+| # | Change | Actionability | Measured Result | Status |
+|---|--------|---------------|-----------------|--------|
+| 1 | Description of change | repo-local | Clean: X.Xs→Y.Ys, Incr: X.Xs→Y.Ys | Kept / Reverted / Blocked |
+| 2 | ... | ... | ... | ... |
+
+Status values: `Kept`, `Kept (best practice)`, `Reverted`, `Blocked`, `No improvement`
+
+### Final Cumulative Result
+- Post-change clean build: X.Xs (was Y.Ys) -- Z.Zs faster/slower
+- Post-change cached clean build: X.Xs (was Y.Ys) -- Z.Zs faster/slower (when COMPILATION_CACHE_ENABLE_CACHING enabled)
+- Post-change incremental build: X.Xs (was Y.Ys) -- Z.Zs faster/slower
+- **Net result:** Faster / Slower / Unchanged
+- If cumulative task metrics improved but wall-clock did not: "Compiler workload decreased but build wait time did not improve. This is expected when Xcode runs these tasks in parallel with other equally long work."
+- If standard clean builds are slower but cached clean builds are faster: "Standard clean builds show overhead from compilation cache population. Cached clean builds (the realistic developer workflow) are faster, confirming the net benefit."
+
+### Blocked or Non-Actionable Findings
+- Finding: reason it could not be addressed from the repo
+
+## Remaining follow-up ideas
+- Item:
+- Why it was deferred:
+
+## Share your results
+
+Add your improvement to the community results table by opening a pull request.
+Copy the row below and append it to the table in README.md:
+
+| <project-name> | X.Xs → X.Xs (-X.Xs / X% faster) | X.Xs → X.Xs (-X.Xs / X% faster) |
+
+Open a PR: https://github.com/AvdLee/Xcode-Build-Optimization-Agent-Skill/edit/main/README.md
+```
+
+## Usage Notes
+
+- Keep approval-required items explicit.
+- Do not imply that an unapproved recommendation was applied.
+- If results are noisy, say that the verification is inconclusive instead of overstating success.
+- The Build Settings Audit scope is strictly build performance. Do not flag language-migration settings like `SWIFT_STRICT_CONCURRENCY` or `SWIFT_UPCOMING_FEATURE_*`.
+- The Compilation Diagnostics section is populated by `diagnose_compilation.py`. If not run, note that it was skipped.
+- `COMPILATION_CACHE_ENABLE_CACHING` has been measured at 5-14% faster clean builds across tested projects. The benefit compounds in real developer workflows (branch switching, pulling changes, CI with persistent DerivedData). The benchmark script auto-detects this setting and runs a cached clean phase for validation.
+- When recommending SPM version pins, verify that tagged versions exist (`git ls-remote --tags`) before suggesting a pin-to-tag change. If no tags exist, recommend pinning to a commit revision hash.
+- Before including a local package in a build-time recommendation, verify it is referenced in `project.pbxproj` via `XCLocalSwiftPackageReference`. Packages that exist on disk but are not linked do not affect build time.

--- a/.agents/skills/xcode-build-orchestrator/references/recommendation-format.md
+++ b/.agents/skills/xcode-build-orchestrator/references/recommendation-format.md
@@ -1,0 +1,85 @@
+# Recommendation Format
+
+All optimization skills should report recommendations in a shared structure so the orchestrator can merge and prioritize them cleanly.
+
+## Required Fields
+
+Each recommendation should include:
+
+- `title`
+- `wait_time_impact` -- plain-language statement of expected wall-clock impact, e.g. "Expected to reduce your clean build by ~3s", "Reduces parallel compile work but unlikely to reduce build wait time", or "Impact on wait time is uncertain -- re-benchmark to confirm"
+- `actionability` -- classifies how fixable the issue is from the project (see values below)
+- `category`
+- `observed_evidence`
+- `estimated_impact`
+- `confidence`
+- `approval_required`
+- `benchmark_verification_status`
+
+### Actionability Values
+
+Every recommendation must include an `actionability` classification:
+
+- `repo-local` -- Fix lives entirely in project files, source code, or local configuration. The developer can apply it without side effects outside the repo.
+- `package-manager` -- Requires CocoaPods or SPM configuration changes that may have broad side effects (e.g., linkage mode, dependency restructuring). These should be benchmarked before and after.
+- `xcode-behavior` -- Observed cost is driven by Xcode internals and is not suppressible from the project. Report the finding for awareness but do not promise a fix.
+- `upstream` -- Requires changes in a third-party dependency or external tool. The developer cannot fix it locally.
+
+## Suggested Optional Fields
+
+- `scope`
+- `affected_files`
+- `affected_targets`
+- `affected_packages`
+- `implementation_notes`
+- `risk_level`
+
+## JSON Example
+
+```json
+{
+  "recommendations": [
+    {
+      "title": "Guard a release-only symbol upload script",
+      "wait_time_impact": "Expected to reduce your incremental build by approximately 6 seconds.",
+      "actionability": "repo-local",
+      "category": "project",
+      "observed_evidence": [
+        "Incremental builds spend 6.3 seconds in a run script phase.",
+        "The script runs for Debug builds even though the output is only needed in Release."
+      ],
+      "estimated_impact": "High incremental-build improvement",
+      "confidence": "High",
+      "approval_required": true,
+      "benchmark_verification_status": "Not yet verified",
+      "scope": "Target build phase",
+      "risk_level": "Low"
+    }
+  ]
+}
+```
+
+## Markdown Rendering Guidance
+
+When rendering for human review, preserve the same field order:
+
+1. title
+2. wait-time impact
+3. actionability
+4. observed evidence
+5. estimated impact
+6. confidence
+7. approval required
+8. benchmark verification status
+
+That makes it easier for the developer to approve or reject specific items quickly.
+
+## Verification Status Values
+
+Recommended values:
+
+- `Not yet verified`
+- `Queued for verification`
+- `Verified improvement`
+- `No measurable improvement`
+- `Inconclusive due to benchmark noise`

--- a/.agents/skills/xcode-build-orchestrator/scripts/benchmark_builds.py
+++ b/.agents/skills/xcode-build-orchestrator/scripts/benchmark_builds.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import platform
+import re
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Benchmark Xcode clean and incremental builds.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--workspace", help="Path to the .xcworkspace file")
+    group.add_argument("--project", help="Path to the .xcodeproj file")
+    parser.add_argument("--scheme", required=True, help="Scheme to build")
+    parser.add_argument("--configuration", default="Debug", help="Build configuration")
+    parser.add_argument("--destination", help="xcodebuild destination string")
+    parser.add_argument("--derived-data-path", help="DerivedData path override")
+    parser.add_argument("--output-dir", default=".build-benchmark", help="Output directory for artifacts")
+    parser.add_argument("--repeats", type=int, default=3, help="Measured runs per build type")
+    parser.add_argument("--skip-warmup", action="store_true", help="Skip the validation build")
+    parser.add_argument(
+        "--touch-file",
+        help="Path to a source file to touch before each incremental build. "
+        "When provided, measures a real edit-rebuild loop instead of a zero-change build.",
+    )
+    parser.add_argument(
+        "--no-cached-clean",
+        action="store_true",
+        help="Skip cached clean builds even when COMPILATION_CACHE_ENABLE_CACHING is detected.",
+    )
+    parser.add_argument(
+        "--extra-arg",
+        action="append",
+        default=[],
+        help="Additional xcodebuild argument to append. Can be passed multiple times.",
+    )
+    return parser.parse_args()
+
+
+def command_base(args: argparse.Namespace) -> List[str]:
+    command = ["xcodebuild"]
+    if args.workspace:
+        command.extend(["-workspace", args.workspace])
+    if args.project:
+        command.extend(["-project", args.project])
+    command.extend(["-scheme", args.scheme, "-configuration", args.configuration])
+    if args.destination:
+        command.extend(["-destination", args.destination])
+    if args.derived_data_path:
+        command.extend(["-derivedDataPath", args.derived_data_path])
+    command.extend(args.extra_arg)
+    return command
+
+
+def shell_join(parts: List[str]) -> str:
+    return " ".join(subprocess.list2cmdline([part]) for part in parts)
+
+
+_TASK_COUNT_RE = re.compile(r"^(.+?)\s*\((\d+)\s+tasks?\)$")
+
+
+def _extract_task_count(name: str) -> tuple[str, Optional[int]]:
+    """Split 'Category (N tasks)' into ('Category', N)."""
+    match = _TASK_COUNT_RE.match(name)
+    if match:
+        return match.group(1).strip(), int(match.group(2))
+    return name, None
+
+
+def parse_timing_summary(output: str) -> List[Dict]:
+    categories: Dict[str, float] = {}
+    task_counts: Dict[str, Optional[int]] = {}
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        for suffix in (" seconds", " second", " sec"):
+            if not line.endswith(suffix):
+                continue
+            trimmed = line[: -len(suffix)]
+            if "|" in trimmed:
+                name_part, _, seconds_text = trimmed.rpartition("|")
+            else:
+                name_part, _, seconds_text = trimmed.rpartition(" ")
+            try:
+                seconds = float(seconds_text.strip())
+            except ValueError:
+                continue
+            cleaned_name = name_part.replace("  ", " ").strip(" -:")
+            if len(cleaned_name) < 3:
+                continue
+            base_name, count = _extract_task_count(cleaned_name)
+            categories[base_name] = categories.get(base_name, 0.0) + seconds
+            if count is not None:
+                task_counts[base_name] = (task_counts.get(base_name) or 0) + count
+            break
+    result: List[Dict] = []
+    for name, seconds in sorted(categories.items(), key=lambda item: item[1], reverse=True):
+        entry: Dict = {"name": name, "seconds": round(seconds, 3)}
+        if name in task_counts:
+            entry["task_count"] = task_counts[name]
+        result.append(entry)
+    return result
+
+
+def run_command(command: List[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(command, capture_output=True, text=True)
+
+
+def stats_for(runs: List[Dict[str, object]]) -> Dict[str, float]:
+    durations = [run["duration_seconds"] for run in runs if run.get("success")]
+    if not durations:
+        return {
+            "count": 0,
+            "min_seconds": 0.0,
+            "max_seconds": 0.0,
+            "median_seconds": 0.0,
+            "average_seconds": 0.0,
+        }
+    return {
+        "count": len(durations),
+        "min_seconds": round(min(durations), 3),
+        "max_seconds": round(max(durations), 3),
+        "median_seconds": round(statistics.median(durations), 3),
+        "average_seconds": round(statistics.fmean(durations), 3),
+    }
+
+
+def xcode_version() -> str:
+    result = run_command(["xcodebuild", "-version"])
+    return result.stdout.strip() if result.returncode == 0 else "unknown"
+
+
+def detect_compilation_caching(base_command: List[str]) -> bool:
+    """Check whether COMPILATION_CACHE_ENABLE_CACHING is enabled in the resolved build settings."""
+    result = run_command([*base_command, "-showBuildSettings"])
+    if result.returncode != 0:
+        return False
+    for line in result.stdout.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("COMPILATION_CACHE_ENABLE_CACHING") and "=" in stripped:
+            value = stripped.split("=", 1)[1].strip()
+            return value == "YES"
+    return False
+
+
+def measure_build(
+    base_command: List[str],
+    artifact_stem: str,
+    output_dir: Path,
+    build_type: str,
+    run_index: int,
+) -> Dict[str, object]:
+    build_command = [*base_command, "build", "-showBuildTimingSummary"]
+    started = time.perf_counter()
+    result = run_command(build_command)
+    elapsed = round(time.perf_counter() - started, 3)
+    log_path = output_dir / f"{artifact_stem}-{build_type}-{run_index}.log"
+    log_path.write_text(result.stdout + result.stderr)
+    return {
+        "id": f"{build_type}-{run_index}",
+        "build_type": build_type,
+        "duration_seconds": elapsed,
+        "success": result.returncode == 0,
+        "exit_code": result.returncode,
+        "command": shell_join(build_command),
+        "raw_log_path": str(log_path),
+        "timing_summary_categories": parse_timing_summary(result.stdout + result.stderr),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    artifact_stem = f"{timestamp}-{args.scheme.replace(' ', '-').lower()}"
+    base_command = command_base(args)
+
+    if not args.skip_warmup:
+        warmup = run_command([*base_command, "build"])
+        if warmup.returncode != 0:
+          sys.stderr.write(warmup.stdout + warmup.stderr)
+          return warmup.returncode
+        warmup_clean = run_command([*base_command, "clean"])
+        if warmup_clean.returncode != 0:
+            sys.stderr.write(warmup_clean.stdout + warmup_clean.stderr)
+            return warmup_clean.returncode
+        warmup_rebuild = run_command([*base_command, "build"])
+        if warmup_rebuild.returncode != 0:
+            sys.stderr.write(warmup_rebuild.stdout + warmup_rebuild.stderr)
+            return warmup_rebuild.returncode
+
+    runs: Dict[str, list] = {"clean": [], "incremental": []}
+
+    for index in range(1, args.repeats + 1):
+        clean_result = run_command([*base_command, "clean"])
+        clean_log_path = output_dir / f"{artifact_stem}-clean-prep-{index}.log"
+        clean_log_path.write_text(clean_result.stdout + clean_result.stderr)
+        if clean_result.returncode != 0:
+            sys.stderr.write(clean_result.stdout + clean_result.stderr)
+            return clean_result.returncode
+        runs["clean"].append(measure_build(base_command, artifact_stem, output_dir, "clean", index))
+
+    # --- Cached clean builds ---------------------------------------------------
+    # When COMPILATION_CACHE_ENABLE_CACHING is enabled, the compilation cache lives outside
+    # DerivedData and survives product deletion.  We measure "cached clean"
+    # builds by pointing DerivedData at a temp directory, warming the cache with
+    # one build, then deleting the DerivedData directory (but not the cache)
+    # before each measured rebuild.  This captures the realistic scenario:
+    # branch switching, pulling changes, or Clean Build Folder.
+    should_cached_clean = not args.no_cached_clean and detect_compilation_caching(base_command)
+    if should_cached_clean:
+        dd_path = Path(args.derived_data_path) if args.derived_data_path else Path(
+            tempfile.mkdtemp(prefix="xcode-bench-dd-")
+        )
+        cached_cmd = list(base_command)
+        if not args.derived_data_path:
+            cached_cmd.extend(["-derivedDataPath", str(dd_path)])
+
+        cache_warmup = run_command([*cached_cmd, "build"])
+        if cache_warmup.returncode != 0:
+            sys.stderr.write("Warning: cached clean warmup build failed, skipping cached clean benchmarks.\n")
+            sys.stderr.write(cache_warmup.stdout + cache_warmup.stderr)
+            should_cached_clean = False
+
+    if should_cached_clean:
+        runs["cached_clean"] = []
+        for index in range(1, args.repeats + 1):
+            shutil.rmtree(dd_path, ignore_errors=True)
+            runs["cached_clean"].append(
+                measure_build(cached_cmd, artifact_stem, output_dir, "cached-clean", index)
+            )
+        shutil.rmtree(dd_path, ignore_errors=True)
+
+    # --- Incremental / zero-change builds --------------------------------------
+    incremental_label = "incremental"
+    if args.touch_file:
+        touch_path = Path(args.touch_file)
+        if not touch_path.exists():
+            sys.stderr.write(f"--touch-file path does not exist: {touch_path}\n")
+            return 1
+        incremental_label = "incremental"
+    else:
+        incremental_label = "zero-change"
+
+    for index in range(1, args.repeats + 1):
+        if args.touch_file:
+            touch_path.touch()
+        runs["incremental"].append(
+            measure_build(base_command, artifact_stem, output_dir, incremental_label, index)
+        )
+
+    summary: Dict[str, object] = {
+        "clean": stats_for(runs["clean"]),
+        "incremental": stats_for(runs["incremental"]),
+    }
+    if "cached_clean" in runs:
+        summary["cached_clean"] = stats_for(runs["cached_clean"])
+
+    artifact = {
+        "schema_version": "1.2.0" if "cached_clean" in runs else "1.1.0",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "build": {
+            "entrypoint": "workspace" if args.workspace else "project",
+            "path": args.workspace or args.project,
+            "scheme": args.scheme,
+            "configuration": args.configuration,
+            "destination": args.destination or "",
+            "derived_data_path": args.derived_data_path or "",
+            "command": shell_join(base_command),
+        },
+        "environment": {
+            "host": platform.node(),
+            "macos_version": platform.platform(),
+            "xcode_version": xcode_version(),
+            "cwd": os.getcwd(),
+        },
+        "runs": runs,
+        "summary": summary,
+        "notes": [f"touch-file: {args.touch_file}"] if args.touch_file else [],
+    }
+
+    artifact_path = output_dir / f"{artifact_stem}.json"
+    artifact_path.write_text(json.dumps(artifact, indent=2) + "\n")
+
+    print(f"Saved benchmark artifact: {artifact_path}")
+    print(f"Clean median: {artifact['summary']['clean']['median_seconds']}s")
+    if "cached_clean" in artifact["summary"]:
+        print(f"Cached clean median: {artifact['summary']['cached_clean']['median_seconds']}s")
+    inc_label = "Incremental" if args.touch_file else "Zero-change"
+    print(f"{inc_label} median: {artifact['summary']['incremental']['median_seconds']}s")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/xcode-build-orchestrator/scripts/diagnose_compilation.py
+++ b/.agents/skills/xcode-build-orchestrator/scripts/diagnose_compilation.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+
+"""Run a single Xcode build with -Xfrontend diagnostics to find slow type-checking."""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+_TYPECHECK_RE = re.compile(
+    r"^(?P<file>.+?):(?P<line>\d+):(?P<col>\d+): warning: "
+    r"(?P<kind>instance method|global function|getter|type-check|expression) "
+    r"'?(?P<name>[^']*?)'?\s+took\s+(?P<ms>\d+)ms\s+to\s+type-check"
+)
+
+_EXPRESSION_RE = re.compile(
+    r"^(?P<file>.+?):(?P<line>\d+):(?P<col>\d+): warning: "
+    r"expression took\s+(?P<ms>\d+)ms\s+to\s+type-check"
+)
+
+_FILE_TIME_RE = re.compile(
+    r"^\s*(?P<seconds>\d+(?:\.\d+)?)\s+seconds\s+.*\s+compiling\s+(?P<file>\S+)"
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run an Xcode build with -Xfrontend type-checking diagnostics."
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--workspace", help="Path to the .xcworkspace file")
+    group.add_argument("--project", help="Path to the .xcodeproj file")
+    parser.add_argument("--scheme", required=True, help="Scheme to build")
+    parser.add_argument("--configuration", default="Debug", help="Build configuration")
+    parser.add_argument("--destination", help="xcodebuild destination string")
+    parser.add_argument("--derived-data-path", help="DerivedData path override")
+    parser.add_argument("--output-dir", default=".build-benchmark", help="Output directory")
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=100,
+        help="Millisecond threshold for -warn-long-function-bodies and "
+        "-warn-long-expression-type-checking (default: 100)",
+    )
+    parser.add_argument("--skip-clean", action="store_true", help="Skip clean before build")
+    parser.add_argument(
+        "--per-file-timing",
+        action="store_true",
+        help="Add -Xfrontend -debug-time-compilation to report per-file compile times.",
+    )
+    parser.add_argument(
+        "--stats-output",
+        action="store_true",
+        help="Add -Xfrontend -stats-output-dir to collect detailed compiler statistics.",
+    )
+    parser.add_argument(
+        "--extra-arg",
+        action="append",
+        default=[],
+        help="Additional xcodebuild argument. Can be passed multiple times.",
+    )
+    return parser.parse_args()
+
+
+def command_base(args: argparse.Namespace) -> List[str]:
+    command = ["xcodebuild"]
+    if args.workspace:
+        command.extend(["-workspace", args.workspace])
+    if args.project:
+        command.extend(["-project", args.project])
+    command.extend(["-scheme", args.scheme, "-configuration", args.configuration])
+    if args.destination:
+        command.extend(["-destination", args.destination])
+    if args.derived_data_path:
+        command.extend(["-derivedDataPath", args.derived_data_path])
+    command.extend(args.extra_arg)
+    return command
+
+
+def parse_diagnostics(output: str) -> List[Dict]:
+    """Extract type-checking warnings from xcodebuild output."""
+    warnings: List[Dict] = []
+    seen = set()
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        match = _TYPECHECK_RE.match(line)
+        if match:
+            key = (match.group("file"), match.group("line"), match.group("col"), "function-body")
+            if key in seen:
+                continue
+            seen.add(key)
+            warnings.append(
+                {
+                    "file": match.group("file"),
+                    "line": int(match.group("line")),
+                    "column": int(match.group("col")),
+                    "duration_ms": int(match.group("ms")),
+                    "kind": "function-body",
+                    "name": match.group("name"),
+                }
+            )
+            continue
+        match = _EXPRESSION_RE.match(line)
+        if match:
+            key = (match.group("file"), match.group("line"), match.group("col"), "expression")
+            if key in seen:
+                continue
+            seen.add(key)
+            warnings.append(
+                {
+                    "file": match.group("file"),
+                    "line": int(match.group("line")),
+                    "column": int(match.group("col")),
+                    "duration_ms": int(match.group("ms")),
+                    "kind": "expression",
+                    "name": "",
+                }
+            )
+    warnings.sort(key=lambda w: w["duration_ms"], reverse=True)
+    return warnings
+
+
+def parse_file_timings(output: str) -> List[Dict]:
+    """Extract per-file compile times from -debug-time-compilation output."""
+    timings: List[Dict] = []
+    seen = set()
+    for raw_line in output.splitlines():
+        match = _FILE_TIME_RE.match(raw_line.strip())
+        if match:
+            filepath = match.group("file")
+            if filepath in seen:
+                continue
+            seen.add(filepath)
+            timings.append(
+                {
+                    "file": filepath,
+                    "duration_seconds": float(match.group("seconds")),
+                }
+            )
+    timings.sort(key=lambda t: t["duration_seconds"], reverse=True)
+    return timings
+
+
+def main() -> int:
+    args = parse_args()
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    scheme_slug = args.scheme.replace(" ", "-").lower()
+    artifact_stem = f"{timestamp}-{scheme_slug}"
+    base = command_base(args)
+
+    if not args.skip_clean:
+        print("Cleaning build products...")
+        clean = subprocess.run([*base, "clean"], capture_output=True, text=True)
+        if clean.returncode != 0:
+            sys.stderr.write(clean.stdout + clean.stderr)
+            return clean.returncode
+
+    threshold = str(args.threshold)
+    swift_flags = (
+        f"$(inherited) -Xfrontend -warn-long-function-bodies={threshold} "
+        f"-Xfrontend -warn-long-expression-type-checking={threshold}"
+    )
+    if args.per_file_timing:
+        swift_flags += " -Xfrontend -debug-time-compilation"
+
+    stats_dir: Optional[Path] = None
+    if args.stats_output:
+        stats_dir = output_dir / f"{artifact_stem}-stats"
+        stats_dir.mkdir(parents=True, exist_ok=True)
+        swift_flags += f" -Xfrontend -stats-output-dir -Xfrontend {stats_dir}"
+
+    build_command = [
+        *base,
+        "build",
+        "-showBuildTimingSummary",
+        f"OTHER_SWIFT_FLAGS={swift_flags}",
+    ]
+
+    extras = []
+    if args.per_file_timing:
+        extras.append("per-file timing")
+    if args.stats_output:
+        extras.append("stats output")
+    extras_label = f" + {', '.join(extras)}" if extras else ""
+    print(f"Building with type-check threshold {threshold}ms{extras_label}...")
+    started = time.perf_counter()
+    result = subprocess.run(build_command, capture_output=True, text=True)
+    elapsed = round(time.perf_counter() - started, 3)
+
+    combined_output = result.stdout + result.stderr
+    log_path = output_dir / f"{artifact_stem}-diagnostics.log"
+    log_path.write_text(combined_output)
+
+    warnings = parse_diagnostics(combined_output)
+
+    file_timings: Optional[List[Dict]] = None
+    if args.per_file_timing:
+        file_timings = parse_file_timings(combined_output)
+
+    artifact = {
+        "schema_version": "1.0.0",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "type": "compilation-diagnostics",
+        "build": {
+            "entrypoint": "workspace" if args.workspace else "project",
+            "path": args.workspace or args.project,
+            "scheme": args.scheme,
+            "configuration": args.configuration,
+            "destination": args.destination or "",
+        },
+        "threshold_ms": args.threshold,
+        "build_duration_seconds": elapsed,
+        "build_success": result.returncode == 0,
+        "raw_log_path": str(log_path),
+        "warnings": warnings,
+        "summary": {
+            "total_warnings": len(warnings),
+            "function_body_warnings": sum(1 for w in warnings if w["kind"] == "function-body"),
+            "expression_warnings": sum(1 for w in warnings if w["kind"] == "expression"),
+            "slowest_ms": warnings[0]["duration_ms"] if warnings else 0,
+        },
+    }
+
+    if file_timings is not None:
+        artifact["per_file_timings"] = file_timings
+    if stats_dir is not None:
+        artifact["stats_dir"] = str(stats_dir)
+
+    artifact_path = output_dir / f"{artifact_stem}-diagnostics.json"
+    artifact_path.write_text(json.dumps(artifact, indent=2) + "\n")
+
+    print(f"\nSaved diagnostics artifact: {artifact_path}")
+    print(f"Build {'succeeded' if result.returncode == 0 else 'failed'} in {elapsed}s")
+    print(f"Found {len(warnings)} type-check warnings above {threshold}ms threshold\n")
+
+    if warnings:
+        print(f"{'Duration':>10}  {'Kind':<15}  {'Location'}")
+        print(f"{'--------':>10}  {'----':<15}  {'--------'}")
+        for w in warnings[:20]:
+            loc = f"{w['file']}:{w['line']}:{w['column']}"
+            label = w["name"] if w["name"] else "(expression)"
+            print(f"{w['duration_ms']:>8}ms  {w['kind']:<15}  {loc}  {label}")
+        if len(warnings) > 20:
+            print(f"\n  ... and {len(warnings) - 20} more (see {artifact_path})")
+    else:
+        print("No type-checking hotspots found above threshold.")
+
+    if file_timings:
+        print(f"\nPer-file compile times (top 20):\n")
+        print(f"{'Duration':>12}  {'File'}")
+        print(f"{'--------':>12}  {'----'}")
+        for t in file_timings[:20]:
+            print(f"{t['duration_seconds']:>10.3f}s  {t['file']}")
+        if len(file_timings) > 20:
+            print(f"\n  ... and {len(file_timings) - 20} more (see {artifact_path})")
+
+    if stats_dir is not None:
+        stat_files = list(stats_dir.glob("*.json"))
+        print(f"\nCompiler statistics: {len(stat_files)} files written to {stats_dir}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/xcode-build-orchestrator/scripts/generate_optimization_report.py
+++ b/.agents/skills/xcode-build-orchestrator/scripts/generate_optimization_report.py
@@ -1,0 +1,533 @@
+#!/usr/bin/env python3
+
+"""Generate a Markdown optimization report from benchmark and diagnostics artifacts."""
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+
+# ---------------------------------------------------------------------------
+# pbxproj helpers
+# ---------------------------------------------------------------------------
+
+_SETTING_RE = re.compile(r"^\s*([A-Z_][A-Z_0-9]*)\s*=\s*(.+?)\s*;", re.MULTILINE)
+
+_CONFIG_ID_RE = re.compile(r"([0-9A-F]{24})\s*/\*\s*(Debug|Release)\s*\*/")
+
+_CONFIG_LIST_RE = re.compile(
+    r"([0-9A-F]{24})\s*/\*\s*Build configuration list for "
+    r"(?P<kind>PBXProject|PBXNativeTarget)\s+\"(?P<name>[^\"]+)\"\s*\*/"
+)
+
+
+def _parse_all_build_configs(pbxproj: str) -> Dict[str, Tuple[str, Dict[str, str]]]:
+    """Return {config_id: (config_name, {key: value})} for every XCBuildConfiguration."""
+    configs: Dict[str, Tuple[str, Dict[str, str]]] = {}
+    for match in re.finditer(
+        r"([0-9A-F]{24})\s*/\*\s*(Debug|Release)\s*\*/\s*=\s*\{\s*"
+        r"isa\s*=\s*XCBuildConfiguration;\s*buildSettings\s*=\s*\{([^}]*)\}",
+        pbxproj,
+        re.DOTALL,
+    ):
+        config_id = match.group(1)
+        config_name = match.group(2)
+        body = match.group(3)
+        settings: Dict[str, str] = {}
+        for s in _SETTING_RE.finditer(body):
+            val = s.group(2).strip().strip('"')
+            settings[s.group(1)] = val
+        configs[config_id] = (config_name, settings)
+    return configs
+
+
+def _resolve_config_list(
+    pbxproj: str, all_configs: Dict[str, Tuple[str, Dict[str, str]]], kind: str
+) -> Dict[str, Dict[str, Dict[str, str]]]:
+    """Resolve configuration lists for a given kind (PBXProject or PBXNativeTarget)."""
+    results: Dict[str, Dict[str, Dict[str, str]]] = {}
+    for list_match in _CONFIG_LIST_RE.finditer(pbxproj):
+        if list_match.group("kind") != kind:
+            continue
+        entity_name = list_match.group("name")
+        list_id = list_match.group(1)
+        block_start = pbxproj.find(f"{list_id} /*", list_match.end())
+        if block_start == -1:
+            block_start = list_match.start()
+        block = pbxproj[block_start : block_start + 500]
+        configs: Dict[str, Dict[str, str]] = {}
+        for cid_match in _CONFIG_ID_RE.finditer(block):
+            cid = cid_match.group(1)
+            if cid in all_configs:
+                cname, settings = all_configs[cid]
+                configs[cname] = settings
+        if configs:
+            results[entity_name] = configs
+    return results
+
+
+def _parse_project_level_configs(pbxproj: str) -> Dict[str, Dict[str, str]]:
+    """Extract project-level Debug and Release build settings."""
+    all_configs = _parse_all_build_configs(pbxproj)
+    resolved = _resolve_config_list(pbxproj, all_configs, "PBXProject")
+    if resolved:
+        return next(iter(resolved.values()))
+    return {}
+
+
+def _parse_target_configs(pbxproj: str) -> Dict[str, Dict[str, Dict[str, str]]]:
+    """Extract per-target Debug and Release build settings."""
+    all_configs = _parse_all_build_configs(pbxproj)
+    return _resolve_config_list(pbxproj, all_configs, "PBXNativeTarget")
+
+
+# ---------------------------------------------------------------------------
+# Best-practices audit
+# ---------------------------------------------------------------------------
+
+_DEBUG_EXPECTATIONS: List[Tuple[str, str, str]] = [
+    ("SWIFT_COMPILATION_MODE", "singlefile", "Single-file mode recompiles only changed files (Xcode UI: Incremental)"),
+    ("SWIFT_OPTIMIZATION_LEVEL", "-Onone", "Optimization passes add compile time without debug benefit"),
+    ("GCC_OPTIMIZATION_LEVEL", "0", "C/ObjC optimization adds compile time without debug benefit"),
+    ("ONLY_ACTIVE_ARCH", "YES", "Building all architectures multiplies compile and link time"),
+    ("DEBUG_INFORMATION_FORMAT", "dwarf", "dwarf-with-dsym generates a separate dSYM, adding overhead"),
+    ("ENABLE_TESTABILITY", "YES", "Required for @testable import during development"),
+    ("EAGER_LINKING", "YES", "Allows linker to start before all compilation finishes, reducing wall-clock time"),
+]
+
+_GENERAL_EXPECTATIONS: List[Tuple[str, str, str]] = [
+    ("COMPILATION_CACHE_ENABLE_CACHING", "YES", "Caches compilation results so repeat builds of unchanged inputs are served from cache. Measured 5-14% faster clean builds across tested projects; benefit compounds during branch switching and pulling changes"),
+]
+
+_RELEASE_EXPECTATIONS: List[Tuple[str, str, str]] = [
+    ("SWIFT_COMPILATION_MODE", "wholemodule", "Whole-module optimization produces faster runtime code"),
+    ("SWIFT_OPTIMIZATION_LEVEL", "-O", "Optimized binaries for production (-Osize also acceptable)"),
+    ("GCC_OPTIMIZATION_LEVEL", "s", "Optimizes C/ObjC for size in release"),
+    ("ONLY_ACTIVE_ARCH", "NO", "Release builds must include all architectures for distribution"),
+    ("DEBUG_INFORMATION_FORMAT", "dwarf-with-dsym", "dSYM bundles are needed for crash symbolication"),
+    ("ENABLE_TESTABILITY", "NO", "Removes internal-symbol export overhead from release builds"),
+]
+
+_CONSISTENCY_KEYS = [
+    "SWIFT_COMPILATION_MODE",
+    "SWIFT_OPTIMIZATION_LEVEL",
+    "ONLY_ACTIVE_ARCH",
+    "DEBUG_INFORMATION_FORMAT",
+]
+
+
+def _effective_value(
+    project: Dict[str, str], target: Dict[str, str], key: str
+) -> Optional[str]:
+    return target.get(key, project.get(key))
+
+
+def _check(actual: Optional[str], expected: str) -> bool:
+    if actual is None:
+        if expected in ("singlefile",):
+            return True
+        return False
+    if expected == "-O" and actual in ("-O", '"-O"', '"-Osize"', "-Osize"):
+        return True
+    return actual.strip('"') == expected
+
+
+def _merged_project_settings(
+    project_configs: Dict[str, Dict[str, str]],
+) -> Dict[str, str]:
+    """Return a flat dict of all settings across Debug and Release for general checks."""
+    merged: Dict[str, str] = {}
+    for config in project_configs.values():
+        merged.update(config)
+    return merged
+
+
+def _audit_config(
+    project_settings: Dict[str, str],
+    expectations: List[Tuple[str, str, str]],
+    config_name: str,
+) -> List[str]:
+    lines: List[str] = []
+    for key, expected, _reason in expectations:
+        actual = project_settings.get(key)
+        display_actual = actual if actual else "(unset)"
+        passed = _check(actual, expected)
+        mark = "[x]" if passed else "[ ]"
+        lines.append(f"- {mark} `{key}`: `{display_actual}` (recommended: `{expected}`)")
+    return lines
+
+
+def _audit_consistency(
+    project_configs: Dict[str, Dict[str, str]],
+    target_configs: Dict[str, Dict[str, Dict[str, str]]],
+) -> List[str]:
+    lines: List[str] = []
+    for key in _CONSISTENCY_KEYS:
+        overrides = []
+        for target_name, configs in target_configs.items():
+            for config_name in ("Debug", "Release"):
+                target_settings = configs.get(config_name, {})
+                if key in target_settings:
+                    proj_val = project_configs.get(config_name, {}).get(key, "(unset)")
+                    tgt_val = target_settings[key]
+                    if tgt_val != proj_val:
+                        overrides.append(
+                            f"{target_name} ({config_name}): `{tgt_val}` vs project `{proj_val}`"
+                        )
+        if overrides:
+            lines.append(f"- [ ] `{key}` has target-level overrides:")
+            for o in overrides:
+                lines.append(f"  - {o}")
+        else:
+            lines.append(f"- [x] `{key}` is consistent across all targets")
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Auto-generated recommendations from audit
+# ---------------------------------------------------------------------------
+
+
+def _auto_recommendations_from_audit(
+    project_configs: Dict[str, Dict[str, str]],
+) -> Dict[str, Any]:
+    """Generate basic recommendations from failing build settings audit checks."""
+    items: List[Dict[str, str]] = []
+
+    debug_settings = project_configs.get("Debug", {})
+    for key, expected, reason in _DEBUG_EXPECTATIONS:
+        if not _check(debug_settings.get(key), expected):
+            actual = debug_settings.get(key, "(unset)")
+            items.append({
+                "title": f"Set `{key}` to `{expected}` for Debug",
+                "category": "build-settings",
+                "observed_evidence": f"Current value: `{actual}`. {reason}.",
+                "estimated_impact": "Medium",
+                "confidence": "High",
+                "risk_level": "Low",
+            })
+
+    merged = {}
+    for config in project_configs.values():
+        merged.update(config)
+    for key, expected, reason in _GENERAL_EXPECTATIONS:
+        if not _check(merged.get(key), expected):
+            actual = merged.get(key, "(unset)")
+            items.append({
+                "title": f"Enable `{key} = {expected}`",
+                "category": "build-settings",
+                "observed_evidence": f"Current value: `{actual}`. {reason}.",
+                "estimated_impact": "High",
+                "confidence": "High",
+                "risk_level": "Low",
+            })
+
+    release_settings = project_configs.get("Release", {})
+    for key, expected, reason in _RELEASE_EXPECTATIONS:
+        if not _check(release_settings.get(key), expected):
+            actual = release_settings.get(key, "(unset)")
+            items.append({
+                "title": f"Set `{key}` to `{expected}` for Release",
+                "category": "build-settings",
+                "observed_evidence": f"Current value: `{actual}`. {reason}.",
+                "estimated_impact": "Medium",
+                "confidence": "High",
+                "risk_level": "Low",
+            })
+
+    if not items:
+        return {"recommendations": []}
+    return {"recommendations": items}
+
+
+# ---------------------------------------------------------------------------
+# Report generation
+# ---------------------------------------------------------------------------
+
+
+def _section_context(benchmark: Dict[str, Any]) -> str:
+    build = benchmark.get("build", {})
+    env = benchmark.get("environment", {})
+    lines = [
+        "## Project Context\n",
+        f"- **Project:** `{build.get('path', 'unknown')}`",
+        f"- **Scheme:** `{build.get('scheme', 'unknown')}`",
+        f"- **Configuration:** `{build.get('configuration', 'unknown')}`",
+        f"- **Destination:** `{build.get('destination', 'unknown')}`",
+        f"- **Xcode:** {env.get('xcode_version', 'unknown').replace(chr(10), ' ')}",
+        f"- **macOS:** {env.get('macos_version', 'unknown')}",
+        f"- **Date:** {benchmark.get('created_at', 'unknown')}",
+        f"- **Benchmark artifact:** `{benchmark.get('_artifact_path', 'unknown')}`",
+    ]
+    return "\n".join(lines)
+
+
+def _section_baseline(benchmark: Dict[str, Any]) -> str:
+    summary = benchmark.get("summary", {})
+    clean = summary.get("clean", {})
+    cached_clean = summary.get("cached_clean", {})
+    incremental = summary.get("incremental", {})
+    has_cached = bool(cached_clean and cached_clean.get("count", 0) > 0)
+
+    if has_cached:
+        lines = [
+            "## Baseline Benchmarks\n",
+            "| Metric | Clean | Cached Clean | Incremental |",
+            "|--------|-------|-------------|-------------|",
+            f"| Median | {clean.get('median_seconds', 0):.3f}s | {cached_clean.get('median_seconds', 0):.3f}s | {incremental.get('median_seconds', 0):.3f}s |",
+            f"| Min | {clean.get('min_seconds', 0):.3f}s | {cached_clean.get('min_seconds', 0):.3f}s | {incremental.get('min_seconds', 0):.3f}s |",
+            f"| Max | {clean.get('max_seconds', 0):.3f}s | {cached_clean.get('max_seconds', 0):.3f}s | {incremental.get('max_seconds', 0):.3f}s |",
+            f"| Runs | {clean.get('count', 0)} | {cached_clean.get('count', 0)} | {incremental.get('count', 0)} |",
+        ]
+        lines.append(
+            "\n> **Cached Clean** = clean build with a warm compilation cache. "
+            "This is the realistic scenario for branch switching, pulling changes, or "
+            "Clean Build Folder. The compilation cache lives outside DerivedData and "
+            "survives product deletion.\n"
+        )
+    else:
+        lines = [
+            "## Baseline Benchmarks\n",
+            "| Metric | Clean | Incremental |",
+            "|--------|-------|-------------|",
+            f"| Median | {clean.get('median_seconds', 0):.3f}s | {incremental.get('median_seconds', 0):.3f}s |",
+            f"| Min | {clean.get('min_seconds', 0):.3f}s | {incremental.get('min_seconds', 0):.3f}s |",
+            f"| Max | {clean.get('max_seconds', 0):.3f}s | {incremental.get('max_seconds', 0):.3f}s |",
+            f"| Runs | {clean.get('count', 0)} | {incremental.get('count', 0)} |",
+        ]
+
+    build_types = ["clean", "cached_clean", "incremental"] if has_cached else ["clean", "incremental"]
+    label_map = {"clean": "Clean", "cached_clean": "Cached Clean", "incremental": "Incremental"}
+    for build_type in build_types:
+        runs = benchmark.get("runs", {}).get(build_type, [])
+        all_cats: Dict[str, Dict] = {}
+        for run in runs:
+            for cat in run.get("timing_summary_categories", []):
+                name = cat["name"]
+                if name not in all_cats:
+                    all_cats[name] = {"seconds": 0.0, "task_count": 0}
+                all_cats[name]["seconds"] += cat["seconds"]
+                all_cats[name]["task_count"] += cat.get("task_count", 0)
+        if all_cats:
+            count = len(runs) or 1
+            ranked = sorted(all_cats.items(), key=lambda x: x[1]["seconds"], reverse=True)
+            label = label_map.get(build_type, build_type.title())
+            lines.append(f"\n### {label} Build Timing Summary\n")
+            lines.append(
+                "> **Note:** These are aggregated task times across all CPU cores. "
+                "Because Xcode runs many tasks in parallel, these totals typically exceed "
+                "the actual build wait time shown above. A large number here does not mean "
+                "it is blocking your build.\n"
+            )
+            lines.append("| Category | Tasks | Seconds |")
+            lines.append("|----------|------:|--------:|")
+            for name, data in ranked:
+                avg_sec = data["seconds"] / count
+                tasks = data["task_count"] // count if data["task_count"] else ""
+                lines.append(f"| {name} | {tasks} | {avg_sec:.3f}s |")
+
+    return "\n".join(lines)
+
+
+def _section_settings_audit(
+    project_configs: Dict[str, Dict[str, str]],
+    target_configs: Dict[str, Dict[str, Dict[str, str]]],
+) -> str:
+    lines = ["## Build Settings Audit\n"]
+
+    lines.append("### Debug Configuration\n")
+    lines.extend(_audit_config(project_configs.get("Debug", {}), _DEBUG_EXPECTATIONS, "Debug"))
+
+    lines.append("\n### General (All Configurations)\n")
+    merged = _merged_project_settings(project_configs)
+    lines.extend(_audit_config(merged, _GENERAL_EXPECTATIONS, "General"))
+
+    lines.append("\n### Release Configuration\n")
+    lines.extend(_audit_config(project_configs.get("Release", {}), _RELEASE_EXPECTATIONS, "Release"))
+
+    lines.append("\n### Cross-Target Consistency\n")
+    lines.extend(_audit_consistency(project_configs, target_configs))
+
+    return "\n".join(lines)
+
+
+def _section_diagnostics(diagnostics: Optional[Dict[str, Any]]) -> str:
+    if diagnostics is None:
+        return "## Compilation Diagnostics\n\nNo diagnostics artifact provided. Run `diagnose_compilation.py` to identify type-checking hotspots."
+    warnings = diagnostics.get("warnings", [])
+    summary = diagnostics.get("summary", {})
+    threshold = diagnostics.get("threshold_ms", 100)
+    lines = [
+        "## Compilation Diagnostics\n",
+        f"Threshold: {threshold}ms | "
+        f"Total warnings: {summary.get('total_warnings', 0)} | "
+        f"Function bodies: {summary.get('function_body_warnings', 0)} | "
+        f"Expressions: {summary.get('expression_warnings', 0)}\n",
+    ]
+    if warnings:
+        lines.append("| Duration | Kind | File | Line | Name |")
+        lines.append("|---------:|------|------|-----:|------|")
+        for w in warnings[:30]:
+            short_file = Path(w["file"]).name
+            name = w.get("name", "") or "(expression)"
+            lines.append(
+                f"| {w['duration_ms']}ms | {w['kind']} | {short_file} | {w['line']} | {name} |"
+            )
+        if len(warnings) > 30:
+            lines.append(f"\n*... and {len(warnings) - 30} more warnings (see full artifact)*")
+    else:
+        lines.append("No type-checking hotspots found above threshold.")
+    return "\n".join(lines)
+
+
+def _section_recommendations(recommendations: Optional[Dict[str, Any]]) -> str:
+    if recommendations is None:
+        return "## Prioritized Recommendations\n\nNo recommendations artifact provided."
+    items = recommendations.get("recommendations", [])
+    if not items:
+        return "## Prioritized Recommendations\n\nNo recommendations found."
+    lines = ["## Prioritized Recommendations\n"]
+    for i, item in enumerate(items, 1):
+        title = item.get("title", "Untitled")
+        lines.append(f"### {i}. {title}\n")
+        for field, label in [
+            ("wait_time_impact", "Wait-Time Impact"),
+            ("actionability", "Actionability"),
+            ("category", "Category"),
+            ("observed_evidence", "Evidence"),
+            ("estimated_impact", "Impact"),
+            ("confidence", "Confidence"),
+            ("risk_level", "Risk"),
+            ("scope", "Scope"),
+        ]:
+            val = item.get(field)
+            if val is None:
+                continue
+            if isinstance(val, list):
+                lines.append(f"**{label}:**")
+                for entry in val:
+                    lines.append(f"- {entry}")
+            else:
+                lines.append(f"**{label}:** {val}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _section_approval(recommendations: Optional[Dict[str, Any]]) -> str:
+    if recommendations is None:
+        return "## Approval Checklist\n\nNo recommendations to approve."
+    items = recommendations.get("recommendations", [])
+    if not items:
+        return "## Approval Checklist\n\nNo recommendations to approve."
+    lines = ["## Approval Checklist\n"]
+    for i, item in enumerate(items, 1):
+        title = item.get("title", "Untitled")
+        wait_impact = item.get("wait_time_impact", "")
+        impact = item.get("estimated_impact", "")
+        risk = item.get("risk_level", "")
+        actionability = item.get("actionability", "")
+        impact_str = wait_impact if wait_impact else impact
+        actionability_str = f" | Actionability: {actionability}" if actionability else ""
+        lines.append(f"- [ ] **{i}. {title}** -- Impact: {impact_str}{actionability_str} | Risk: {risk}")
+    return "\n".join(lines)
+
+
+def _section_next_steps(benchmark: Dict[str, Any]) -> str:
+    build = benchmark.get("build", {})
+    command = build.get("command", "xcodebuild build")
+    lines = [
+        "## Next Steps\n",
+        "After implementing approved changes, re-benchmark with the same inputs:\n",
+        "```bash",
+        f"python3 scripts/benchmark_builds.py \\",
+    ]
+    if build.get("entrypoint") == "workspace":
+        lines.append(f"  --workspace {build.get('path', 'App.xcworkspace')} \\")
+    else:
+        lines.append(f"  --project {build.get('path', 'App.xcodeproj')} \\")
+    lines.extend([
+        f"  --scheme {build.get('scheme', 'App')} \\",
+        f"  --configuration {build.get('configuration', 'Debug')} \\",
+    ])
+    if build.get("destination"):
+        lines.append(f'  --destination "{build["destination"]}" \\')
+    lines.append("  --output-dir .build-benchmark")
+    lines.append("```\n")
+    lines.append("Compare the new wall-clock medians against the baseline. Report results as:")
+    lines.append('"Your [clean/incremental] build now takes X.Xs (was Y.Ys) -- Z.Zs faster/slower."')
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate a Markdown build optimization report.")
+    parser.add_argument("--benchmark", required=True, help="Path to benchmark JSON artifact")
+    parser.add_argument("--recommendations", help="Path to recommendations JSON")
+    parser.add_argument("--diagnostics", help="Path to diagnostics JSON")
+    parser.add_argument("--project-path", help="Path to .xcodeproj for build settings audit")
+    parser.add_argument("--output", help="Output Markdown path (default: stdout)")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    benchmark = json.loads(Path(args.benchmark).read_text())
+    benchmark["_artifact_path"] = args.benchmark
+
+    recommendations = None
+    if args.recommendations:
+        recommendations = json.loads(Path(args.recommendations).read_text())
+
+    diagnostics = None
+    if args.diagnostics:
+        diagnostics = json.loads(Path(args.diagnostics).read_text())
+
+    project_configs: Dict[str, Dict[str, str]] = {}
+    target_configs: Dict[str, Dict[str, Dict[str, str]]] = {}
+    if args.project_path:
+        pbxproj_path = Path(args.project_path) / "project.pbxproj"
+        if pbxproj_path.exists():
+            pbxproj = pbxproj_path.read_text()
+            project_configs = _parse_project_level_configs(pbxproj)
+            target_configs = _parse_target_configs(pbxproj)
+
+    if recommendations is None and project_configs:
+        auto = _auto_recommendations_from_audit(project_configs)
+        if auto["recommendations"]:
+            recommendations = auto
+
+    sections = [
+        "# Xcode Build Optimization Plan\n",
+        _section_context(benchmark),
+        _section_baseline(benchmark),
+    ]
+
+    if project_configs:
+        sections.append(_section_settings_audit(project_configs, target_configs))
+
+    sections.append(_section_diagnostics(diagnostics))
+    sections.append(_section_recommendations(recommendations))
+    sections.append(_section_approval(recommendations))
+    sections.append(_section_next_steps(benchmark))
+
+    report = "\n\n".join(sections) + "\n"
+
+    if args.output:
+        Path(args.output).write_text(report)
+        print(f"Saved optimization report: {args.output}")
+    else:
+        print(report, end="")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/xcode-compilation-analyzer/SKILL.md
+++ b/.agents/skills/xcode-compilation-analyzer/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: xcode-compilation-analyzer
+description: Analyze Swift and mixed-language compile hotspots using build timing summaries and Swift frontend diagnostics, then produce a recommend-first source-level optimization plan. Use when a developer reports slow compilation, type-checking warnings, expensive clean-build compile phases, long CompileSwiftSources tasks, warn-long-function-bodies output, or wants to speed up Swift type checking.
+---
+
+# Xcode Compilation Analyzer
+
+Use this skill when compile time, not just general project configuration, looks like the bottleneck.
+
+## Core Rules
+
+- Start from evidence, ideally a recent `.build-benchmark/` artifact or raw timing-summary output.
+- Prefer analysis-only compiler flags over persistent project edits during investigation.
+- Rank findings by expected **wall-clock** impact, not cumulative compile-time impact. When compile tasks are heavily parallelized (sum of compile categories >> wall-clock median), note that fixing individual hotspots may improve parallel efficiency without reducing build wait time.
+- When the evidence points to parallelized work rather than serial bottlenecks, label recommendations as "Reduces compiler workload (parallel)" rather than "Reduces build time."
+- Do not edit source or build settings without explicit developer approval.
+
+## What To Inspect
+
+- `Build Timing Summary` output from clean and incremental builds
+- long-running `CompileSwiftSources` or per-file compilation tasks
+- `SwiftEmitModule` time -- can reach 60s+ after a single-line change in large modules; if it dominates incremental builds, the module is likely too large or macro-heavy
+- `Planning Swift module` time -- if this category is disproportionately large in incremental builds (up to 30s per module), it signals unexpected input invalidation or macro-related rebuild cascading
+- ad hoc runs with:
+  - `-Xfrontend -warn-long-expression-type-checking=<ms>`
+  - `-Xfrontend -warn-long-function-bodies=<ms>`
+- deeper diagnostic flags for thorough investigation:
+  - `-Xfrontend -debug-time-compilation` -- per-file compile times to rank the slowest files
+  - `-Xfrontend -debug-time-function-bodies` -- per-function compile times (unfiltered, complements the threshold-based warning flags)
+  - `-Xswiftc -driver-time-compilation` -- driver-level timing to isolate driver overhead
+  - `-Xfrontend -stats-output-dir <path>` -- detailed compiler statistics (JSON) per compilation unit for root-cause analysis
+- mixed Swift and Objective-C surfaces that increase bridging work
+
+## Analysis Workflow
+
+1. Identify whether the main issue is broad compilation volume or a few extreme hotspots.
+2. Parse timing-summary categories and rank the biggest compile contributors.
+3. Run the diagnostics script to surface type-checking hotspots:
+   ```bash
+   python3 scripts/diagnose_compilation.py \
+     --project App.xcodeproj \
+     --scheme MyApp \
+     --configuration Debug \
+     --destination "platform=iOS Simulator,name=iPhone 16" \
+     --threshold 100 \
+     --output-dir .build-benchmark
+   ```
+   This produces a ranked list of functions and expressions that exceed the millisecond threshold. Use the diagnostics artifact alongside source inspection to focus on the most expensive files first.
+4. Map the evidence to a concrete recommendation list.
+5. Separate code-level suggestions from project-level or module-level suggestions.
+
+## Apple-Derived Checks
+
+Look for these patterns first:
+
+- missing explicit type information in expensive expressions
+- complex chained or nested expressions that are hard to type-check
+- delegate properties typed as `AnyObject` instead of a concrete protocol
+- oversized Objective-C bridging headers or generated Swift-to-Objective-C surfaces
+- header imports that skip framework qualification and miss module-cache reuse
+- classes missing `final` that are never subclassed
+- overly broad access control (`public`/`open`) on internal-only symbols
+- monolithic SwiftUI `body` properties that should be decomposed into subviews
+- long method chains or closures without intermediate type annotations
+
+## Reporting Format
+
+For each recommendation, include:
+
+- observed evidence
+- likely affected file or module
+- expected wait-time impact (e.g. "Expected to reduce your clean build by ~2s" or "Reduces parallel compile work but unlikely to reduce build wait time")
+- confidence
+- whether approval is required before applying it
+
+If the evidence points to project configuration instead of source, hand off to [`xcode-project-analyzer`](../xcode-project-analyzer/SKILL.md) by reading its SKILL.md and applying its workflow to the same project context.
+
+## Preferred Tactics
+
+- Suggest ad hoc flag injection through the build command before recommending persistent build-setting changes.
+- Prefer narrowing giant view builders, closures, or result-builder expressions into smaller typed units.
+- Recommend explicit imports and protocol typing when they reduce compiler search space.
+- Call out when mixed-language boundaries are the real issue rather than Swift syntax alone.
+
+## Additional Resources
+
+- For the detailed audit checklist, see [references/code-compilation-checks.md](references/code-compilation-checks.md)
+- For the shared recommendation structure, see [references/recommendation-format.md](references/recommendation-format.md)
+- For source citations, see [references/build-optimization-sources.md](references/build-optimization-sources.md)

--- a/.agents/skills/xcode-compilation-analyzer/references/build-optimization-sources.md
+++ b/.agents/skills/xcode-compilation-analyzer/references/build-optimization-sources.md
@@ -1,0 +1,155 @@
+# Build Optimization Sources
+
+This file stores the external sources that the README and skill docs should cite consistently.
+
+## Apple: Improving the speed of incremental builds
+
+Source:
+
+- <https://developer.apple.com/documentation/xcode/improving-the-speed-of-incremental-builds>
+
+Key takeaways:
+
+- Measure first with `Build With Timing Summary` or `xcodebuild -showBuildTimingSummary`.
+- Accurate target dependencies improve correctness and parallelism.
+- Run scripts should declare inputs and outputs so Xcode can skip unnecessary work.
+- `.xcfilelist` files are appropriate when scripts have many inputs or outputs.
+- Custom frameworks and libraries benefit from module maps, typically by enabling `DEFINES_MODULE`.
+- Module reuse is strongest when related sources compile with consistent options.
+- Breaking monolithic targets into better-scoped modules can reduce unnecessary rebuilds.
+
+## Apple: Improving build efficiency with good coding practices
+
+Source:
+
+- <https://developer.apple.com/documentation/xcode/improving-build-efficiency-with-good-coding-practices>
+
+Key takeaways:
+
+- Use framework-qualified imports when module maps are available.
+- Keep Objective-C bridging surfaces narrow.
+- Prefer explicit type information when inference becomes expensive.
+- Use explicit delegate protocols instead of overly generic delegate types.
+- Simplify complex expressions that are hard for the compiler to type-check.
+
+## Apple: Building your project with explicit module dependencies
+
+Source:
+
+- <https://developer.apple.com/documentation/xcode/building-your-project-with-explicit-module-dependencies>
+
+Key takeaways:
+
+- Explicit module builds make module work visible in the build log and improve scheduling.
+- Repeated builds of the same module often point to avoidable module variants.
+- Inconsistent build options across targets can force duplicate module builds.
+- Timing summaries can reveal option drift that prevents module reuse.
+
+## SwiftLee: Build performance analysis for speeding up Xcode builds
+
+Source:
+
+- <https://www.avanderlee.com/optimization/analysing-build-performance-xcode/>
+
+Key takeaways:
+
+- Clean and incremental builds should both be measured because they reveal different problems.
+- Build Timeline and Build Timing Summary are practical starting points for build optimization.
+- Build scripts often produce large incremental-build wins when guarded correctly.
+- `-warn-long-function-bodies` and `-warn-long-expression-type-checking` help surface compile hotspots.
+- Typical debug and release build setting mismatches are worth auditing, especially in older projects.
+
+## Apple: Xcode Release Notes -- Compilation Caching
+
+Source:
+
+- Xcode Release Notes (149700201)
+
+Key takeaways:
+
+- Compilation caching is an opt-in feature for Swift and C-family languages.
+- It caches prior compilation results and reuses them when the same source inputs are recompiled.
+- Branch switching and clean builds benefit the most.
+- Can be enabled via the "Enable Compilation Caching" build setting or per-user project settings.
+
+## Apple: Demystify explicitly built modules (WWDC24)
+
+Source:
+
+- <https://developer.apple.com/videos/play/wwdc2024/10171/>
+
+Key takeaways:
+
+- Explains how explicitly built modules divide compilation into scan, module build, and source compile stages.
+- Unrelated modules build in parallel, improving CPU utilization.
+- Module variant duplication is a key bottleneck -- uniform compiler options across targets prevent it.
+- The build log shows each module as a discrete task, making it easier to diagnose scheduling issues.
+
+## Swift Compile-Time Best Practices
+
+Well-known Swift language patterns that reduce type-checker workload during compilation:
+
+- Mark classes `final` when they are not intended for subclassing. This eliminates dynamic dispatch overhead and allows the compiler to de-virtualize method calls.
+- Restrict access control to the narrowest useful scope (`private`, `fileprivate`). Fewer visible symbols reduce the compiler's search space during type resolution.
+- Prefer value types (`struct`, `enum`) over `class` when reference semantics are not needed. Value types are simpler for the compiler to reason about.
+- Break long method chains (`.map().flatMap().filter()`) into intermediate `let` bindings with explicit type annotations. Even simple-looking chains can take seconds to type-check.
+- Provide explicit return types on closures passed to generic functions, especially in SwiftUI result-builder contexts.
+- Decompose large SwiftUI `body` properties into smaller extracted subviews. Each subview narrows the scope of the result-builder expression the type-checker must resolve.
+
+## Bitrise: Demystifying Explicitly Built Modules for Xcode
+
+Source:
+
+- <https://bitrise.io/blog/post/demystifying-explicitly-built-modules-for-xcode>
+
+Key takeaways:
+
+- Explicit module builds give `xcodebuild` visibility into smaller compilation tasks for better parallelism.
+- Enabled by default for C/Objective-C in Xcode 16+; experimental for Swift.
+- Minimizing module variants by aligning build options is the primary optimization lever.
+- Some projects see regressions from dependency scanning overhead -- benchmark before and after.
+
+## Bitrise: Xcode Compilation Cache FAQ
+
+Source:
+
+- <https://docs.bitrise.io/en/bitrise-build-cache/build-cache-for-xcode/xcode-compilation-cache-faq.html>
+
+Key takeaways:
+
+- Granular caching is controlled by `SWIFT_ENABLE_COMPILE_CACHE` and `CLANG_ENABLE_COMPILE_CACHE`, under the umbrella `COMPILATION_CACHE_ENABLE_CACHING` setting.
+- Non-cacheable tasks include `CompileStoryboard`, `CompileXIB`, `CompileAssetCatalogVariant`, `PhaseScriptExecution`, `DataModelCompile`, `CopyPNGFile`, `GenerateDSYMFile`, and `Ld`.
+- SPM dependencies are not yet cacheable as of Xcode 26 beta.
+
+## RocketSim Docs: Build Insights
+
+Sources:
+
+- <https://www.rocketsim.app/docs/features/build-insights/build-insights/>
+- <https://www.rocketsim.app/docs/features/build-insights/team-build-insights/>
+
+Key takeaways:
+
+- RocketSim automatically tracks clean vs incremental builds over time without build scripts.
+- It reports build counts, duration trends, and percentile-based metrics such as p75 and p95.
+- Team Build Insights adds machine, Xcode, and macOS comparisons for cross-team visibility.
+- This repository is best positioned as the point-in-time analyze-and-improve toolkit, while RocketSim is the monitor-over-time companion.
+
+## Swift Forums: Slow incremental builds because of planning swift module
+
+Source:
+
+- <https://forums.swift.org/t/slow-incremental-builds-because-of-planning-swift-module/84803>
+
+Key takeaways:
+
+- "Planning Swift module" can dominate incremental builds (up to 30s per module), sometimes exceeding clean build time.
+- Replanning every module without scheduling compiles is a sign that build inputs are being modified unexpectedly (e.g., a misconfigured linter touching file timestamps).
+- Enable **Task Backtraces** (Xcode 16.4+: Scheme Editor > Build > Build Debugging) to see why each task re-ran in an incremental build.
+- Heavy Swift macro usage (e.g., TCA / swift-syntax) can cause trivial changes to cascade into near-full rebuilds.
+- `swift-syntax` builds universally (all architectures) when no prebuilt binary is available, adding significant overhead.
+- `SwiftEmitModule` can take 60s+ after a single-line change in large modules.
+- Asset catalog compilation is single-threaded per target; splitting assets into separate bundles across targets enables parallel compilation.
+- Multi-platform targets (e.g., adding watchOS) can cause SPM packages to build 3x (iOS arm64, iOS x86_64, watchOS arm64).
+- Zero-change incremental builds still incur ~10s of fixed overhead: compute dependencies, send project description, create build description, script phases, codesigning, and validation.
+- Codesigning and validation run even when output has not changed.

--- a/.agents/skills/xcode-compilation-analyzer/references/code-compilation-checks.md
+++ b/.agents/skills/xcode-compilation-analyzer/references/code-compilation-checks.md
@@ -1,0 +1,106 @@
+# Code Compilation Checks
+
+Use this reference when a build benchmark shows compilation dominating build time.
+
+## Primary Evidence Sources
+
+- `xcodebuild -showBuildTimingSummary`
+- build log compile tasks
+- `-warn-long-function-bodies`
+- `-warn-long-expression-type-checking`
+- `-debug-time-compilation` (per-file compile time ranking)
+- `-debug-time-function-bodies` (unfiltered per-function timing)
+- `-driver-time-compilation` (driver overhead)
+- `-stats-output-dir` (detailed compiler statistics as JSON)
+
+## Triage Questions
+
+1. Is one file or expression dominating compile time?
+2. Is the issue mostly Swift type-checking, mixed-language bridging, or header import churn?
+3. Are multiple files in the same module paying the same module-setup cost repeatedly?
+4. Is `SwiftEmitModule` disproportionately large for any target? If a single-line change triggers 60s+ of module emission, the target is likely too large or heavily macro-dependent.
+5. Does `Planning Swift module` dominate incremental builds? If modules are replanned but no compiles are scheduled, build inputs are being invalidated unexpectedly.
+
+## Checklist
+
+### Explicit typing
+
+- Add explicit property or local variable types when initialization expressions are complex.
+- Prefer intermediate typed variables over one giant inferred expression.
+
+### Expression simplification
+
+- Break long chains into smaller expressions.
+- Split complex result-builder code into smaller helpers or subviews.
+- Replace nested ternaries or overloaded generic chains with simpler steps.
+
+### Delegate typing
+
+- Avoid `AnyObject?` or overly generic delegate surfaces.
+- Prefer a named delegate protocol so the compiler has a narrower lookup space.
+
+### Objective-C and Swift bridging
+
+- Keep the Objective-C bridging header narrow.
+- Move internal-only Objective-C declarations out of the bridging surface.
+- Mark Swift members `private` when they do not need Objective-C visibility.
+
+### Framework-qualified imports
+
+- Prefer `#import <Framework/Header.h>` or module imports when a module map exists.
+- Watch for textual includes that defeat module-cache reuse.
+
+### Access control and dispatch optimization
+
+- Mark classes not intended for subclassing as `final`. This eliminates virtual dispatch overhead and lets the compiler de-virtualize method calls, reducing both compile and runtime cost.
+- Use `private` or `fileprivate` for properties and methods not used outside their declaration or file. Narrower visibility reduces the compiler's symbol search space.
+- Prefer `internal` (the default) over `public` unless the symbol genuinely crosses module boundaries. Wider access forces the compiler to consider more call sites.
+
+### Value types over reference types
+
+- Prefer `struct` and `enum` over `class` when reference semantics are not needed. Value types are simpler for the compiler to reason about and do not require vtable dispatch.
+- When a class exists solely to group data without identity semantics, convert it to a struct.
+
+### SwiftUI view decomposition
+
+- Extract subviews into dedicated `struct View` types instead of using `@ViewBuilder` helper properties. Separate structs reduce the type-checker scope per `body` property.
+- Break monolithic `body` properties (roughly 50+ lines) into smaller composed subviews. Large result-builder bodies are among the most expensive expressions to type-check.
+- Avoid deeply nested `Group`/`VStack`/`HStack` hierarchies within a single body.
+
+### Closure and chain patterns
+
+- Avoid long method chains like `.map().flatMap().filter().reduce()` without intermediate type annotations. Each link in the chain multiplies the type-checker's candidate set.
+- Break complex closures into named functions with explicit parameter and return types.
+- Add explicit return types to closures passed to generic functions so the compiler does not need to infer them from context.
+
+### Generic constraint complexity
+
+- Minimize deeply nested generic constraints (e.g., `where T: Collection, T.Element: Comparable, T.Element.SubSequence: ...`). Each additional constraint widens the compiler's search space.
+- Use type aliases to flatten complex generic stacks into readable names.
+- Prefer `some Protocol` (opaque return types) over unconstrained generics when the concrete type does not need to be visible to callers.
+
+### Module emission and planning overhead
+
+- Check `SwiftEmitModule` time in the Build Timing Summary. Large modules with many public symbols take longer to emit, and this cost is paid on every incremental build that touches the module.
+- If `SwiftEmitModule` exceeds compile time for the same target, the module's public API surface may be unnecessarily wide -- narrow access control or split the module.
+- Check `Planning Swift module` time. If it is significant in incremental builds, escalate to `xcode-project-analyzer` to investigate unexpected input invalidation or misconfigured scripts.
+
+### Precompiled and prefix headers
+
+- For mixed-language projects with large Objective-C codebases, verify that prefix headers are not bloated with unnecessary imports. Every import in a prefix header is parsed for every translation unit.
+- Migrate away from prefix headers toward explicit module imports where possible.
+
+## Recommendation Heuristics
+
+- High impact: repeated type-check warnings in a hot module, giant bridging headers, or a few files dominating compile time.
+- Medium impact: several moderate hotspots in result builders or overloaded generic code.
+- Low impact: isolated warnings without measurable benchmark impact.
+
+## Escalation Guidance
+
+Hand findings to `xcode-project-analyzer` when:
+
+- build scripts dominate instead of compilation
+- module reuse is blocked by project settings
+- target structure or explicit-module settings appear to be the real bottleneck
+- `Planning Swift module` overhead points to input invalidation or script-related causes rather than source complexity

--- a/.agents/skills/xcode-compilation-analyzer/references/recommendation-format.md
+++ b/.agents/skills/xcode-compilation-analyzer/references/recommendation-format.md
@@ -1,0 +1,85 @@
+# Recommendation Format
+
+All optimization skills should report recommendations in a shared structure so the orchestrator can merge and prioritize them cleanly.
+
+## Required Fields
+
+Each recommendation should include:
+
+- `title`
+- `wait_time_impact` -- plain-language statement of expected wall-clock impact, e.g. "Expected to reduce your clean build by ~3s", "Reduces parallel compile work but unlikely to reduce build wait time", or "Impact on wait time is uncertain -- re-benchmark to confirm"
+- `actionability` -- classifies how fixable the issue is from the project (see values below)
+- `category`
+- `observed_evidence`
+- `estimated_impact`
+- `confidence`
+- `approval_required`
+- `benchmark_verification_status`
+
+### Actionability Values
+
+Every recommendation must include an `actionability` classification:
+
+- `repo-local` -- Fix lives entirely in project files, source code, or local configuration. The developer can apply it without side effects outside the repo.
+- `package-manager` -- Requires CocoaPods or SPM configuration changes that may have broad side effects (e.g., linkage mode, dependency restructuring). These should be benchmarked before and after.
+- `xcode-behavior` -- Observed cost is driven by Xcode internals and is not suppressible from the project. Report the finding for awareness but do not promise a fix.
+- `upstream` -- Requires changes in a third-party dependency or external tool. The developer cannot fix it locally.
+
+## Suggested Optional Fields
+
+- `scope`
+- `affected_files`
+- `affected_targets`
+- `affected_packages`
+- `implementation_notes`
+- `risk_level`
+
+## JSON Example
+
+```json
+{
+  "recommendations": [
+    {
+      "title": "Guard a release-only symbol upload script",
+      "wait_time_impact": "Expected to reduce your incremental build by approximately 6 seconds.",
+      "actionability": "repo-local",
+      "category": "project",
+      "observed_evidence": [
+        "Incremental builds spend 6.3 seconds in a run script phase.",
+        "The script runs for Debug builds even though the output is only needed in Release."
+      ],
+      "estimated_impact": "High incremental-build improvement",
+      "confidence": "High",
+      "approval_required": true,
+      "benchmark_verification_status": "Not yet verified",
+      "scope": "Target build phase",
+      "risk_level": "Low"
+    }
+  ]
+}
+```
+
+## Markdown Rendering Guidance
+
+When rendering for human review, preserve the same field order:
+
+1. title
+2. wait-time impact
+3. actionability
+4. observed evidence
+5. estimated impact
+6. confidence
+7. approval required
+8. benchmark verification status
+
+That makes it easier for the developer to approve or reject specific items quickly.
+
+## Verification Status Values
+
+Recommended values:
+
+- `Not yet verified`
+- `Queued for verification`
+- `Verified improvement`
+- `No measurable improvement`
+- `Inconclusive due to benchmark noise`

--- a/.agents/skills/xcode-compilation-analyzer/scripts/diagnose_compilation.py
+++ b/.agents/skills/xcode-compilation-analyzer/scripts/diagnose_compilation.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+
+"""Run a single Xcode build with -Xfrontend diagnostics to find slow type-checking."""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+_TYPECHECK_RE = re.compile(
+    r"^(?P<file>.+?):(?P<line>\d+):(?P<col>\d+): warning: "
+    r"(?P<kind>instance method|global function|getter|type-check|expression) "
+    r"'?(?P<name>[^']*?)'?\s+took\s+(?P<ms>\d+)ms\s+to\s+type-check"
+)
+
+_EXPRESSION_RE = re.compile(
+    r"^(?P<file>.+?):(?P<line>\d+):(?P<col>\d+): warning: "
+    r"expression took\s+(?P<ms>\d+)ms\s+to\s+type-check"
+)
+
+_FILE_TIME_RE = re.compile(
+    r"^\s*(?P<seconds>\d+(?:\.\d+)?)\s+seconds\s+.*\s+compiling\s+(?P<file>\S+)"
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run an Xcode build with -Xfrontend type-checking diagnostics."
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--workspace", help="Path to the .xcworkspace file")
+    group.add_argument("--project", help="Path to the .xcodeproj file")
+    parser.add_argument("--scheme", required=True, help="Scheme to build")
+    parser.add_argument("--configuration", default="Debug", help="Build configuration")
+    parser.add_argument("--destination", help="xcodebuild destination string")
+    parser.add_argument("--derived-data-path", help="DerivedData path override")
+    parser.add_argument("--output-dir", default=".build-benchmark", help="Output directory")
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=100,
+        help="Millisecond threshold for -warn-long-function-bodies and "
+        "-warn-long-expression-type-checking (default: 100)",
+    )
+    parser.add_argument("--skip-clean", action="store_true", help="Skip clean before build")
+    parser.add_argument(
+        "--per-file-timing",
+        action="store_true",
+        help="Add -Xfrontend -debug-time-compilation to report per-file compile times.",
+    )
+    parser.add_argument(
+        "--stats-output",
+        action="store_true",
+        help="Add -Xfrontend -stats-output-dir to collect detailed compiler statistics.",
+    )
+    parser.add_argument(
+        "--extra-arg",
+        action="append",
+        default=[],
+        help="Additional xcodebuild argument. Can be passed multiple times.",
+    )
+    return parser.parse_args()
+
+
+def command_base(args: argparse.Namespace) -> List[str]:
+    command = ["xcodebuild"]
+    if args.workspace:
+        command.extend(["-workspace", args.workspace])
+    if args.project:
+        command.extend(["-project", args.project])
+    command.extend(["-scheme", args.scheme, "-configuration", args.configuration])
+    if args.destination:
+        command.extend(["-destination", args.destination])
+    if args.derived_data_path:
+        command.extend(["-derivedDataPath", args.derived_data_path])
+    command.extend(args.extra_arg)
+    return command
+
+
+def parse_diagnostics(output: str) -> List[Dict]:
+    """Extract type-checking warnings from xcodebuild output."""
+    warnings: List[Dict] = []
+    seen = set()
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        match = _TYPECHECK_RE.match(line)
+        if match:
+            key = (match.group("file"), match.group("line"), match.group("col"), "function-body")
+            if key in seen:
+                continue
+            seen.add(key)
+            warnings.append(
+                {
+                    "file": match.group("file"),
+                    "line": int(match.group("line")),
+                    "column": int(match.group("col")),
+                    "duration_ms": int(match.group("ms")),
+                    "kind": "function-body",
+                    "name": match.group("name"),
+                }
+            )
+            continue
+        match = _EXPRESSION_RE.match(line)
+        if match:
+            key = (match.group("file"), match.group("line"), match.group("col"), "expression")
+            if key in seen:
+                continue
+            seen.add(key)
+            warnings.append(
+                {
+                    "file": match.group("file"),
+                    "line": int(match.group("line")),
+                    "column": int(match.group("col")),
+                    "duration_ms": int(match.group("ms")),
+                    "kind": "expression",
+                    "name": "",
+                }
+            )
+    warnings.sort(key=lambda w: w["duration_ms"], reverse=True)
+    return warnings
+
+
+def parse_file_timings(output: str) -> List[Dict]:
+    """Extract per-file compile times from -debug-time-compilation output."""
+    timings: List[Dict] = []
+    seen = set()
+    for raw_line in output.splitlines():
+        match = _FILE_TIME_RE.match(raw_line.strip())
+        if match:
+            filepath = match.group("file")
+            if filepath in seen:
+                continue
+            seen.add(filepath)
+            timings.append(
+                {
+                    "file": filepath,
+                    "duration_seconds": float(match.group("seconds")),
+                }
+            )
+    timings.sort(key=lambda t: t["duration_seconds"], reverse=True)
+    return timings
+
+
+def main() -> int:
+    args = parse_args()
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    scheme_slug = args.scheme.replace(" ", "-").lower()
+    artifact_stem = f"{timestamp}-{scheme_slug}"
+    base = command_base(args)
+
+    if not args.skip_clean:
+        print("Cleaning build products...")
+        clean = subprocess.run([*base, "clean"], capture_output=True, text=True)
+        if clean.returncode != 0:
+            sys.stderr.write(clean.stdout + clean.stderr)
+            return clean.returncode
+
+    threshold = str(args.threshold)
+    swift_flags = (
+        f"$(inherited) -Xfrontend -warn-long-function-bodies={threshold} "
+        f"-Xfrontend -warn-long-expression-type-checking={threshold}"
+    )
+    if args.per_file_timing:
+        swift_flags += " -Xfrontend -debug-time-compilation"
+
+    stats_dir: Optional[Path] = None
+    if args.stats_output:
+        stats_dir = output_dir / f"{artifact_stem}-stats"
+        stats_dir.mkdir(parents=True, exist_ok=True)
+        swift_flags += f" -Xfrontend -stats-output-dir -Xfrontend {stats_dir}"
+
+    build_command = [
+        *base,
+        "build",
+        "-showBuildTimingSummary",
+        f"OTHER_SWIFT_FLAGS={swift_flags}",
+    ]
+
+    extras = []
+    if args.per_file_timing:
+        extras.append("per-file timing")
+    if args.stats_output:
+        extras.append("stats output")
+    extras_label = f" + {', '.join(extras)}" if extras else ""
+    print(f"Building with type-check threshold {threshold}ms{extras_label}...")
+    started = time.perf_counter()
+    result = subprocess.run(build_command, capture_output=True, text=True)
+    elapsed = round(time.perf_counter() - started, 3)
+
+    combined_output = result.stdout + result.stderr
+    log_path = output_dir / f"{artifact_stem}-diagnostics.log"
+    log_path.write_text(combined_output)
+
+    warnings = parse_diagnostics(combined_output)
+
+    file_timings: Optional[List[Dict]] = None
+    if args.per_file_timing:
+        file_timings = parse_file_timings(combined_output)
+
+    artifact = {
+        "schema_version": "1.0.0",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "type": "compilation-diagnostics",
+        "build": {
+            "entrypoint": "workspace" if args.workspace else "project",
+            "path": args.workspace or args.project,
+            "scheme": args.scheme,
+            "configuration": args.configuration,
+            "destination": args.destination or "",
+        },
+        "threshold_ms": args.threshold,
+        "build_duration_seconds": elapsed,
+        "build_success": result.returncode == 0,
+        "raw_log_path": str(log_path),
+        "warnings": warnings,
+        "summary": {
+            "total_warnings": len(warnings),
+            "function_body_warnings": sum(1 for w in warnings if w["kind"] == "function-body"),
+            "expression_warnings": sum(1 for w in warnings if w["kind"] == "expression"),
+            "slowest_ms": warnings[0]["duration_ms"] if warnings else 0,
+        },
+    }
+
+    if file_timings is not None:
+        artifact["per_file_timings"] = file_timings
+    if stats_dir is not None:
+        artifact["stats_dir"] = str(stats_dir)
+
+    artifact_path = output_dir / f"{artifact_stem}-diagnostics.json"
+    artifact_path.write_text(json.dumps(artifact, indent=2) + "\n")
+
+    print(f"\nSaved diagnostics artifact: {artifact_path}")
+    print(f"Build {'succeeded' if result.returncode == 0 else 'failed'} in {elapsed}s")
+    print(f"Found {len(warnings)} type-check warnings above {threshold}ms threshold\n")
+
+    if warnings:
+        print(f"{'Duration':>10}  {'Kind':<15}  {'Location'}")
+        print(f"{'--------':>10}  {'----':<15}  {'--------'}")
+        for w in warnings[:20]:
+            loc = f"{w['file']}:{w['line']}:{w['column']}"
+            label = w["name"] if w["name"] else "(expression)"
+            print(f"{w['duration_ms']:>8}ms  {w['kind']:<15}  {loc}  {label}")
+        if len(warnings) > 20:
+            print(f"\n  ... and {len(warnings) - 20} more (see {artifact_path})")
+    else:
+        print("No type-checking hotspots found above threshold.")
+
+    if file_timings:
+        print(f"\nPer-file compile times (top 20):\n")
+        print(f"{'Duration':>12}  {'File'}")
+        print(f"{'--------':>12}  {'----'}")
+        for t in file_timings[:20]:
+            print(f"{t['duration_seconds']:>10.3f}s  {t['file']}")
+        if len(file_timings) > 20:
+            print(f"\n  ... and {len(file_timings) - 20} more (see {artifact_path})")
+
+    if stats_dir is not None:
+        stat_files = list(stats_dir.glob("*.json"))
+        print(f"\nCompiler statistics: {len(stat_files)} files written to {stats_dir}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/xcode-project-analyzer/SKILL.md
+++ b/.agents/skills/xcode-project-analyzer/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: xcode-project-analyzer
+description: Audit Xcode project configuration, build settings, scheme behavior, and script phases to find build-time improvements with explicit approval gates. Use when a developer wants project-level build analysis, slow incremental builds, guidance on target dependencies, build settings review, run script phase analysis, parallelization improvements, or module-map and DEFINES_MODULE configuration.
+---
+
+# Xcode Project Analyzer
+
+Use this skill for project- and target-level build inefficiencies that are unlikely to be solved by source edits alone.
+
+## Core Rules
+
+- Recommendation-first by default.
+- Require explicit approval before changing project files, schemes, or build settings.
+- Prefer measured findings tied to timing summaries, build logs, or project configuration evidence.
+- Distinguish debug-only pain from release-only pain.
+
+## What To Review
+
+- scheme build order and target dependencies
+- debug vs release build settings against the [build settings best practices](references/build-settings-best-practices.md)
+- run script phases and dependency-analysis settings
+- derived-data churn or obviously invalidating custom steps
+- opportunities for parallelization
+- explicit module dependency settings and module-map readiness
+- "Planning Swift module" time in the Build Timing Summary -- if it dominates incremental builds, suspect unexpected input modification or macro-related invalidation
+- asset catalog compilation time, especially in targets with large or numerous catalogs
+- `ExtractAppIntentsMetadata` time in the Build Timing Summary -- if this phase consumes significant time, record it as `xcode-behavior` (report the cost and impact, but do not suggest a repo-local optimization unless there is explicit Apple guidance)
+- zero-change build overhead -- if a no-op rebuild exceeds a few seconds, investigate fixed-cost phases (script execution, codesign, validation, CopySwiftLibs)
+- CocoaPods usage -- if a `Podfile` or `Pods.xcodeproj` exists, CocoaPods is deprecated; recommend migrating to SPM and do not attempt CocoaPods-specific optimizations (see [project-audit-checks.md](references/project-audit-checks.md))
+- Task Backtraces (Xcode 16.4+: Scheme Editor > Build > Build Debugging) to diagnose why tasks re-run unexpectedly in incremental builds
+
+## Build Settings Best Practices Audit
+
+Every project audit should include a build settings checklist comparing the project's Debug and Release configurations against the recommended values in [build-settings-best-practices.md](references/build-settings-best-practices.md). Present results using checkmark/cross indicators (`[x]`/`[ ]`). The scope is strictly build performance -- do not flag language-migration settings like `SWIFT_STRICT_CONCURRENCY` or `SWIFT_UPCOMING_FEATURE_*`.
+
+## Apple-Derived Checks
+
+Review these items in every audit:
+
+- target dependencies are accurate and not missing or inflated
+- schemes build in `Dependency Order`
+- run scripts declare inputs and outputs
+- `.xcfilelist` files are used when scripts have many inputs or outputs
+- `DEFINES_MODULE` is enabled where custom frameworks or libraries should expose module maps
+- headers are self-contained enough for module-map use
+- explicit module dependency settings are consistent for targets that should share modules
+
+## Typical Wins
+
+- skip debug-time scripts that only matter in release
+- add missing script guards or dependency-analysis metadata
+- remove accidental serial bottlenecks in schemes
+- align build settings that cause unnecessary module variants
+- fix stale project structure that forces broader rebuilds than necessary
+- identify linters or formatters that touch file timestamps without changing content, silently invalidating build inputs and forcing module replanning
+- split large asset catalogs into separate resource bundles across targets to parallelize compilation
+- use Task Backtraces to pinpoint the exact input change that triggers unnecessary incremental work
+
+## Reporting Format
+
+For each issue, include:
+
+- evidence
+- likely scope
+- why it affects clean builds, incremental builds, or both
+- estimated impact
+- approval requirement
+
+If the evidence points to package graph or build plugins, hand off to [`spm-build-analysis`](../spm-build-analysis/SKILL.md) by reading its SKILL.md and applying its workflow to the same project context.
+
+## Additional Resources
+
+- For the detailed audit checklist, see [references/project-audit-checks.md](references/project-audit-checks.md)
+- For build settings best practices, see [references/build-settings-best-practices.md](references/build-settings-best-practices.md)
+- For the shared recommendation structure, see [references/recommendation-format.md](references/recommendation-format.md)
+- For Apple-aligned source summaries, see [references/build-optimization-sources.md](references/build-optimization-sources.md)

--- a/.agents/skills/xcode-project-analyzer/references/build-optimization-sources.md
+++ b/.agents/skills/xcode-project-analyzer/references/build-optimization-sources.md
@@ -1,0 +1,155 @@
+# Build Optimization Sources
+
+This file stores the external sources that the README and skill docs should cite consistently.
+
+## Apple: Improving the speed of incremental builds
+
+Source:
+
+- <https://developer.apple.com/documentation/xcode/improving-the-speed-of-incremental-builds>
+
+Key takeaways:
+
+- Measure first with `Build With Timing Summary` or `xcodebuild -showBuildTimingSummary`.
+- Accurate target dependencies improve correctness and parallelism.
+- Run scripts should declare inputs and outputs so Xcode can skip unnecessary work.
+- `.xcfilelist` files are appropriate when scripts have many inputs or outputs.
+- Custom frameworks and libraries benefit from module maps, typically by enabling `DEFINES_MODULE`.
+- Module reuse is strongest when related sources compile with consistent options.
+- Breaking monolithic targets into better-scoped modules can reduce unnecessary rebuilds.
+
+## Apple: Improving build efficiency with good coding practices
+
+Source:
+
+- <https://developer.apple.com/documentation/xcode/improving-build-efficiency-with-good-coding-practices>
+
+Key takeaways:
+
+- Use framework-qualified imports when module maps are available.
+- Keep Objective-C bridging surfaces narrow.
+- Prefer explicit type information when inference becomes expensive.
+- Use explicit delegate protocols instead of overly generic delegate types.
+- Simplify complex expressions that are hard for the compiler to type-check.
+
+## Apple: Building your project with explicit module dependencies
+
+Source:
+
+- <https://developer.apple.com/documentation/xcode/building-your-project-with-explicit-module-dependencies>
+
+Key takeaways:
+
+- Explicit module builds make module work visible in the build log and improve scheduling.
+- Repeated builds of the same module often point to avoidable module variants.
+- Inconsistent build options across targets can force duplicate module builds.
+- Timing summaries can reveal option drift that prevents module reuse.
+
+## SwiftLee: Build performance analysis for speeding up Xcode builds
+
+Source:
+
+- <https://www.avanderlee.com/optimization/analysing-build-performance-xcode/>
+
+Key takeaways:
+
+- Clean and incremental builds should both be measured because they reveal different problems.
+- Build Timeline and Build Timing Summary are practical starting points for build optimization.
+- Build scripts often produce large incremental-build wins when guarded correctly.
+- `-warn-long-function-bodies` and `-warn-long-expression-type-checking` help surface compile hotspots.
+- Typical debug and release build setting mismatches are worth auditing, especially in older projects.
+
+## Apple: Xcode Release Notes -- Compilation Caching
+
+Source:
+
+- Xcode Release Notes (149700201)
+
+Key takeaways:
+
+- Compilation caching is an opt-in feature for Swift and C-family languages.
+- It caches prior compilation results and reuses them when the same source inputs are recompiled.
+- Branch switching and clean builds benefit the most.
+- Can be enabled via the "Enable Compilation Caching" build setting or per-user project settings.
+
+## Apple: Demystify explicitly built modules (WWDC24)
+
+Source:
+
+- <https://developer.apple.com/videos/play/wwdc2024/10171/>
+
+Key takeaways:
+
+- Explains how explicitly built modules divide compilation into scan, module build, and source compile stages.
+- Unrelated modules build in parallel, improving CPU utilization.
+- Module variant duplication is a key bottleneck -- uniform compiler options across targets prevent it.
+- The build log shows each module as a discrete task, making it easier to diagnose scheduling issues.
+
+## Swift Compile-Time Best Practices
+
+Well-known Swift language patterns that reduce type-checker workload during compilation:
+
+- Mark classes `final` when they are not intended for subclassing. This eliminates dynamic dispatch overhead and allows the compiler to de-virtualize method calls.
+- Restrict access control to the narrowest useful scope (`private`, `fileprivate`). Fewer visible symbols reduce the compiler's search space during type resolution.
+- Prefer value types (`struct`, `enum`) over `class` when reference semantics are not needed. Value types are simpler for the compiler to reason about.
+- Break long method chains (`.map().flatMap().filter()`) into intermediate `let` bindings with explicit type annotations. Even simple-looking chains can take seconds to type-check.
+- Provide explicit return types on closures passed to generic functions, especially in SwiftUI result-builder contexts.
+- Decompose large SwiftUI `body` properties into smaller extracted subviews. Each subview narrows the scope of the result-builder expression the type-checker must resolve.
+
+## Bitrise: Demystifying Explicitly Built Modules for Xcode
+
+Source:
+
+- <https://bitrise.io/blog/post/demystifying-explicitly-built-modules-for-xcode>
+
+Key takeaways:
+
+- Explicit module builds give `xcodebuild` visibility into smaller compilation tasks for better parallelism.
+- Enabled by default for C/Objective-C in Xcode 16+; experimental for Swift.
+- Minimizing module variants by aligning build options is the primary optimization lever.
+- Some projects see regressions from dependency scanning overhead -- benchmark before and after.
+
+## Bitrise: Xcode Compilation Cache FAQ
+
+Source:
+
+- <https://docs.bitrise.io/en/bitrise-build-cache/build-cache-for-xcode/xcode-compilation-cache-faq.html>
+
+Key takeaways:
+
+- Granular caching is controlled by `SWIFT_ENABLE_COMPILE_CACHE` and `CLANG_ENABLE_COMPILE_CACHE`, under the umbrella `COMPILATION_CACHE_ENABLE_CACHING` setting.
+- Non-cacheable tasks include `CompileStoryboard`, `CompileXIB`, `CompileAssetCatalogVariant`, `PhaseScriptExecution`, `DataModelCompile`, `CopyPNGFile`, `GenerateDSYMFile`, and `Ld`.
+- SPM dependencies are not yet cacheable as of Xcode 26 beta.
+
+## RocketSim Docs: Build Insights
+
+Sources:
+
+- <https://www.rocketsim.app/docs/features/build-insights/build-insights/>
+- <https://www.rocketsim.app/docs/features/build-insights/team-build-insights/>
+
+Key takeaways:
+
+- RocketSim automatically tracks clean vs incremental builds over time without build scripts.
+- It reports build counts, duration trends, and percentile-based metrics such as p75 and p95.
+- Team Build Insights adds machine, Xcode, and macOS comparisons for cross-team visibility.
+- This repository is best positioned as the point-in-time analyze-and-improve toolkit, while RocketSim is the monitor-over-time companion.
+
+## Swift Forums: Slow incremental builds because of planning swift module
+
+Source:
+
+- <https://forums.swift.org/t/slow-incremental-builds-because-of-planning-swift-module/84803>
+
+Key takeaways:
+
+- "Planning Swift module" can dominate incremental builds (up to 30s per module), sometimes exceeding clean build time.
+- Replanning every module without scheduling compiles is a sign that build inputs are being modified unexpectedly (e.g., a misconfigured linter touching file timestamps).
+- Enable **Task Backtraces** (Xcode 16.4+: Scheme Editor > Build > Build Debugging) to see why each task re-ran in an incremental build.
+- Heavy Swift macro usage (e.g., TCA / swift-syntax) can cause trivial changes to cascade into near-full rebuilds.
+- `swift-syntax` builds universally (all architectures) when no prebuilt binary is available, adding significant overhead.
+- `SwiftEmitModule` can take 60s+ after a single-line change in large modules.
+- Asset catalog compilation is single-threaded per target; splitting assets into separate bundles across targets enables parallel compilation.
+- Multi-platform targets (e.g., adding watchOS) can cause SPM packages to build 3x (iOS arm64, iOS x86_64, watchOS arm64).
+- Zero-change incremental builds still incur ~10s of fixed overhead: compute dependencies, send project description, create build description, script phases, codesigning, and validation.
+- Codesigning and validation run even when output has not changed.

--- a/.agents/skills/xcode-project-analyzer/references/build-settings-best-practices.md
+++ b/.agents/skills/xcode-project-analyzer/references/build-settings-best-practices.md
@@ -1,0 +1,216 @@
+# Build Settings Best Practices
+
+This reference lists Xcode build settings that affect build performance. Use it to audit a project and produce a pass/fail checklist.
+
+The scope is strictly **build performance**. Do not flag language-migration settings like `SWIFT_STRICT_CONCURRENCY` or `SWIFT_UPCOMING_FEATURE_*` -- those are developer adoption choices unrelated to build speed.
+
+## How To Read This Reference
+
+Each setting includes:
+
+- **Setting name** and the Xcode build-settings key
+- **Recommended value** for Debug and Release
+- **Why it matters** for build time
+- **Risk** of changing it
+
+Use checkmark and cross indicators when reporting:
+
+- `[x]` -- setting matches the recommended value
+- `[ ]` -- setting does not match; include the actual value and the expected value
+
+## Debug Configuration
+
+These settings optimize for fast iteration during development.
+
+### Compilation Mode
+
+- **Key:** `SWIFT_COMPILATION_MODE`
+- **Recommended:** `singlefile` (Xcode UI: "Incremental"; or unset -- Xcode defaults to singlefile for Debug)
+- **Why:** Single-file mode recompiles only changed files. `wholemodule` recompiles the entire target on every change.
+- **Risk:** Low
+
+### Swift Optimization Level
+
+- **Key:** `SWIFT_OPTIMIZATION_LEVEL`
+- **Recommended:** `-Onone`
+- **Why:** Optimization passes add significant compile time. Debug builds do not benefit from runtime speed improvements.
+- **Risk:** Low
+
+### GCC Optimization Level
+
+- **Key:** `GCC_OPTIMIZATION_LEVEL`
+- **Recommended:** `0`
+- **Why:** Same rationale as Swift optimization level, but for C/C++/Objective-C sources.
+- **Risk:** Low
+
+### Build Active Architecture Only
+
+- **Key:** `ONLY_ACTIVE_ARCH` (`BUILD_ACTIVE_ARCHITECTURE_ONLY`)
+- **Recommended:** `YES`
+- **Why:** Building all architectures doubles or triples compile and link time for no debug benefit.
+- **Risk:** Low
+
+### Debug Information Format
+
+- **Key:** `DEBUG_INFORMATION_FORMAT`
+- **Recommended:** `dwarf`
+- **Why:** `dwarf-with-dsym` generates a separate dSYM bundle which adds overhead. Plain `dwarf` embeds debug info directly in the binary, which is sufficient for local debugging.
+- **Risk:** Low
+
+### Enable Testability
+
+- **Key:** `ENABLE_TESTABILITY`
+- **Recommended:** `YES`
+- **Why:** Required for `@testable import`. Adds minor overhead by exporting internal symbols, but this is expected during development.
+- **Risk:** Low
+
+### Active Compilation Conditions
+
+- **Key:** `SWIFT_ACTIVE_COMPILATION_CONDITIONS`
+- **Recommended:** Should include `DEBUG`
+- **Why:** Guards conditional compilation blocks (e.g., `#if DEBUG`) and ensures debug-only code paths are included.
+- **Risk:** Low
+
+### Eager Linking
+
+- **Key:** `EAGER_LINKING`
+- **Recommended:** `YES`
+- **Why:** Allows the linker to start work before all compilation tasks finish, reducing wall-clock build time. Particularly effective for Debug builds where link time is a meaningful fraction of total build time.
+- **Risk:** Low
+
+## Release Configuration
+
+These settings optimize for production builds.
+
+### Compilation Mode
+
+- **Key:** `SWIFT_COMPILATION_MODE`
+- **Recommended:** `wholemodule`
+- **Why:** Whole-module optimization produces faster runtime code. Build time is secondary for release.
+- **Risk:** Low
+
+### Swift Optimization Level
+
+- **Key:** `SWIFT_OPTIMIZATION_LEVEL`
+- **Recommended:** `-O` or `-Osize`
+- **Why:** Produces optimized binaries. `-Osize` trades some speed for smaller binary size.
+- **Risk:** Low
+
+### GCC Optimization Level
+
+- **Key:** `GCC_OPTIMIZATION_LEVEL`
+- **Recommended:** `s`
+- **Why:** Optimizes C/C++/Objective-C for size, matching the typical release expectation.
+- **Risk:** Low
+
+### Build Active Architecture Only
+
+- **Key:** `ONLY_ACTIVE_ARCH`
+- **Recommended:** `NO`
+- **Why:** Release builds must include all supported architectures for distribution.
+- **Risk:** Low
+
+### Debug Information Format
+
+- **Key:** `DEBUG_INFORMATION_FORMAT`
+- **Recommended:** `dwarf-with-dsym`
+- **Why:** dSYM bundles are required for crash symbolication in production.
+- **Risk:** Low
+
+### Enable Testability
+
+- **Key:** `ENABLE_TESTABILITY`
+- **Recommended:** `NO`
+- **Why:** Removes internal-symbol export overhead from release builds. Testing should use Debug configuration.
+- **Risk:** Low
+
+## General (All Configurations)
+
+### Compilation Caching
+
+- **Key:** `COMPILATION_CACHE_ENABLE_CACHING`
+- **Recommended:** `YES`
+- **Why:** Caches compilation results for Swift and C-family sources so repeated compilations of the same inputs are served from cache. The biggest wins come from branch switching and clean builds where source files are recompiled unchanged. This is an opt-in feature. The umbrella setting controls both `SWIFT_ENABLE_COMPILE_CACHE` and `CLANG_ENABLE_COMPILE_CACHE` under the hood; those can be toggled independently if needed.
+- **Measurement:** Measured 5-14% faster clean builds across tested projects (87 to 1,991 Swift files). The benefit compounds in real developer workflows where the cache persists between builds -- branch switching, pulling changes, and CI with persistent DerivedData -- though the exact savings depend on how many files change between builds.
+- **Risk:** Low -- can also be enabled via per-user project settings so it does not need to be committed to the shared project file.
+
+### Integrated Swift Driver
+
+- **Key:** `SWIFT_USE_INTEGRATED_DRIVER`
+- **Recommended:** `YES`
+- **Why:** Uses the integrated Swift driver which runs inside the build system process, eliminating inter-process overhead for compilation scheduling. Enabled by default in modern Xcode but worth verifying in migrated projects.
+- **Risk:** Low
+
+### Clang Module Compilation
+
+- **Key:** `CLANG_ENABLE_MODULES`
+- **Recommended:** `YES`
+- **Why:** Enables Clang module compilation for C/Objective-C sources, caching module maps on disk instead of reprocessing headers on every import. Eliminates redundant header parsing across translation units.
+- **Risk:** Low
+
+### Explicit Module Builds
+
+- **Key:** `SWIFT_ENABLE_EXPLICIT_MODULES` (C/ObjC enabled by default in Xcode 16+; for Swift use `_EXPERIMENTAL_SWIFT_EXPLICIT_MODULES`)
+- **Recommended:** Evaluate per-project
+- **Why:** Makes module compilation visible to the build system as discrete tasks, improving parallelism and scheduling. Reduces redundant module rebuilds by making dependency edges explicit. Some projects see regressions due to the overhead of dependency scanning, so benchmark before and after enabling.
+- **Risk:** Medium -- test thoroughly; currently experimental for Swift targets.
+
+## Cross-Target Consistency
+
+These checks find settings differences between targets that cause redundant build work.
+
+### Project-Level vs Target-Level Overrides
+
+Build-affecting settings should be set at the project level unless a target has a specific reason to override. Unnecessary per-target overrides cause confusion and can silently create module variants.
+
+Settings to check for project-level consistency:
+
+- `SWIFT_COMPILATION_MODE`
+- `SWIFT_OPTIMIZATION_LEVEL`
+- `ONLY_ACTIVE_ARCH`
+- `DEBUG_INFORMATION_FORMAT`
+
+### Module Variant Duplication
+
+When multiple targets import the same SPM package but compile with different Swift compiler options, the build system produces separate module variants for each combination. This inflates `SwiftEmitModule` task counts.
+
+Check for drift in:
+
+- `SWIFT_OPTIMIZATION_LEVEL`
+- `SWIFT_COMPILATION_MODE`
+- `OTHER_SWIFT_FLAGS`
+- Target-level build settings that override project defaults
+
+### Out of Scope
+
+Do **not** flag the following as build-performance issues:
+
+- `SWIFT_STRICT_CONCURRENCY` -- language migration choice
+- `SWIFT_UPCOMING_FEATURE_*` -- language migration choice
+- `SWIFT_APPROACHABLE_CONCURRENCY` -- language migration choice
+- `SWIFT_ACTIVE_COMPILATION_CONDITIONS` values beyond `DEBUG` (e.g., `WIDGETS`, `APPCLIP`) -- intentional per-target customization
+
+## Checklist Output Format
+
+When reporting results, use this structure:
+
+```markdown
+### Debug Configuration
+- [x] `SWIFT_COMPILATION_MODE`: `singlefile` (recommended: `singlefile`)
+- [ ] `DEBUG_INFORMATION_FORMAT`: `dwarf-with-dsym` (recommended: `dwarf`)
+- [x] `SWIFT_OPTIMIZATION_LEVEL`: `-Onone` (recommended: `-Onone`)
+...
+
+### Release Configuration
+- [x] `SWIFT_COMPILATION_MODE`: `wholemodule` (recommended: `wholemodule`)
+...
+
+### General (All Configurations)
+- [ ] `COMPILATION_CACHE_ENABLE_CACHING`: `NO` (recommended: `YES`)
+...
+
+### Cross-Target Consistency
+- [x] All targets inherit `SWIFT_OPTIMIZATION_LEVEL` from project level
+- [ ] `OTHER_SWIFT_FLAGS` differs between Stock Analyzer and StockAnalyzerClip
+...
+```

--- a/.agents/skills/xcode-project-analyzer/references/project-audit-checks.md
+++ b/.agents/skills/xcode-project-analyzer/references/project-audit-checks.md
@@ -1,0 +1,101 @@
+# Project Audit Checks
+
+Use this reference when reviewing build-system configuration rather than source-level compile behavior.
+
+## Target And Scheme Checks
+
+- Confirm target dependencies are explicit and accurate.
+- Remove dependencies that no longer reflect real build requirements.
+- Ensure the scheme builds targets in `Dependency Order`.
+- Look for oversized or monolithic targets that block parallel work.
+
+## Build Script Checks
+
+- Does each script need to run during incremental builds?
+- Are input and output files declared?
+- Should inputs and outputs be moved into `.xcfilelist` files?
+- Can the script skip debug builds, simulator builds, or unchanged inputs?
+- Would the script become parallelizable if dependency analysis were declared correctly?
+- Could a misconfigured linter or formatter script be touching file timestamps without changing content? This silently invalidates build inputs and forces replanning of every module.
+
+## Build Planning And Incremental Overhead Checks
+
+- Check whether "Planning Swift module" appears as a significant category in the Build Timing Summary. In projects with many modules this step can take up to 30s per module, sometimes exceeding clean build time.
+- If modules are replanned but no compiles are scheduled, suspect unexpected input modification (see Build Script Checks above).
+- Enable **Task Backtraces** (Xcode 16.4+) to diagnose why tasks re-run in incremental builds: Scheme Editor > Build tab > Build Debugging > enable "Task Backtraces." Expanding tasks in the build log will show a backtrace explaining what input change triggered the re-run.
+- Measure zero-change incremental build time as a baseline. Even with no source changes, builds incur fixed overhead: compute dependencies, send project description to build service, create build description, run script phases, codesign, and validate. If this baseline exceeds a few seconds, investigate each contributor.
+- Check whether codesigning and validation run on every build even when the build output has not changed.
+
+## Zero-Change Build Overhead Analysis
+
+When a zero-change build (no edits, immediate rebuild) takes more than a few seconds, the overhead comes from fixed-cost phases rather than compilation. Investigate these categories in the Build Timing Summary:
+
+- **PhaseScriptExecution**: Script phases with `alwaysOutOfDate = 1` or missing input/output declarations run on every build regardless of changes. Linters, formatters, and upload scripts are common offenders.
+- **CodeSign**: Codesigning runs on every build for the app target and any embedded frameworks. Time scales with the number of signed binaries.
+- **ValidateEmbeddedBinary**: Validates embedded binaries against the host app's provisioning profile. Runs unconditionally.
+- **CopySwiftLibs**: Copies Swift standard libraries into the app bundle. Runs even when nothing changed.
+- **RegisterWithLaunchServices**: Registers the built app with Launch Services. Fast but present in every build.
+- **ProcessInfoPlistFile**: Re-processes Info.plist files. Time scales with the number of targets.
+- **ExtractAppIntentsMetadata**: Extracts App Intents metadata from all targets. This phase is driven by Xcode and runs across all targets including CocoaPods and SwiftPM dependencies, not just first-party targets. If the project does not use App Intents, the work is unnecessary overhead, but it is not cleanly suppressible from project-level build settings alone. Classify findings about this phase as `xcode-behavior` actionability -- report the measured cost for awareness but do not promise a repo-local fix.
+
+A zero-change build above 5 seconds on Apple Silicon typically indicates script phase overhead or an excessive number of targets requiring codesign and validation passes.
+
+## Asset Catalog Checks
+
+- Asset catalog compilation (`CompileAssetCatalog`) is single-threaded per target. Multiple catalogs within the same target compile sequentially in a single process.
+- If asset catalog compilation appears as a significant timing category, recommend splitting assets into separate resource bundles across separate targets to enable parallel compilation.
+- Asset catalog compilation is not cacheable by the Xcode compilation cache (`CompileAssetCatalogVariant` is non-cacheable).
+- Check whether asset catalogs rebuild during incremental builds even when no assets changed. If so, investigate whether build inputs for the catalog step are being invalidated unexpectedly.
+
+## Build Setting Checks
+
+Audit project-level and target-level settings against the [build settings best practices](build-settings-best-practices.md). Present results as a checklist with `[x]`/`[ ]` indicators.
+
+Key settings to verify:
+
+- `SWIFT_COMPILATION_MODE` -- `singlefile` for Debug, `wholemodule` for Release
+- `SWIFT_OPTIMIZATION_LEVEL` -- `-Onone` for Debug, `-O` or `-Osize` for Release
+- `ONLY_ACTIVE_ARCH` -- `YES` for Debug, `NO` for Release
+- `DEBUG_INFORMATION_FORMAT` -- `dwarf` for Debug, `dwarf-with-dsym` for Release
+- `GCC_OPTIMIZATION_LEVEL` -- `0` for Debug, `s` for Release
+- `ENABLE_TESTABILITY` -- `YES` for Debug, `NO` for Release
+- `COMPILATION_CACHE_ENABLE_CACHING` -- recommended `YES` for all configurations; caches repeated compilations during branch switching and clean builds
+- `EAGER_LINKING` -- recommended `YES` for Debug; starts linking before all compilation finishes
+- `SWIFT_USE_INTEGRATED_DRIVER` -- recommended `YES`; uses the integrated driver for better scheduling
+- `CLANG_ENABLE_MODULES` -- recommended `YES`; caches module maps on disk for C/ObjC
+
+Do not flag language-migration settings (`SWIFT_STRICT_CONCURRENCY`, `SWIFT_UPCOMING_FEATURE_*`) as build performance issues.
+
+## Module And Header Checks
+
+- `DEFINES_MODULE` is enabled for custom frameworks that should benefit from module maps.
+- Public headers are self-contained enough to compile as a module.
+- Import statements use framework-qualified imports where available.
+- targets that should share built modules use consistent options
+
+## Explicit Module Dependency Checks
+
+- Check whether explicit modules are enabled or expected in the current Xcode version and Swift mode.
+- Look for repeated module builds caused by configuration drift.
+- Compare preprocessor macros or other build options across sibling targets that import the same modules.
+
+## CocoaPods Projects
+
+CocoaPods is deprecated. Do not attempt CocoaPods-specific build optimizations such as linkage mode changes (`use_frameworks! :linkage => :static`), `COCOAPODS_PARALLEL_CODE_SIGN`, or Podfile tweaks. These are unreliable and frequently regress build times.
+
+When a project uses CocoaPods (presence of `Podfile`, `Pods/`, or a `Pods.xcodeproj`), recommend migrating to Swift Package Manager as the highest-impact long-term improvement. SPM advantages for build time:
+
+- **Compilation caching**: `COMPILATION_CACHE_ENABLE_CACHING` works with SPM targets out of the box, delivering cumulative benefits across branch switching, pulling changes, and CI.
+- **Better build parallelism**: SPM targets build in parallel based on the dependency graph without the overhead of a separate Pods project.
+- **No xcconfig regeneration**: CocoaPods regenerates xcconfigs and its own project file on every `pod install`. SPM resolution is lighter and its outputs integrate natively.
+- **Native Xcode integration**: No separate `Pods.xcodeproj`, no workspace stitching, and full support for modern Xcode features like explicit modules.
+
+Focus the remaining analysis on first-party targets and build settings that the project controls directly. Do not audit or recommend changes to `Pods.xcodeproj` or the Podfile.
+
+## Recommendation Prioritization
+
+Qualify every estimated impact with wall-clock framing. High-priority items should be those likely to reduce the developer's actual wait time, not just cumulative task totals. If the impact on wait time is uncertain, say so.
+
+- High: serial script bottlenecks, missing dependency metadata, configuration drift causing redundant module builds, excessive "Planning Swift module" time, or scripts silently invalidating build inputs.
+- Medium: stale target structure, noncritical scripts running too often, slow asset catalog compilation blocking the critical path, unnecessary codesigning on unchanged output, or significant `ExtractAppIntentsMetadata` time in projects without App Intents.
+- Low: settings cleanup without strong evidence of current impact.

--- a/.agents/skills/xcode-project-analyzer/references/recommendation-format.md
+++ b/.agents/skills/xcode-project-analyzer/references/recommendation-format.md
@@ -1,0 +1,85 @@
+# Recommendation Format
+
+All optimization skills should report recommendations in a shared structure so the orchestrator can merge and prioritize them cleanly.
+
+## Required Fields
+
+Each recommendation should include:
+
+- `title`
+- `wait_time_impact` -- plain-language statement of expected wall-clock impact, e.g. "Expected to reduce your clean build by ~3s", "Reduces parallel compile work but unlikely to reduce build wait time", or "Impact on wait time is uncertain -- re-benchmark to confirm"
+- `actionability` -- classifies how fixable the issue is from the project (see values below)
+- `category`
+- `observed_evidence`
+- `estimated_impact`
+- `confidence`
+- `approval_required`
+- `benchmark_verification_status`
+
+### Actionability Values
+
+Every recommendation must include an `actionability` classification:
+
+- `repo-local` -- Fix lives entirely in project files, source code, or local configuration. The developer can apply it without side effects outside the repo.
+- `package-manager` -- Requires CocoaPods or SPM configuration changes that may have broad side effects (e.g., linkage mode, dependency restructuring). These should be benchmarked before and after.
+- `xcode-behavior` -- Observed cost is driven by Xcode internals and is not suppressible from the project. Report the finding for awareness but do not promise a fix.
+- `upstream` -- Requires changes in a third-party dependency or external tool. The developer cannot fix it locally.
+
+## Suggested Optional Fields
+
+- `scope`
+- `affected_files`
+- `affected_targets`
+- `affected_packages`
+- `implementation_notes`
+- `risk_level`
+
+## JSON Example
+
+```json
+{
+  "recommendations": [
+    {
+      "title": "Guard a release-only symbol upload script",
+      "wait_time_impact": "Expected to reduce your incremental build by approximately 6 seconds.",
+      "actionability": "repo-local",
+      "category": "project",
+      "observed_evidence": [
+        "Incremental builds spend 6.3 seconds in a run script phase.",
+        "The script runs for Debug builds even though the output is only needed in Release."
+      ],
+      "estimated_impact": "High incremental-build improvement",
+      "confidence": "High",
+      "approval_required": true,
+      "benchmark_verification_status": "Not yet verified",
+      "scope": "Target build phase",
+      "risk_level": "Low"
+    }
+  ]
+}
+```
+
+## Markdown Rendering Guidance
+
+When rendering for human review, preserve the same field order:
+
+1. title
+2. wait-time impact
+3. actionability
+4. observed evidence
+5. estimated impact
+6. confidence
+7. approval required
+8. benchmark verification status
+
+That makes it easier for the developer to approve or reject specific items quickly.
+
+## Verification Status Values
+
+Recommended values:
+
+- `Not yet verified`
+- `Queued for verification`
+- `Verified improvement`
+- `No measurable improvement`
+- `Inconclusive due to benchmark noise`

--- a/.claude/skills/core-data-expert
+++ b/.claude/skills/core-data-expert
@@ -1,0 +1,1 @@
+../../.agents/skills/core-data-expert

--- a/.claude/skills/ios-clean-architecture/SKILL.md
+++ b/.claude/skills/ios-clean-architecture/SKILL.md
@@ -1,0 +1,454 @@
+---
+name: ios-clean-architecture
+description: Use when working on iOS/SwiftUI projects that follow Clean Architecture with SPM modules, a DIContainer, Builder pattern, and UseCase/Repository/NetworkService layers. Triggers on creating a new feature module, adding a network endpoint, wiring a ViewModel state machine, setting up dependency injection, or reviewing layer boundaries. Swift 6.2 / iOS 17+ / SwiftUI + @Observable.
+---
+
+# iOS Clean Architecture (SwiftUI + SPM, Swift 6.2)
+
+Modular Clean Architecture template for iOS apps. Protocol-first, DI via a
+service-locator container, Builder pattern per feature, `@Observable`
+ViewModels with enum state machines. Targets **Swift 6.2**, which makes
+**main-actor isolation the default for app code** — you no longer need
+explicit `@MainActor` on most UI-adjacent types. Derived from the
+Rick & Morty reference implementation.
+
+## When to use
+
+- iOS 17+ / **Swift 6.2** / SwiftUI project (UIKit integration OK)
+- Multi-module codebase managed via Swift Package Manager
+- You're creating a new feature, new endpoint, new use case, or reviewing
+  layer boundaries
+
+## Swift 6.2 default actor isolation
+
+Enable the "approachable concurrency" defaults in each target's
+`Package.swift` / build settings:
+
+```swift
+.target(
+    name: "FeedView",
+    swiftSettings: [
+        .defaultIsolation(MainActor.self),              // Swift 6.2
+        .enableUpcomingFeature("InferIsolatedConformances"),
+    ]
+)
+```
+
+With this on:
+- Types, methods, and closures default to `@MainActor` — **do not write
+  `@MainActor` by hand** on ViewModels, Builders, Repositories, UseCases,
+  Routers, or the DIContainer.
+- Mark code that must run off the main actor with `nonisolated` (pure
+  computation, value types used across actors) or isolate it to a custom
+  actor / `Task.detached`.
+- Protocol conformances are inferred to the enclosing isolation, so
+  `extension FeedRepository: FeedRepositoryProtocol` doesn't need any
+  attribute either.
+
+## When NOT to use
+
+- Cross-platform (React Native, Flutter, KMP)
+- UIKit-only apps that won't adopt `@Observable`
+- Single-module prototypes where modularisation is overkill
+- Projects using Combine + `ObservableObject` (different pattern entirely)
+
+---
+
+## The dependency rule
+
+Outer layers depend on inner layers, never the reverse.
+
+```
+Presentation (Views, ViewModels, Builders, Routers)
+        ↓
+Business Logic (Use Cases, Domain Models, Adapters)
+        ↓
+Data (Repositories, Network, DTOs, Endpoints)
+```
+
+Data flows one way: **User → ViewModel → UseCase → Repository → NetworkService**.
+
+---
+
+## Module layout
+
+Each concern is a separate SPM package in the workspace root.
+
+| Package | Layer | Responsibility |
+|---|---|---|
+| `RickMortyNetworkLayer` | Data | Generic HTTP client (`NetworkService`, `URLSessionNetworkService`) |
+| `CoreAPI` | Data | Endpoint enum implementing the `Endpoint` protocol |
+| `RickMortyRepository` | Data | Implements repository protocols, orchestrates network calls |
+| `DependencyContainer` | Infra | `DIContainer` service locator |
+| `UseCase` | Business | Use cases, domain models, adapters, protocol definitions |
+| `FeedView` / `CharacterDetailsView` / ... | Presentation | Feature modules (one package per feature) |
+| `RickMortyUI` | Presentation | Shared UI components |
+| `DevPreview` | Utility | `DevPreview.shared.container` for SwiftUI previews |
+
+Open the **`.xcworkspace`**, never the `.xcodeproj` directly.
+
+---
+
+## Pattern templates
+
+### 1. Endpoint protocol + enum implementation
+
+```swift
+public protocol Endpoint {
+    var baseURL: String { get }
+    var path: String { get }
+    var method: HTTPMethod { get }
+    var headers: HTTPHeaders { get }
+    var parameters: [String: Any]? { get }
+    var contentType: String { get }
+}
+
+public enum RickMortyEndpoint: Endpoint {
+    case getCharacters(page: Int?, status: String?)
+
+    public var baseURL: String { "https://rickandmortyapi.com/api" }
+    public var path: String {
+        switch self {
+        case .getCharacters: return "/character"
+        }
+    }
+    // method, headers, parameters, contentType via switch
+}
+```
+
+### 2. NetworkService
+
+```swift
+public protocol NetworkService {
+    func request<T: Decodable>(endpoint: Endpoint, responseModel: T.Type) async throws -> T
+}
+```
+
+Concrete implementation is `URLSessionNetworkService`. **No third-party
+networking libs** — use `URLSession` directly. Protocol picks up main-actor
+isolation from the module's default isolation setting.
+
+### 3. DIContainer
+
+```swift
+@Observable
+public final class DIContainer {
+    public func register<T>(_ service: T.Type, _ implementation: T)
+    public func register<T>(_ service: T.Type, _ factory: () -> T)
+    public func resolve<T>(_ service: T.Type) -> T?
+    public func requireResolve<T>(_ service: T.Type) throws -> T  // throws DIError.serviceNotRegistered
+}
+```
+
+Always use `requireResolve` at composition time — never force-unwrap.
+
+### 4. Repository
+
+```swift
+@Observable
+public final class FeedRepository: FeedRepositoryProtocol {
+    private let networkService: NetworkService
+    public init(networkService: NetworkService) { self.networkService = networkService }
+
+    public func fetchCharacters(page: Int?, status: String?) async throws -> CharactersPageResponse {
+        try await networkService.request(
+            endpoint: RickMortyEndpoint.getCharacters(page: page, status: status),
+            responseModel: CharactersPageResponse.self
+        )
+    }
+}
+```
+
+Repository is a thin adapter over `NetworkService`. Protocol lives in
+`UseCase` package (inner layer owns the interface).
+
+### 5. UseCase
+
+```swift
+public protocol FeedUseCaseProtocol {
+    func execute(page: Int?, status: String?) async throws -> CharactersPageResponse
+}
+
+@Observable
+public final class FeedUseCase: FeedUseCaseProtocol {
+    private let repository: FeedRepositoryProtocol
+
+    public init(container: DIContainer) throws {
+        self.repository = try container.requireResolve(FeedRepositoryProtocol.self)
+    }
+
+    public func execute(page: Int? = nil, status: String? = nil) async throws -> CharactersPageResponse {
+        try await repository.fetchCharacters(page: page, status: status)
+    }
+}
+```
+
+### 6. Builder
+
+```swift
+@Observable
+public final class FeedBuilder {
+    private let container: DIContainer
+    public init(container: DIContainer) { self.container = container }
+
+    public func buildFeedView(router: Router) -> some View {
+        let useCase = try! container.requireResolve(FeedUseCaseProtocol.self)
+        let feedRouter = FeedRouter(
+            router: router,
+            characterDetailsBuilder: CharacterDetailsBuilder(container: container)
+        )
+        let viewModel = FeedViewModel(useCase: useCase, router: feedRouter)
+        return FeedView(viewModel: viewModel)
+    }
+}
+```
+
+One Builder per feature package. It's the **only** place features are
+constructed.
+
+### 7. ViewModel (state machine + pagination)
+
+```swift
+@Observable
+final class FeedViewModel {
+    enum State: Equatable {
+        case idle
+        case loading
+        case loaded([CharacterAdapter])
+        case loadingMore([CharacterAdapter])
+        case error(FeedError)
+    }
+
+    private(set) var state: State = .idle
+    private(set) var characters: [CharacterAdapter] = []
+    private(set) var currentPage = 1
+    private(set) var hasMorePages = true
+    private var isLoading = false
+
+    private let useCase: FeedUseCaseProtocol
+    private let router: FeedRouterProtocol
+
+    init(useCase: FeedUseCaseProtocol, router: FeedRouterProtocol) {
+        self.useCase = useCase
+        self.router = router
+    }
+
+    func loadInitialData() async {
+        guard !isLoading else { return }
+        isLoading = true
+        defer { isLoading = false }
+        state = .loading
+        do {
+            let page = try await useCase.execute(page: 1, status: nil)
+            characters = page.results.map(CharacterAdapter.from)
+            state = .loaded(characters)
+        } catch {
+            state = .error(mapError(error))
+        }
+    }
+
+    func loadMoreData() async {
+        guard !isLoading, hasMorePages else { return }
+        isLoading = true
+        defer { isLoading = false }
+        state = .loadingMore(characters)
+        // fetch currentPage + 1, append, update hasMorePages
+    }
+
+    func applyFilter(_ status: Status?) async {
+        currentPage = 1
+        characters.removeAll()
+        await loadInitialData()
+    }
+
+    private func mapError(_ error: Error) -> FeedError {
+        if error is URLError { return .network }
+        if error is DecodingError { return .decoding }
+        return .unknown(message: error.localizedDescription)
+    }
+}
+```
+
+**Load-bearing rules**:
+- `isLoading` guard prevents concurrent fetches
+- Filter/refresh always resets `currentPage = 1` and clears `characters`
+- Error mapping happens at the ViewModel boundary, never deeper
+
+### 8. Router
+
+```swift
+protocol FeedRouterProtocol {
+    func showCharacterDetails(_ character: CharacterAdapter)
+}
+
+struct FeedRouter: FeedRouterProtocol {
+    let router: Router  // SUIRouting
+    let characterDetailsBuilder: CharacterDetailsBuilder
+
+    func showCharacterDetails(_ character: CharacterAdapter) {
+        router.showScreen(.push) { inner in
+            characterDetailsBuilder.buildCharacterDetailsView(router: inner, character: character)
+        }
+    }
+}
+```
+
+Routers are protocol-backed structs. Navigation library is **SUIRouting**
+(pinned at `1.0.6+`). `router.showScreen(.push)` takes a closure receiving
+an inner router for nested navigation.
+
+### 9. AppComposition (registration order matters)
+
+```swift
+@Observable
+final class AppComposition {
+    let container = DIContainer()
+    let feedUseCase: FeedUseCaseProtocol?
+    let isConfigured: Bool
+
+    init() {
+        do {
+            // 1. Infrastructure
+            container.register(NetworkService.self, URLSessionNetworkService(session: .shared))
+            let network = try container.requireResolve(NetworkService.self)
+
+            // 2. Data — swap for UI testing
+            if ProcessInfo.processInfo.arguments.contains("-ui-testing") {
+                container.register(FeedRepositoryProtocol.self, UITestFeedRepository())
+            } else {
+                container.register(FeedRepositoryProtocol.self, FeedRepository(networkService: network))
+            }
+
+            // 3. Business
+            let useCase = try FeedUseCase(container: container)
+            container.register(FeedUseCaseProtocol.self, useCase)
+
+            self.feedUseCase = useCase
+            self.isConfigured = true
+        } catch {
+            self.feedUseCase = nil
+            self.isConfigured = false
+        }
+    }
+}
+```
+
+---
+
+## Hard constraints
+
+1. **Swift 6.2 default actor isolation is on** — every target opts in via
+   `.defaultIsolation(MainActor.self)`. Do **not** write `@MainActor` by
+   hand on ViewModels, Builders, Repositories, UseCases, Routers, or the
+   DIContainer; the compiler infers it. Only annotate explicitly when you
+   deviate (`nonisolated`, a custom actor, `@globalActor`).
+2. **Push expensive work off the main actor deliberately** — mark pure
+   helpers `nonisolated`, use `Task.detached` or a dedicated actor for CPU
+   work / large decoding. Default-main is a safety default, not a licence
+   to block the UI.
+3. **No force unwrapping** — use `requireResolve` (throws), `guard let`,
+   `if let`. The one pragmatic exception is inside `Builder.build…` where
+   the container is guaranteed to be configured.
+4. **Protocol-first** — every cross-module dependency is a protocol.
+   Concrete types never appear in another module's public API.
+5. **Builder is mandatory** — features are never instantiated directly.
+   Always `FeatureBuilder(container:).buildXView(router:)`.
+6. **Workspace, not project** — open `*.xcworkspace`. The `.xcodeproj`
+   alone doesn't see the SPM packages.
+7. **`@Observable` not `ObservableObject`** — Swift 5.9+ macro, tracked
+   automatically by SwiftUI. No `@Published`.
+8. **Use Swift Testing**, not XCTest — `@Test`, `@Suite`.
+
+---
+
+## Testing patterns
+
+```swift
+@Suite("FeedViewModel • State")
+struct FeedViewModelTests {
+
+    @Test("Initial load transitions idle → loading → loaded")
+    func initialLoadSuccess() async throws {
+        let useCase = FakeFeedUseCase(stubbed: .success(CharactersPageResponse.fixture))
+        let vm = FeedViewModel(useCase: useCase, router: SpyRouter())
+
+        await vm.loadInitialData()
+
+        #expect(vm.state == .loaded(useCase.stubbedCharacters))
+    }
+}
+```
+
+**Test doubles**:
+- `MockNetworkService` — stubs `request(endpoint:responseModel:)`
+- `MockURLProtocol` — for real `URLSession` tests
+- `FakeFeedUseCase` — returns canned data, records calls
+- `SpyRouter` — records navigation events
+
+Each SPM package has its own `Tests/` directory. ViewModels are tested
+against fake UseCases; Repositories are tested against mock
+`NetworkService`.
+
+---
+
+## Recipes
+
+### Add a new endpoint
+
+1. **Endpoint** — add a case to `RickMortyEndpoint` and update `path` /
+   `method` / `parameters`.
+2. **Repository protocol** — add method to `FeedRepositoryProtocol` (or a
+   new repo protocol) in the `UseCase` package.
+3. **Repository impl** — implement in `FeedRepository` using
+   `networkService.request(endpoint:responseModel:)`.
+4. **UseCase** — add an `execute` method exposing the feature at the
+   business-logic boundary.
+
+### Add a new feature module
+
+1. **Package** — `mkdir NewFeature && cd NewFeature && swift package init
+   --type library`. Add to `*.xcworkspace` via Xcode → File → Add Package →
+   Add Local.
+2. **Builder** — `NewFeatureBuilder(container: DIContainer)` with a
+   `buildXView(router:)` method. Mark `@Observable` (main-actor isolation
+   is inferred).
+3. **ViewModel + Router** — ViewModel is `@Observable` with enum state
+   machine. Router is a protocol-backed struct. Both inherit main-actor
+   isolation from the target's default.
+4. **Compose** — register any new protocols in `AppComposition`. Wire the
+   feature in via `TabBarBuilder` or the relevant parent builder.
+
+### Wire up SwiftUI Previews
+
+```swift
+#Preview("Feed — loaded") {
+    let container = DevPreview.shared.container
+    let builder = FeedBuilder(container: container)
+    RouterView { router in
+        builder.buildFeedView(router: router)
+    }
+}
+```
+
+`DevPreview.shared.container` is pre-configured with real implementations
+so previews hit the same code path as production.
+
+---
+
+## Anti-patterns (reject on sight)
+
+- `ObservableObject` / `@Published` — use `@Observable` instead
+- `try!` / force-unwraps outside of Builder internals
+- ViewModels calling `URLSession` or repositories directly — must go
+  through a UseCase
+- Property injection or global singletons — constructor injection only
+- Base classes for ViewModels — compose with protocols
+- Concrete types crossing module boundaries — use protocols
+- Updating `SUIRouting` without regression testing — pinned version,
+  has known macOS quirks
+- Sprinkling `@MainActor` everywhere — in Swift 6.2 with
+  `defaultIsolation(MainActor.self)` it's already the default; adding it
+  by hand is noise
+- Dropping or weakening default isolation to silence concurrency
+  warnings — fix the root cause (mark the offending code `nonisolated`
+  or move it to an actor / detached task)

--- a/.claude/skills/spm-build-analysis
+++ b/.claude/skills/spm-build-analysis
@@ -1,0 +1,1 @@
+../../.agents/skills/spm-build-analysis

--- a/.claude/skills/swift-concurrency
+++ b/.claude/skills/swift-concurrency
@@ -1,0 +1,1 @@
+../../.agents/skills/swift-concurrency

--- a/.claude/skills/swift-testing-expert
+++ b/.claude/skills/swift-testing-expert
@@ -1,0 +1,1 @@
+../../.agents/skills/swift-testing-expert

--- a/.claude/skills/swiftui-expert-skill
+++ b/.claude/skills/swiftui-expert-skill
@@ -1,0 +1,1 @@
+../../.agents/skills/swiftui-expert-skill

--- a/.claude/skills/xcode-build-benchmark
+++ b/.claude/skills/xcode-build-benchmark
@@ -1,0 +1,1 @@
+../../.agents/skills/xcode-build-benchmark

--- a/.claude/skills/xcode-build-fixer
+++ b/.claude/skills/xcode-build-fixer
@@ -1,0 +1,1 @@
+../../.agents/skills/xcode-build-fixer

--- a/.claude/skills/xcode-build-orchestrator
+++ b/.claude/skills/xcode-build-orchestrator
@@ -1,0 +1,1 @@
+../../.agents/skills/xcode-build-orchestrator

--- a/.claude/skills/xcode-compilation-analyzer
+++ b/.claude/skills/xcode-compilation-analyzer
@@ -1,0 +1,1 @@
+../../.agents/skills/xcode-compilation-analyzer

--- a/.claude/skills/xcode-project-analyzer
+++ b/.claude/skills/xcode-project-analyzer
@@ -1,0 +1,1 @@
+../../.agents/skills/xcode-project-analyzer

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,10 @@ settings.local.json
 *.local.json
 
 # Claude Code configuration
-.claude/
+.claude/*
+!.claude/skills/
+!.claude/commands/
+.claude/settings.local.json
 
 # Xcode
 ## User settings

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,9 +22,75 @@ Usage notes:
 <available_skills>
 
 <skill>
-<name>swift-concurrency</name>
-<description>'Expert guidance on Swift Concurrency best practices, patterns, and implementation. Use when developers mention: (1) Swift Concurrency, async/await, actors, or tasks, (2) "use Swift Concurrency" or "modern concurrency patterns", (3) migrating to Swift 6, (4) data races or thread safety issues, (5) refactoring closures to async/await, (6) @MainActor, Sendable, or actor isolation, (7) concurrent code architecture or performance optimization.'</description>
+<name>core-data-expert</name>
+<description>'Expert Core Data guidance (iOS/macOS): stack setup, fetch requests & NSFetchedResultsController, saving/merge conflicts, threading & Swift Concurrency, batch operations & persistent history, migrations, performance, and NSPersistentCloudKitContainer/CloudKit sync.'</description>
 <location>project</location>
+</skill>
+
+<skill>
+<name>ios-clean-architecture</name>
+<description>Use when working on iOS/SwiftUI projects that follow Clean Architecture with SPM modules, a DIContainer, Builder pattern, and UseCase/Repository/NetworkService layers. Triggers on creating a new feature module, adding a network endpoint, wiring a ViewModel state machine, setting up dependency injection, or reviewing layer boundaries. Swift 6.2 / iOS 17+ / SwiftUI + @Observable.</description>
+<location>project</location>
+</skill>
+
+<skill>
+<name>spm-build-analysis</name>
+<description>Analyze Swift Package Manager dependencies, package plugins, module variants, and CI-oriented build overhead that slow Xcode builds. Use when a developer suspects packages, plugins, or dependency graph shape are hurting clean or incremental build performance, mentions SPM slowness, package resolution time, build plugin overhead, duplicate module builds from configuration drift, circular dependencies between modules, oversized modules needing splitting, or modularization best practices.</description>
+<location>project</location>
+</skill>
+
+<skill>
+<name>swift-concurrency</name>
+<description>'Diagnose data races, convert callback-based code to async/await, implement actor isolation patterns, resolve Sendable conformance issues, and guide Swift 6 migration. Use when developers mention: (1) Swift Concurrency, async/await, actors, or tasks, (2) "use Swift Concurrency" or "modern concurrency patterns", (3) migrating to Swift 6, (4) data races or thread safety issues, (5) refactoring closures to async/await, (6) @MainActor, Sendable, or actor isolation, (7) concurrent code architecture or performance optimization, (8) concurrency-related linter warnings (SwiftLint or similar; e.g. async_without_await, Sendable/actor isolation/MainActor lint).'</description>
+<location>project</location>
+</skill>
+
+<skill>
+<name>swift-testing-expert</name>
+<description>'Expert guidance for Swift Testing: test structure, #expect/#require macros, traits and tags, parameterized tests, test plans, parallel execution, async waiting patterns, and XCTest migration. Use when writing new Swift tests, modernizing XCTest suites, debugging flaky tests, or improving test quality and maintainability in Apple-platform or Swift server projects.'</description>
+<location>project</location>
+</skill>
+
+<skill>
+<name>swiftui-expert-skill</name>
+<description>Write, review, or improve SwiftUI code following best practices for state management, view composition, performance, macOS-specific APIs, and iOS 26+ Liquid Glass adoption. Use when building new SwiftUI features, refactoring existing views, reviewing code quality, or adopting modern SwiftUI patterns.</description>
+<location>project</location>
+</skill>
+
+<skill>
+<name>xcode-build-benchmark</name>
+<description>Benchmark Xcode clean and incremental builds with repeatable inputs, timing summaries, and timestamped `.build-benchmark/` artifacts. Use when a developer wants a baseline, wants to compare before and after changes, asks to measure build performance, mentions build times, build duration, how long builds take, or wants to know if builds got faster or slower.</description>
+<location>project</location>
+</skill>
+
+<skill>
+<name>xcode-build-fixer</name>
+<description>Apply approved Xcode build optimization changes following best practices, then re-benchmark to verify improvement. Use when a developer has an approved optimization plan from xcode-build-orchestrator, wants to apply specific build fixes, needs help implementing build setting changes, script phase guards, source-level compilation fixes, or SPM restructuring that was recommended by an analysis skill.</description>
+<location>project</location>
+</skill>
+
+<skill>
+<name>xcode-build-orchestrator</name>
+<description>Orchestrate Xcode build optimization by benchmarking first, running the specialist analysis skills, prioritizing findings, requesting explicit approval, delegating approved fixes to xcode-build-fixer, and re-benchmarking after changes. Use when a developer wants an end-to-end build optimization workflow, asks to speed up Xcode builds, wants a full build audit, or needs a recommend-first optimization pass covering compilation, project settings, and packages.</description>
+<location>project</location>
+</skill>
+
+<skill>
+<name>xcode-compilation-analyzer</name>
+<description>Analyze Swift and mixed-language compile hotspots using build timing summaries and Swift frontend diagnostics, then produce a recommend-first source-level optimization plan. Use when a developer reports slow compilation, type-checking warnings, expensive clean-build compile phases, long CompileSwiftSources tasks, warn-long-function-bodies output, or wants to speed up Swift type checking.</description>
+<location>project</location>
+</skill>
+
+<skill>
+<name>xcode-project-analyzer</name>
+<description>Audit Xcode project configuration, build settings, scheme behavior, and script phases to find build-time improvements with explicit approval gates. Use when a developer wants project-level build analysis, slow incremental builds, guidance on target dependencies, build settings review, run script phase analysis, parallelization improvements, or module-map and DEFINES_MODULE configuration.</description>
+<location>project</location>
+</skill>
+
+<skill>
+<name>find-skills</name>
+<description>Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending capabilities. This skill should be used when the user is looking for functionality that might exist as an installable skill.</description>
+<location>global</location>
 </skill>
 
 </available_skills>

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -17,17 +17,18 @@
 
 ## Overview
 
-**RickMorty** is a native iOS application built with **Swift 6.0** and **SwiftUI**, following **Clean Architecture** principles. The app displays characters from the Rick and Morty API with features including infinite scroll pagination, status filtering, and detailed character views.
+**RickMorty** is a native iOS application built with **Swift 6.2+** following **Clean Architecture** principles. The app displays characters from the Rick and Morty API with infinite scroll pagination, status filtering, and detail screens — and deliberately implements the character list twice: once in SwiftUI (`FeedView`) and once in UIKit (`FeedListViewController`), sharing the same business logic layer.
 
 ### Technology Stack
-- **Language**: Swift 6.0 (strict concurrency enabled)
-- **UI Framework**: SwiftUI with `@Observable` macro
-- **Minimum Deployment**: iOS 17.0+
-- **Build System**: Xcode 16.4+
-- **Dependency Management**: Swift Package Manager (SPM)
+
+- **Language**: Swift 6.1+ (strict concurrency enabled)
+- **UI Framework**: SwiftUI + UIKit hybrid with `@Observable` macro
+- **Minimum Deployment**: iOS 17.0+ (packages) / iOS 18.5 (main app target)
+- **Build System**: Xcode 16+
+- **Dependency Management**: Swift Package Manager (11 local packages)
 - **Architecture**: Clean Architecture with modular design
-- **Routing**: SUIRouting (v1.0.7)
-- **Testing**: Swift Testing Framework
+- **Routing**: SUIRouting (v1.0.6)
+- **Testing**: Swift Testing Framework (`@Test`, `@Suite`)
 
 ---
 
@@ -39,23 +40,70 @@ The application strictly follows Clean Architecture, separating concerns into di
 **Dependency Rule**: Dependencies point inward. Outer layers depend on inner layers, never the reverse.
 
 ```
-┌─────────────────────────────────────────────┐
-│   Presentation Layer (Views & ViewModels)  │
-│   (FeedView, CharacterDetailsView, etc.)   │
-└──────────────────┬──────────────────────────┘
-                   │ depends on
-                   ↓
-┌─────────────────────────────────────────────┐
-│      Business Logic Layer (Use Cases)       │
-│         (FeedUseCase, protocols)            │
-└──────────────────┬──────────────────────────┘
-                   │ depends on
-                   ↓
-┌─────────────────────────────────────────────┐
-│          Data Layer (Repository)            │
-│  (RickMortyRepository, RickMortyNetworkLayer)│
-└─────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────┐
+│                        Main App                          │
+│   RickMorty/App/{RickMortyApp, AppDelegate,             │
+│                  AppComposition}.swift                   │
+└────────────────────────┬─────────────────────────────────┘
+                         │
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│                      TabBarView                          │
+└──────────────┬───────────────────────────────┬───────────┘
+               │                               │
+               ▼                               ▼
+  ┌─────────────────────┐         ┌─────────────────────────┐
+  │      FeedView       │         │      FeedListView        │
+  │      (SwiftUI)      │         │      (UIKit)             │
+  └──────────┬──────────┘         └────────────┬────────────┘
+             │                                 │
+             └──────────────┬──────────────────┘
+                            │ both depend on:
+                            ▼
+             ┌────────────────────────────────┐
+             │     CharacterDetailsView       │
+             │     DependencyContainer        │
+             │     DevPreview                 │
+             │     RickMortyUI                │
+             │     SUIRouting (external)      │
+             └──────────────┬─────────────────┘
+                            │
+                            ▼
+                   ┌─────────────────┐
+                   │    UseCase      │
+                   │  (protocols,    │
+                   │   DTOs,         │
+                   │   adapters)     │
+                   └────────┬────────┘
+                            │
+                            ▼
+             ┌──────────────────────────────┐
+             │      RickMortyRepository     │
+             └───────────┬──────────────────┘
+                         │
+              ┌──────────┴────────────┐
+              ▼                       ▼
+  ┌────────────────────────┐  ┌──────────────────┐
+  │  RickMortyNetworkLayer │  │    CoreAPI       │
+  │  (URLSession, no deps) │  │ (RickMortyEndpt) │
+  └────────────────────────┘  └──────────────────┘
 ```
+
+**Package reference table:**
+
+| Package | Key Types | Responsibility |
+| --- | --- | --- |
+| `RickMortyNetworkLayer` | `NetworkService`, `URLSessionNetworkService`, `Endpoint`, `NetworkError` | Generic URLSession HTTP client |
+| `CoreAPI` | `RickMortyEndpoint` | Rick & Morty API endpoint definitions |
+| `DependencyContainer` | `DIContainer`, `DIError` | Service locator / DI |
+| `UseCase` | `FeedUseCase`, `FeedUseCaseProtocol`, `FeedRepositoryProtocol`, `CharacterAdapter`, `FeedError`, DTOs | Business logic + shared types |
+| `RickMortyRepository` | `FeedRepository` | Data-layer orchestration |
+| `RickMortyUI` | `CharacterView`, `CharacterTableViewCell`, `CachedAsyncImage`, `ImageCache`, `FiltersView`, `ErrorView` | Shared UI components |
+| `DevPreview` | `DevPreview` | DI container singleton for previews |
+| `CharacterDetailsView` | `CharacterDetailsBuilder`, `CharacterDetailsViewModel`, `CharacterDetailsView` | Detail screen |
+| `FeedView` | `FeedBuilder`, `FeedViewModel`, `FeedView`, `FeedRouter` | SwiftUI character list |
+| `FeedListView` | `FeedListBuilder`, `FeedListViewModel`, `FeedListViewController`, `FeedListTabView`, `FeedListRouter` | UIKit character list |
+| `TabBarView` | `TabBarBuilder`, `TabBarView` | Tab navigation shell |
 
 ### 2. Protocol-Oriented Design
 All inter-layer communication happens through protocols, enabling:
@@ -169,11 +217,12 @@ API endpoint definitions for Rick and Morty API.
 
 **Endpoints**:
 ```swift
-enum RickMortyEndpoint: Endpoint {
-    case characters(page: Int, status: String?)
-    // Add more as needed
+public enum RickMortyEndpoint: Endpoint {
+    case getCharacters(page: Int?, status: String?)
+    // Add new cases here as the API grows
 
-    var baseURL: String { "https://rickandmortyapi.com/api" }
+    public var baseURL: String { "https://rickandmortyapi.com/api" }
+    public var path: String { "/character" }
 }
 ```
 
@@ -237,16 +286,24 @@ Character list feature.
 - Status filtering (Alive, Dead, Unknown)
 - Error handling with retry
 
-**State Machine**:
+**ViewModel declaration pattern** (same in both `FeedViewModel` and `FeedListViewModel`):
 ```swift
-enum State {
-    case idle
-    case loading
-    case loaded([CharacterAdapter])
-    case error(FeedError)
-    case loadingMore([CharacterAdapter])
+@Observable   // macro must come first
+@MainActor
+final class FeedViewModel {
+    enum State {
+        case idle
+        case loading
+        case loaded([CharacterAdapter])
+        case error(FeedError)
+        case loadingMore([CharacterAdapter])
+    }
+    private(set) var state: State = .idle
+    // ...
 }
 ```
+
+Views use `@State var viewModel: FeedViewModel` — not `@StateObject` — because `@Observable` does not require `ObservableObject`.
 
 #### 7. **CharacterDetailsView**
 Character detail screen.
@@ -378,22 +435,30 @@ Every feature has a Builder class that composes views with dependencies.
 
 **Example**:
 ```swift
-@MainActor
 @Observable
-final class FeedBuilder {
+@MainActor
+public final class FeedBuilder {
     private let container: DIContainer
 
-    init(container: DIContainer) {
+    public init(container: DIContainer) {
         self.container = container
     }
 
-    func buildFeedView(router: FeedRouterProtocol) -> FeedView {
-        let useCase = try! container.requireResolve(FeedUseCaseProtocol.self)
-        let viewModel = FeedViewModel(useCase: useCase, router: router)
-        return FeedView(viewModel: viewModel)
+    public func buildFeedView(router: Router) -> some View {
+        FeedView(
+            viewModel: FeedViewModel(
+                feedUseCase: FeedUseCase(container: container),
+                router: FeedRouter(
+                    router: router,
+                    characterDetailsBuilder: CharacterDetailsBuilder(container: container)
+                )
+            )
+        )
     }
 }
 ```
+
+Note the declaration order: `@Observable` before `@MainActor`. Views hold builders via `@Environment(FeedBuilder.self)` — never accessed directly from the DI container.
 
 ### 2. State Machine Pattern
 ViewModels use enum-based state machines for clarity.
@@ -474,51 +539,64 @@ All abstractions are protocols, not base classes.
 ## Navigation
 
 ### SUIRouting Library
-The app uses the external **SUIRouting** library (v1.0.7) for declarative navigation.
+The app uses the external **SUIRouting** library (v1.0.6, pinned `.upToNextMajor(from: "1.0.6")`) for declarative navigation. Each tab is wrapped in `RouterView { router in ... }` which provides a `Router` value.
 
-**Pattern**:
+**Router protocol + implementation:**
 ```swift
+@MainActor
 protocol FeedRouterProtocol {
-    func navigateToDetails(character: CharacterAdapter)
+    func showCharacterDetails(characterDetailsAdapter: CharacterAdapter)
 }
 
-final class FeedRouter: FeedRouterProtocol {
-    private let router: Router // SUIRouting
+@MainActor
+struct FeedRouter: FeedRouterProtocol {
+    let router: Router                              // SUIRouting.Router
+    let characterDetailsBuilder: CharacterDetailsBuilder
 
-    func navigateToDetails(character: CharacterAdapter) {
-        router.push(CharacterDetailsView(character: character))
+    func showCharacterDetails(characterDetailsAdapter: CharacterAdapter) {
+        router.showScreen(.push) { innerRouter in
+            characterDetailsBuilder.buildCharacterDetailsView(
+                characterDetailsAdapter: characterDetailsAdapter,
+                backAction: { innerRouter.dismissScreen() }
+            )
+        }
     }
 }
 ```
 
-**Key Concepts**:
-- Routers are protocol-based
-- Injected into ViewModels
-- Use `Router` object from SUIRouting for actual navigation
+**Key Concepts:**
+
+- Router protocols (`FeedRouterProtocol`, `FeedListRouterProtocol`) are **internal** to their packages — ViewModels never see SUIRouting's `Router` type directly, enabling testing with `SpyRouter`
+- `router.showScreen(.push)` pushes onto the navigation stack; `innerRouter.dismissScreen()` pops it
+- `RouterView { router in ... }` is the SwiftUI integration point in `TabBarView`
+
+**Known limitation:** SUIRouting uses iOS-only APIs (`fullScreenCover`, `NavigationStack`). Building FeedView, FeedListView, or TabBarView packages on macOS fails. CI uses `continue-on-error: true` for those steps.
 
 ---
 
 ## State Management
 
 ### SwiftUI @Observable
-The app uses Swift 5.9+ `@Observable` macro instead of `ObservableObject`.
+The app uses the `@Observable` macro instead of `ObservableObject`. Declaration order matters — `@Observable` must come before `@MainActor`:
 
-**Usage**:
 ```swift
+@Observable   // macro first
 @MainActor
-@Observable
 final class FeedViewModel {
-    var state: State = .idle
-    var isLoading: Bool { /* computed */ }
-
-    // SwiftUI tracks changes automatically
+    private(set) var state: State = .idle
+    // SwiftUI tracks property reads automatically
 }
 ```
 
-**Benefits**:
-- Less boilerplate
-- Automatic change tracking
-- Better performance
+Views hold the ViewModel as `@State`, not `@StateObject`:
+
+```swift
+struct FeedView: View {
+    @State var viewModel: FeedViewModel
+}
+```
+
+**Benefits:** fine-grained change tracking (only accessed properties trigger re-renders), no `@Published` needed, works with Swift 6 strict concurrency.
 
 ### State Machine Pattern
 ViewModels manage state transitions explicitly:
@@ -533,12 +611,50 @@ state = .loading
 // Loaded successfully
 state = .loaded(characters)
 
-// Loading more pages
+// Loading more pages — preserves visible list while fetching
 state = .loadingMore(existingCharacters)
 
 // Error occurred
 state = .error(feedError)
 ```
+
+### UIKit + @Observable (Hybrid Integration)
+
+`FeedListView` demonstrates how `UIViewController` reacts to an `@Observable` ViewModel without Combine or `ObservableObject`. Two pieces make it work:
+
+**1. `FeedListTabView`** — a `UIViewControllerRepresentable` that bridges the UIKit stack into SwiftUI's `TabView`:
+
+```swift
+public struct FeedListTabView: UIViewControllerRepresentable {
+    let viewModel: FeedListViewModel
+
+    public func makeUIViewController(context: Context) -> UINavigationController {
+        let vc = FeedListViewController(viewModel: viewModel)
+        return UINavigationController(rootViewController: vc)
+    }
+
+    public func updateUIViewController(_ uiViewController: UINavigationController, context: Context) {}
+}
+```
+
+**2. `startObservingViewModel()`** — a recursive observation loop started in `viewDidLoad()`. `withObservationTracking(_:onChange:)` fires `onChange` exactly once per change, so the pattern re-registers itself after each update:
+
+```swift
+func startObservingViewModel() {
+    withObservationTracking {
+        _ = viewModel.state
+        _ = viewModel.characters
+        _ = viewModel.isLoadingMore
+    } onChange: { [weak self] in
+        Task { @MainActor in
+            self?.renderState()
+            self?.startObservingViewModel()  // re-register for the next change
+        }
+    }
+}
+```
+
+`Task { @MainActor in ... }` is required because `onChange` fires on an unspecified thread.
 
 ---
 

--- a/FeedListView/Package.resolved
+++ b/FeedListView/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "3e2baaeb41406fb4483118bf185a36359243cd69d4740ae9b880029f3bf1eddb",
+  "pins" : [
+    {
+      "identity" : "suirouting",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/obadasemary/SUIRouting.git",
+      "state" : {
+        "revision" : "f21ce56a0a823a5cdf05b239c77f2c2ac2a077d4",
+        "version" : "1.0.7"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/TabBarView/Package.resolved
+++ b/TabBarView/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "8848e606841bada70f0345ef5bfe46960133ed81dd1438e967496bcc8cdea1dd",
+  "pins" : [
+    {
+      "identity" : "suirouting",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/obadasemary/SUIRouting.git",
+      "state" : {
+        "revision" : "f21ce56a0a823a5cdf05b239c77f2c2ac2a077d4",
+        "version" : "1.0.7"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,55 @@
+{
+  "version": 1,
+  "skills": {
+    "core-data-expert": {
+      "source": "avdlee/core-data-agent-skill",
+      "sourceType": "github",
+      "computedHash": "b8d2829005b1f2fefbaa8af2ea7d7d64e2fbeca2f2172033176ad0780edc3970"
+    },
+    "spm-build-analysis": {
+      "source": "avdlee/xcode-build-optimization-agent-skill",
+      "sourceType": "github",
+      "computedHash": "9785f2113e45cd29aedc4c1e7e5763735157ff1e4c99a4ca4a65d4f625814c55"
+    },
+    "swift-concurrency": {
+      "source": "avdlee/swift-concurrency-agent-skill",
+      "sourceType": "github",
+      "computedHash": "f3f1bda772590c6ee32446c9eec59bb3ff6c38329e3c78fa949e6a859644a10b"
+    },
+    "swift-testing-expert": {
+      "source": "avdlee/swift-testing-agent-skill",
+      "sourceType": "github",
+      "computedHash": "ee2a73c7148264cb7e0a0819d3063225541e57162353d97707d9fab830d27ba6"
+    },
+    "swiftui-expert-skill": {
+      "source": "avdlee/swiftui-agent-skill",
+      "sourceType": "github",
+      "computedHash": "cc254d18562b0666f4c85561b92b21eb1878e346b659f8b6d80c02a166725cb4"
+    },
+    "xcode-build-benchmark": {
+      "source": "avdlee/xcode-build-optimization-agent-skill",
+      "sourceType": "github",
+      "computedHash": "e132c38adbb8a74e3e0474c0e34566b209fa3bf29532604af97d715b8c721ec8"
+    },
+    "xcode-build-fixer": {
+      "source": "avdlee/xcode-build-optimization-agent-skill",
+      "sourceType": "github",
+      "computedHash": "7d1c68154af030a24b7420c9f9c7805e6009e0012da34b9a16c0cfef3396b608"
+    },
+    "xcode-build-orchestrator": {
+      "source": "avdlee/xcode-build-optimization-agent-skill",
+      "sourceType": "github",
+      "computedHash": "d03e65e314a8fbe0ae0cf7469fa1a4280b5d335a7f163fdc7a7a91dbb0fd1b2b"
+    },
+    "xcode-compilation-analyzer": {
+      "source": "avdlee/xcode-build-optimization-agent-skill",
+      "sourceType": "github",
+      "computedHash": "9857f081cf044a06f93f382ea1a53c3fe9699ac0d0686abbabea67696c2eff6a"
+    },
+    "xcode-project-analyzer": {
+      "source": "avdlee/xcode-build-optimization-agent-skill",
+      "sourceType": "github",
+      "computedHash": "dfe1901df149b68d8869a48143508444605ed8ba20b448d1faec1d6218d58859"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add 10 specialized iOS/Xcode skills to `.claude/skills/` and `.agents/skills/` (core-data-expert, spm-build-analysis, swift-concurrency, swift-testing-expert, swiftui-expert-skill, xcode-build-benchmark, xcode-build-fixer, xcode-build-orchestrator, xcode-compilation-analyzer, xcode-project-analyzer)
- Update `AGENTS.md` to register all new skills with accurate descriptions
- Update `ARCHITECTURE.md` with accurate Swift 6.1+/UIKit hybrid details, corrected package table, SUIRouting version, and UIKit `@Observable` integration pattern
- Add `Package.resolved` for `FeedListView` and `TabBarView`
- Add `skills-lock.json` for skill version pinning

## Test plan

- [x] Verify skills are discoverable via the skill system
- [x] Confirm `ARCHITECTURE.md` reflects the actual codebase structure
- [ ] Check `AGENTS.md` skill entries match installed skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive reference guides for Core Data, Swift Concurrency, Swift Testing, and SwiftUI development patterns, including best practices, common pitfalls, and troubleshooting workflows.
  * Introduced structured skill documentation for Core Data expert, SPM build analysis, Swift Concurrency, Swift Testing, and SwiftUI expert capabilities with triage templates and routing maps.
  * Added specialized reference materials covering testing strategies, async patterns, animation techniques, accessibility, and performance optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->