### PR TITLE
Fix CI: Install iOS Simulator Runtime before simulator-dependent steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
           rm -rf ~/Library/Developer/Xcode/DerivedData/ModuleCache.noindex
           echo "✅ Module cache cleaned"
 
+      - name: Install iOS Simulator Runtime
+        run: |
+          echo "📦 Installing iOS Simulator runtime..."
+          xcodebuild -downloadPlatform iOS
+          echo "✅ iOS Simulator runtime installed"
+
       - name: Show Xcode version
         run: xcodebuild -version
 
@@ -140,6 +146,12 @@ jobs:
           key: ${{ runner.os }}-xcode-ui-tests-${{ hashFiles('**/*.xcodeproj/project.pbxproj', '**/*.xcworkspace/contents.xcworkspacedata') }}
           restore-keys: |
             ${{ runner.os }}-xcode-ui-tests-
+
+      - name: Install iOS Simulator Runtime
+        run: |
+          echo "📦 Installing iOS Simulator runtime..."
+          xcodebuild -downloadPlatform iOS
+          echo "✅ iOS Simulator runtime installed"
 
       - name: Clean Module Cache
         run: |
@@ -250,6 +262,12 @@ jobs:
 
       - name: Select Xcode 26.0.1
         run: sudo xcode-select -s /Applications/Xcode_26.0.1.app/Contents/Developer
+
+      - name: Install iOS Simulator Runtime
+        run: |
+          echo "📦 Installing iOS Simulator runtime..."
+          xcodebuild -downloadPlatform iOS
+          echo "✅ iOS Simulator runtime installed"
 
       - name: List available simulators
         run: |


### PR DESCRIPTION
## Summary

- Adds `xcodebuild -downloadPlatform iOS` step to `xcode-build-test`, `ui-tests`, and `integration-test` jobs
- Ensures the iOS Simulator runtime is available before any job attempts to launch an iPhone 17 Pro simulator
- Prevents build/test failures caused by a missing runtime on fresh CI runners

## Test plan

- [x] Verify `xcode-build-test` job passes with the new install step
- [x] Verify `ui-tests` job passes with the new install step
- [x] Verify `integration-test` job passes with the new install step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved iOS build and test infrastructure setup to ensure proper simulator runtime availability during CI pipeline execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->